### PR TITLE
Fix pg_*() deprecations as of PHP 8.1

### DIFF
--- a/admin/opret.php
+++ b/admin/opret.php
@@ -98,6 +98,7 @@
 // 20240407 PHR	Removed function getFiscalYear() and changed $fiscalYear to '1' everywhere 
 // 20240531 PHR removed changes 20230804 made by LOE 
 // 20240621 LOE modified list function block causing undefined "PHP Warning:  Undefined array key 2 in" error during account creation
+// 20250121 connection as first parameter in pg_*
 
 @session_start();
 $s_id=session_id();
@@ -600,23 +601,23 @@ function opret ($sqhost,$squser,$sqpass,$db,$brugernavn,$passwd,$std_kto_plan) {
 		$qtxt.= "RETURN NEW; ";
 		$qtxt.= "END; ";
 		$qtxt.= "$$ language 'plpgsql';";
-		pg_query($qtxt);
+		pg_query($connection, $qtxt);
 		$qtxt = "CREATE TRIGGER update_adresser_modtime BEFORE UPDATE ";
 		$qtxt.= "ON adresser FOR EACH ROW EXECUTE PROCEDURE ";
 		$qtxt.= "update_modtime_column(); ";
-		pg_query($qtxt);
+		pg_query($connection, $qtxt);
 		$qtxt = "CREATE TRIGGER update_batch_kob_modtime BEFORE UPDATE ";
 		$qtxt.= "ON batch_kob FOR EACH ROW EXECUTE PROCEDURE ";
 		$qtxt.= "update_modtime_column(); ";
-		pg_query($qtxt);
+		pg_query($connection, $qtxt);
 		$qtxt = "CREATE TRIGGER update_batch_salg_modtime BEFORE UPDATE ";
 		$qtxt.= "ON batch_salg FOR EACH ROW EXECUTE PROCEDURE ";
 		$qtxt.= "update_modtime_column(); ";
-		pg_query($qtxt);
+		pg_query($connection, $qtxt);
 		$qtxt = "CREATE TRIGGER update_varer_modtime BEFORE UPDATE ";
 		$qtxt.= "ON varer FOR EACH ROW EXECUTE PROCEDURE ";
 		$qtxt.= "update_modtime_column(); ";
-		pg_query($qtxt);
+		pg_query($connection, $qtxt);
 	}
 	$qtxt = file_get_contents('../importfiler/saf_t_codes.sql');
 	db_modify($qtxt, __FILE__ . " linje " . __LINE__);

