### PR TITLE
Missing semicolon

### DIFF
--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -1609,7 +1609,7 @@ if (!function_exists('hent_shop_ordrer')) {
 	{
 	  global $db;
 	  $qtxt = "select box4, box5 from grupper where art='API'";
-	  $r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))
+	  $r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 	  ($r['box4']) ? $api_fil = trim($r['box4']) : $api_fil = 0;
 	  if ($api_fil) {
 		file_put_contents("../temp/$db/ny_shop.txt", $r["box5"]);


### PR DESCRIPTION
## What are the changes about?
Missing semicolon in includes/std_func.php

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
