### PR TITLE
Increase session_id length specifier in table online to 32 chars

### DIFF
--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -366,10 +366,6 @@ $qtxt="SELECT column_name FROM information_schema.columns WHERE table_name='regn
 if (!$r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
 	db_modify("ALTER table regnskab ADD column sms integer",__FILE__ . " linje " . __LINE__);
 }
-$qtxt="SELECT column_name FROM information_schema.columns WHERE table_name='online' and column_name='session_id'";
-if (!$r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
-	db_modify("ALTER TABLE online ALTER COLUMN session_id TYPE varchar(32)",__FILE__ . " linje " . __LINE__);
-}
 include ('../includes/online.php');
 
 ?>

--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -366,6 +366,10 @@ $qtxt="SELECT column_name FROM information_schema.columns WHERE table_name='regn
 if (!$r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
 	db_modify("ALTER table regnskab ADD column sms integer",__FILE__ . " linje " . __LINE__);
 }
+$qtxt="SELECT column_name FROM information_schema.columns WHERE table_name='online' and column_name='session_id'";
+if (!$r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
+	db_modify("ALTER TABLE online ALTER COLUMN session_id TYPE varchar(32)",__FILE__ . " linje " . __LINE__);
+}
 include ('../includes/online.php');
 
 ?>

--- a/index/install.php
+++ b/index/install.php
@@ -32,6 +32,7 @@
 // 20220823 PHR Changed email to varchar(60) in 'regnskab'
 // 20221106 PHR - Various changes to fit php8 / MySQLi
 // 20250116 allow user specified hostname for database, ie. other than localhost.
+// 20250121 Increase session_id length specifier from 30 to 32.
 
 session_start();
 ob_start(); //Starter output buffering
@@ -224,7 +225,7 @@ if (isset($_POST['opret'])){
 	$qtxt = "INSERT INTO regnskab (regnskab, dbhost, dbuser, db, version,bilag) values ";
 	$qtxt.= "('$db_navn' ,'$db_host', '$db_bruger', '$db_navn', '$version','0')";
 	db_modify($qtxt,__FILE__ . " linje " . __LINE__);
-	$qtxt = "CREATE TABLE online (session_id varchar(30), brugernavn text, db varchar(30), dbuser varchar(30), rettigheder varchar(30), ";
+	$qtxt = "CREATE TABLE online (session_id varchar(32), brugernavn text, db varchar(30), dbuser varchar(30), rettigheder varchar(30), ";
 	$qtxt.= "regnskabsaar integer, logtime varchar(30), revisor boolean, language_id int)";
 	db_modify($qtxt,__FILE__ . " linje " . __LINE__);
 	$qtxt = "CREATE TABLE kundedata (id serial NOT NULL, firmanavn text, addr1 text, addr2 text, postnr varchar(10), ";

--- a/index/install.php
+++ b/index/install.php
@@ -32,7 +32,7 @@
 // 20220823 PHR Changed email to varchar(60) in 'regnskab'
 // 20221106 PHR - Various changes to fit php8 / MySQLi
 // 20250116 allow user specified hostname for database, ie. other than localhost.
-// 20250121 Increase session_id length specifier from 30 to 32.
+// 20250129 Increase session_id length constraint from 30 to 32 on table online.
 
 session_start();
 ob_start(); //Starter output buffering

--- a/index/login.php
+++ b/index/login.php
@@ -59,6 +59,7 @@
 // 20230718 LOE - Made some modifications + 20230725
 // 20240417 PHR - Unified login - redirets to correct server.
 // 20240417 PHR - 'regnskab' and 'brugernavn' is now case-insensitive
+// 20250129 Increase session_id length constraint from 30 to 32 on table online.
 
 ob_start(); //Starter output buffering
 @session_start();
@@ -90,6 +91,14 @@ $qtxt = "SELECT column_name FROM information_schema.columns WHERE table_name='re
 if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 	$qtxt = "ALTER table regnskab ADD column invoices int DEFAULT(0)";
 	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+}
+// Increase session_id length constraint to 32 on table online if needed.
+// Must be done before insertion of record in online, therefore not included in betweenUpdates.
+$qtxt="SELECT column_name, data_type, character_maximum_length FROM information_schema.columns 
+		WHERE table_name = 'online' AND column_name = 'session_id' AND character_maximum_length < 32";
+if ($r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
+	$qtxt = "ALTER TABLE online ALTER COLUMN session_id TYPE varchar(32)";
+	db_modify($qtxt,__FILE__ . " linje " . __LINE__);
 }
 
 


### PR DESCRIPTION
## What are the changes about?
Increase session_id length specifier in table online to 32 chars

PHP default session id length is 32 chars.
With only 30 chars in db, this is crashing the app on login and throwing the following log:

_PHP Warning:  pg_query(): Query failed: ERROR:  value too long for type character varying(30) in .../includes/db_query.php on line 121, referer: http://.../index/index.php_

See also this regarding deprecation as of PHP 8.4: https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.session

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