--- a/api/api.php
+++ b/api/api.php
@@ -87,13 +87,13 @@ if (!$result) {
 if ($method == 'GET') {
   if (!$key) echo '[';
 		
-  while($i=0;$i<db_num_rows($result);$i++) {
+  for($i=0;$i<db_num_rows($result);$i++) {
     echo ($i>0?',':'').json_encode(db_fetch_object($result));
   }
   if (!$key) echo ']';
 } elseif ($method == 'POST') {
-	$insert_id = SELECT nextval('foo_seq'); INSERT INTO table (foo...) values ($link)
-echo  pg_insert_id($link);
+	$insert_id = "SELECT nextval('foo_seq'); INSERT INTO table (foo...) values ($link)";
+echo  pg_insert_id($link); // <-- function pg_insert_id neither exists nor defined ??
 } else {
   echo pg_affected_rows($link);
 }

--- a/includes/db_query.php
+++ b/includes/db_query.php
@@ -35,6 +35,7 @@
 // 20200308 PHR addded function db_create, db_exists & tbl_exists.
 // 20221106 PHR - Various changes to fit php8 / MySQLi
 // 20230730 LOE - Minor modification, abolute path to std_func
+// 20250121 connection as first parameter in pg_*
 
 
 if (!function_exists('get_relative')) {
@@ -104,7 +105,7 @@ if (!function_exists('db_error')) {
 	function db_error() {
 		if ($db_type=='mysqli') echo mysqli_error(). "\n";
 		else if ($db_type=='mysql') echo mysql_error(). "\n";
-		else  echo pg_last_error(). "\n";
+		else  echo pg_last_error($connection). "\n";
 	}
 }
 
@@ -136,9 +137,8 @@ if (!function_exists('db_modify')) {
 			$db_query=mysqli_query($connection, $qtext); 
 		} 
 		else {
-			$db_query="pg_query";
 			$qtext=str_replace(' like ',' ilike ',$qtext);
-			$db_query=$db_query($qtext);
+			$db_query=pg_query($connection, $qtext);
 		}
 #20190704 END
 		
@@ -152,7 +152,7 @@ if (!function_exists('db_modify')) {
 		if (!$db_query) { #20190704
 			if ($db_type=="mysql")       $errtxt = mysql_error($connection);
 			else if ($db_type=="mysqli") $errtxt = mysqli_error($connection); #20190704
-			else $errtxt=pg_last_error();
+			else $errtxt=pg_last_error($connection);
 			$fp=fopen("$temp/.ht_modify.log","a");
 			fwrite($fp,"-- ".$brugernavn." ".date("Y-m-d H:i:s").": ".$spor."\n");
 			fwrite($fp,"-- Fejl!! ".$qtext." | $errtxt;\n");
@@ -229,8 +229,8 @@ if (!function_exists('db_select')) {
 			$errtxt=mysqli_error($connection); #20190704
 		} else {
 			$qtext=str_replace(' like ',' ilike ',$qtext);
-			$query=pg_query($qtext);
-			$errtxt=pg_last_error();
+			$query=pg_query($connection, $qtext);
+			$errtxt=pg_last_error($connection);
 		}
 		if ($errtxt)	{		
 			$db=trim($db);
@@ -287,10 +287,10 @@ if (!function_exists('db_select')) {
 	}
 }
 
-if (!function_exists('db_catalog_setval')) {
+if (!function_exists('db_catalog_setval')) { // <-- Never used
 	function db_catalog_setval($seq, $val, $bool) {
 		global $db_type;
-		return pg_catalog.setval($seq, $val, $bool);
+		return pg_catalog.setval($seq, $val, $bool); // <-- invalid function
 	}
 }
 
@@ -363,7 +363,7 @@ if (!function_exists('transaktion')) {
 		fwrite($fp,$qtext.";\n");
 		if ($db_type=="mysql") mysql_query($qtext);
 		elseif ($db_type=="mysqli") mysqli_query($connection, $qtext); #20190704
-		else pg_query($qtext);
+		else pg_query($connection, $qtext);
 	}
 }
 
@@ -374,7 +374,7 @@ if (!function_exists('db_escape_string')) {
 		
 		if ($db_type=="mysql") return mysql_real_escape_string($qtext);
 		elseif ($db_type=="mysqli") return mysqli_real_escape_string($connection, $qtext); #20190704
-		else return pg_escape_string($qtext);
+		else return pg_escape_string($connection, $qtext);
 	}
 }
 

--- a/includes/opdat_3.8.php
+++ b/includes/opdat_3.8.php
@@ -25,6 +25,7 @@
 //
 // Copyright (c) 2003-2020 saldi.dk ApS
 // ----------------------------------------------------------------------
+// 20250121 connection as first parameter in pg_*
 
 function opdat_3_8($under_nr, $lap_nr){
 	global $version;
@@ -223,23 +224,23 @@ function opdat_3_8($under_nr, $lap_nr){
 				$qtxt.= "RETURN NEW; ";
 				$qtxt.= "END; ";
 				$qtxt.= "$$ language 'plpgsql';";
-				pg_query($qtxt);
+				pg_query($connection, $qtxt);
 				$qtxt = "CREATE TRIGGER update_adresser_modtime BEFORE UPDATE ";
 				$qtxt.= "ON adresser FOR EACH ROW EXECUTE PROCEDURE ";
 				$qtxt.= "update_modtime_column(); ";
-				pg_query($qtxt);
+				pg_query($connection, $qtxt);
 				$qtxt = "CREATE TRIGGER update_batch_kob_modtime BEFORE UPDATE ";
 				$qtxt.= "ON batch_kob FOR EACH ROW EXECUTE PROCEDURE ";
 				$qtxt.= "update_modtime_column(); ";
-				pg_query($qtxt);
+				pg_query($connection, $qtxt);
 				$qtxt = "CREATE TRIGGER update_batch_salg_modtime BEFORE UPDATE ";
 				$qtxt.= "ON batch_salg FOR EACH ROW EXECUTE PROCEDURE ";
 				$qtxt.= "update_modtime_column(); ";
-				pg_query($qtxt);
+				pg_query($connection, $qtxt);
 				$qtxt = "CREATE TRIGGER update_varer_modtime BEFORE UPDATE ";
 				$qtxt.= "ON varer FOR EACH ROW EXECUTE PROCEDURE ";
 				$qtxt.= "update_modtime_column(); ";
-				pg_query($qtxt);
+				pg_query($connection, $qtxt);
 				$qtxt="UPDATE grupper set box1='$nextver' where art = 'VE'";
 				db_modify($qtxt,__FILE__ . " linje " . __LINE__);
 			}


### PR DESCRIPTION


## What are the changes about?
Fix pg_*() deprecations as of PHP 8.1

Otherwise A LOT of warnings are thrown on login page and further on with display_errors on

See: https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.pgsql

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
