### PR TITLE
Import af data fra CVR-registret via cvrapi.dk

### DIFF
--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -634,9 +634,9 @@ if ($drg=$x) {
 print "</tbody></table></td>"; # <- TABEL 1.2.1
 print "<td valign=top><table border=0 width=100%><tbody>"; # TABEL 1.2.2 ->
 $bg=$bgcolor5;
-print "<tr bgcolor=$bg><td>".findtekst(376,$sprog_id)."<!--tekst 376--></td><td><input class=\"inputbox\" type=text size=10 name=cvrnr value=\"$cvrnr\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
+print "<tr bgcolor=$bg><td>".findtekst(376,$sprog_id)."<!--tekst 376--></td><td><input class=\"inputbox\" type=text size=10 name=cvrnr value=\"$cvrnr\" onchange=\"javascript:docChange = true;\" title=\"Tast CVR-nr. efterfulgt af F8 for at importere data fra Erhvervsstyrelsen (Data leveres af CVR API)\"></td></tr>\n";
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
-print "<tr bgcolor=$bg><td>".findtekst(377,$sprog_id)."<!--tekst 377--></td><td><input class=\"inputbox\" type=text size=10 name=tlf value=\"$tlf\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
+print "<tr bgcolor=$bg><td>".findtekst(377,$sprog_id)."<!--tekst 377--></td><td><input class=\"inputbox\" type=text size=10 name=tlf value=\"$tlf\" onchange=\"javascript:docChange = true;\" title=\"Tast telefonnr. efterfulgt af F8 for at importere data fra Erhvervsstyrelsen (Data leveres af CVR API)\"></td></tr>\n";
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
 print "<tr bgcolor=$bg><td>".findtekst(378,$sprog_id)."<!--tekst 378--></td><td><input class=\"inputbox\" type=text size=10 name=fax value=\"$fax\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
 if ($kontotype=='erhverv') {
@@ -865,4 +865,50 @@ function split_navn($firmanavn) {
 }
 
 ?>
+<script type="text/javascript">
+function cvrapi(param, country, type)
+{
+	jQuery.ajax
+	({
+		type: "GET",
+		dataType: "jsonp",
+		url: "//cvrapi.dk/api?"+type+"="+param+"&country="+country,
+		success: function (b)
+		{
+			if(b.hasOwnProperty("vat")) $("[name=cvrnr]").val(b.vat);
+			if(b.hasOwnProperty("name")) $("[name=firmanavn]").val(b.name);
+			if(b.hasOwnProperty("address")){
+				if(b.hasOwnProperty("addressco") && b.addressco != null){
+					$("[name=addr1]").val("c/o " + b.addressco);
+					$("[name=addr2]").val(b.address);
+				} else {
+					$("[name=addr1]").val(b.address);
+					$("[name=addr2]").val(null);
+				}
+			}
+			if(b.hasOwnProperty("zipcode")) $("[name=postnr]").val(b.zipcode);
+			if(b.hasOwnProperty("city")) $("[name=bynavn]").val(b.city);
+			if(b.hasOwnProperty("phone")) $("[name=tlf]").val(b.phone);
+			if(b.hasOwnProperty("email")) $("[name=email]").val(b.email);
+			if(b.hasOwnProperty("fax")) $("[name=fax]").val(b.fax);
+		}
+	});
+}
+$(document).keyup(function(e){
+var cvrnr = $("[name=cvrnr]").val();
+var tlfnr = $("[name=tlf]").val();
+
+// Tryk på F2 aktiverer rubrikken kundenr. eller CVR-nr., hvis kundenr. allerede er aktivt
+if(e.key == 'F2'){
+	if($("[name=ny_kontonr]").is(':focus')) $("[name=cvrnr]").select();
+	else $("[name=ny_kontonr]").select();
+}
+
+// Tryk på F8 henter data via cvrapi.dk når rubrikken CVR-nr. eller telefonnr. er aktiv
+if(e.key == 'F8'){
+	if(cvrnr.length == 8 && $("[name=cvrnr]").is(':focus')) cvrapi(cvrnr, 'dk', 'vat');
+	if(tlfnr.length == 8 && $("[name=tlf]").is(':focus')) cvrapi(tlfnr, 'dk', 'phone');
+}
+});
+</script>
 </body></html>

--- a/kreditor/kreditorkort.php
+++ b/kreditor/kreditorkort.php
@@ -279,9 +279,9 @@ print "</SELECT></td></tr>\n";
 print "</tbody></table></td>";#  <- tabel 1.2.1 
 print "<td  valign=\"top\"><table cellpadding=\"0\" cellspacing=\"0\" border=\"0\"><tbody>\n"; # tabel 1.2.2 ->
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
-print "<tr bgcolor=$bg><td width=\"25%\"> CVR-nr.</td><td width=\"75%\"><input class=\"inputbox\" type=text size=\"10\" name=cvrnr value=\"$cvrnr\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
+print "<tr bgcolor=$bg><td width=\"25%\"> CVR-nr.</td><td width=\"75%\"><input class=\"inputbox\" type=text size=\"10\" name=cvrnr value=\"$cvrnr\" onchange=\"javascript:docChange = true;\" title=\"Tast CVR-nr. efterfulgt af F8 for at importere data fra Erhvervsstyrelsen (Data leveres af CVR API)\"></td></tr>\n";
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
-print "<tr bgcolor=$bg><td> Telefon</td><td><input class=\"inputbox\" type=text size=\"10\" name=tlf value=\"$tlf\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
+print "<tr bgcolor=$bg><td> Telefon</td><td><input class=\"inputbox\" type=text size=\"10\" name=tlf value=\"$tlf\" onchange=\"javascript:docChange = true;\" title=\"Tast telefonnr. efterfulgt af F8 for at importere data fra Erhvervsstyrelsen (Data leveres af CVR API)\"></td></tr>\n";
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
 print "<tr bgcolor=$bg><td> Telefax</td><td><input class=\"inputbox\" type=text size=\"10\" name=fax value=\"$fax\" onchange=\"javascript:docChange = true;\"></td></tr>\n";
 ($bg==$bgcolor) ? $bg=$bgcolor5 : $bg=$bgcolor;
@@ -392,5 +392,53 @@ print "<td width=\"40%\" $top_bund>&nbsp;</td>";
 print	"</tbody></table>";#tabel 1.3 slut
 print	"</td></tr>";
 print	"</tbody></table>";#tabel 1 slut
+?>
+<script type="text/javascript">
+function cvrapi(param, country, type)
+{
+	jQuery.ajax
+	({
+		type: "GET",
+		dataType: "jsonp",
+		url: "//cvrapi.dk/api?"+type+"="+param+"&country="+country,
+		success: function (b)
+		{
+			if(b.hasOwnProperty("vat")) $("[name=cvrnr]").val(b.vat);
+			if(b.hasOwnProperty("name")) $("[name=firmanavn]").val(b.name);
+			if(b.hasOwnProperty("address")){
+				if(b.hasOwnProperty("addressco") && b.addressco != null){
+					$("[name=addr1]").val("c/o " + b.addressco);
+					$("[name=addr2]").val(b.address);
+				} else {
+					$("[name=addr1]").val(b.address);
+					$("[name=addr2]").val(null);
+				}
+			}
+			if(b.hasOwnProperty("zipcode")) $("[name=postnr]").val(b.zipcode);
+			if(b.hasOwnProperty("city")) $("[name=bynavn]").val(b.city);
+			if(b.hasOwnProperty("phone")) $("[name=tlf]").val(b.phone);
+			if(b.hasOwnProperty("email")) $("[name=email]").val(b.email);
+			if(b.hasOwnProperty("fax")) $("[name=fax]").val(b.fax);
+		}
+	});
+}
+$(document).keyup(function(e){
+var cvrnr = $("[name=cvrnr]").val();
+var tlfnr = $("[name=tlf]").val();
+
+// Tryk på F2 aktiverer rubrikken kundenr. eller CVR-nr., hvis kundenr. allerede er aktivt
+if(e.key == 'F2'){
+	if($("[name=ny_kontonr]").is(':focus')) $("[name=cvrnr]").select();
+	else $("[name=ny_kontonr]").select();
+}
+
+// Tryk på F8 henter data via cvrapi.dk når rubrikken CVR-nr. eller telefonnr. er aktiv
+if(e.key == 'F8'){
+	if(cvrnr.length == 8 && $("[name=cvrnr]").is(':focus')) cvrapi(cvrnr, 'dk', 'vat');
+	if(tlfnr.length == 8 && $("[name=tlf]").is(':focus')) cvrapi(tlfnr, 'dk', 'phone');
+}
+});
+</script>
+<?
 print	"</body></html>";
 ?>


### PR DESCRIPTION
Funktionen efterspurgt på http://forum.saldi.dk/viewtopic.php?f=15&t=1147

På henholdsvis debitorkort og kreditorkort importeres data og indsættes i de relevante felter. Der gemmes intet i databasen og brugeren kan derfor selv validere og fejlrette data.
Der kan importeres baseret på enten cvrnr. eller telefonnr.
I cvrnr. feltet indtastes cvrnr., der skal søges på efterfulgt af tryk på F8. Hvis søgningen giver resultat, indsættes posterne i de øvrige felter. Tilsvarende er muligt ved at indtaste et telefonnr. i dette felt efterfulgt af tryk på F8.

Servicen leveres gennem CVR API, cvrapi.dk. Som vilkår skal der angives kilde, hvilket jeg har indsat som title-tag.

Herudover skiftes ved tryk på F2 mellem felterne kundenr./leverandørnr. og cvrnr., så der hurtigere kan oprettes nye konti.

/Niels Rune Brandt