### PR TITLE
Add hostname to psql

### DIFF
--- a/admin/restore.php
+++ b/admin/restore.php
@@ -30,6 +30,7 @@
 // 20241108 PHR PHP8
 // 20250130 migrate utf8_en-/decode() to mb_convert_encoding
 // 20222706 MSC - Implementing new design
+// 20250201 Add hostname to psql
 
 @session_start();
 $s_id=session_id();
@@ -277,12 +278,12 @@ if ($restore=='OK') {
 		if (file_exists("/usr/bin/mysql")) $mysql = "/usr/bin/mysql";
 		elseif (file_exists("/bin/mysql")) $mysql = "/usr/mysql";
 		else echo "mysql not found<br>";
-		if ($mysql) system("$mysql -u $squser --password=$sqpass $db < $filnavn2");
+		if ($mysql) system("$mysql -u $squser --password=$sqpass -h $sqhost $db < $filnavn2");
 	} else {
 		if (file_exists("/usr/bin/psql")) $psql = "/usr/bin/psql";
 		elseif (file_exists("/bin/psql")) $psql = "/usr/psql";
 		else echo "psql not found<br>";
-		if ($psql) system("export PGPASSWORD=$sqpass\n$psql -U $squser $db < $filnavn2");
+		if ($psql) system("export PGPASSWORD=$sqpass\n$psql -h $sqhost -U $squser $db < $filnavn2");
 	}
 	db_close($connection);
 	print "<BODY ONLOAD=\"javascript:alert('Regnskabet er genskabt. Du skal logge ind igen!')\">";

--- a/admin/restore.php
+++ b/admin/restore.php
@@ -31,6 +31,8 @@
 // 20250130 migrate utf8_en-/decode() to mb_convert_encoding
 // 20222706 MSC - Implementing new design
 // 20250201 Add hostname to psql
+// 20250201 removed init of $uploadedfile which was never used
+// 20250201 $brugernavn is never set near the end of the restore function
 
 @session_start();
 $s_id=session_id();
@@ -52,7 +54,7 @@ else
 $title="SALDI - genindl&aelig;s sikkerhedskopi";
 $modulnr=11;
 $css="../css/standard.css";
-$backupdate=$backupdb=$backupver=$backupnavn=$filnavn=$menu=$regnskab=$timezone=$popup=$uploadedfile=NULL;
+$backupdate=$backupdb=$backupver=$backupnavn=$filnavn=$menu=$regnskab=$timezone=$popup=NULL;
 
 include("../includes/connect.php");
 if (isset($_GET['db']) && $_GET['db']) {
@@ -116,14 +118,19 @@ if(isset($_FILES['uploadedfile']['name']) || isset($_POST['filnavn'])) { # 20160
 			unlink($filnavn);
 		} 
 	}
-	$fejl = $_FILES['uploadedfile']['error'];
+	// if_isset cannot be used here since 'error' will be 0 on succes. But if_isset would return it as false
+	if (isset($_FILES['uploadedfile']['error'])) {
+		$fejl = $_FILES['uploadedfile']['error'];
+	} else {
+			$fejl = false;
+	}
 	if ($fejl) {
 		switch ($fejl) {
 			case 1: print "<BODY onLoad=\"javascript:alert('Filen er for stor - Kontroller upload_max_filesize i php.ini')\">";
 			case 2: print "<BODY onLoad=\"javascript:alert('Filen er for stor - er det en SALDI-sikkerhedskopi?')\">";
 		}
 	}
-	if (basename($_FILES['uploadedfile']['name'])) {
+	if (isset($_FILES['uploadedfile']['name']) && basename($_FILES['uploadedfile']['name'])) {
 		$filnavn="../temp/".$db."/restore.gz";
 		$tmp=$_FILES['uploadedfile']['tmp_name'];
 		system ("rm -rf ../temp/".$db."/*");
@@ -202,7 +209,6 @@ function restore($filnavn,$backup_encode,$backup_dbtype){
 
 global $connection;
 global $s_id;
-global $brugernavn;
 global $regnskab;
 global $db;
 global $sqdb;
@@ -293,7 +299,7 @@ if ($restore=='OK') {
 	if ($popup) {
 		print "<BODY ONLOAD=\"JavaScript:opener.location.reload();\"";
 		print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
-	} else print "<meta http-equiv=\"refresh\" content=\"0;URL=../index/index.php?regnskab=".htmlentities($regnskab,ENT_COMPAT,$charset)."&navn=".htmlentities($brugernavn,ENT_COMPAT,$charset)."\">";
+	} else print "<meta http-equiv=\"refresh\" content=\"0;URL=../index/index.php?regnskab=".htmlentities($regnskab,ENT_COMPAT,$charset)."\">";
  
 } else {
 	unlink($filnavn);

--- a/admin/vis_regnskaber.php
+++ b/admin/vis_regnskaber.php
@@ -22,6 +22,7 @@ $s_id=session_id();
 // ----------------------------------------------------------------------
 // 20210328 PHR Some cleanup.
 // 20210916 LOE Translated some texts
+// 20250201 Add hostname to psql
 
 $css="../css/standard.css";
 $title="vis regnskaber";
@@ -171,7 +172,7 @@ if ($beregn) {
 	$fp=fopen("../temp/$sqdb/tmp.sh","w");
 	fwrite($fp,"#!/bin/sh\n");
 	fwrite($fp,"export PGPASSWORD='$sqpass'\n");
-	fwrite($fp,"psql --username=$squser -l > ../temp/dbliste.txt\n");
+	fwrite($fp,"psql --host=$sqhost --username=$squser -l > ../temp/dbliste.txt\n");
 	fclose($fp);
 	system("/bin/sh '../temp/$sqdb/tmp.sh'");
 	unlink ("../temp/$sqdb/tmp.sh");


### PR DESCRIPTION
## What are the changes about?
Follow up to #24

`psql` hostname must be set when running in docker or otherwise separate hosts for Restore to work

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
