### PR TITLE
Remove ini_set display_errors

### DIFF
--- a/admin/opret.php
+++ b/admin/opret.php
@@ -103,7 +103,6 @@
 @session_start();
 $s_id=session_id();
 
-ini_set("display_errors","1");
 $css="../css/standard.css";
 		
 include("../includes/connect.php");

--- a/admin/restore.php
+++ b/admin/restore.php
@@ -31,7 +31,6 @@
 
 @session_start();
 $s_id=session_id();
-ini_set('display_errors',0);
 
 ?>
 <script LANGUAGE="JavaScript">

--- a/api/rest_api_client.php
+++ b/api/rest_api_client.php
@@ -28,7 +28,6 @@
 // Copyright (c) 2004-2017 DANOSOFT ApS
 // ----------------------------------------------------------------------
 
-ini_set('display_errors', 1);
 
 if(!ini_get('allow_url_fopen') ) {
    echo 'allow_url_fopen not enabled<br>';

--- a/debitor/pos_ordre.php
+++ b/debitor/pos_ordre.php
@@ -359,7 +359,6 @@ include("pos_ordre_includes/divFuncs/drawer/drawerStatusFunc.php");
 preDrawerCheck();
 global $initial_price; #from debitor/pos_ordre_includes/showPosLines/productLines.php
 
-ini_set('display_errors', '0');
 
 // Projekt kan knytttes til menu, f.eks dag og aften så man kan trække en rapport på hvor man har sin indtjening. 
 // Projektet knyttes til varen så det både kan være dag og aften på samme bon. 

--- a/debitor/pos_ordre_includes/pos_ordre.php
+++ b/debitor/pos_ordre_includes/pos_ordre.php
@@ -274,7 +274,6 @@ include("pos_ordre_includes/divFuncs/drawer/drawerStatusFunc.php");
 preDrawerCheck();
 global $initial_price; #from debitor/pos_ordre_includes/showPosLines/productLines.php
 
-ini_set('display_errors', '0');
 
 // Projekt kan knytttes til menu, f.eks dag og aften så man kan trække en rapport på hvor man har sin indtjening. 
 // Projektet knyttes til varen så det både kan være dag og aften på samme bon. 

--- a/finans/importer.php
+++ b/finans/importer.php
@@ -48,7 +48,6 @@ include("../includes/online.php");
 include("../includes/settings.php");
 include("../includes/std_func.php");
 
-# ini_set('display_errors', 1);
 
 print "<div align=\"center\">";
 

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -90,7 +90,6 @@
 // 20240804	PHR - Removed (float) from belob
 // 20240807 PHR	- Minor correction.
 
-ini_set('display_errors', 1);
 ob_start(); //Starter output buffering
 
 @session_start();

--- a/includes/online.php
+++ b/includes/online.php
@@ -139,8 +139,6 @@ if ($r = db_fetch_array($q)) {
 	}
 }
 #}
-if (substr($db, 0, 4) == 'laja') ini_set('display_errors', 0);
-else ini_set('display_errors', 0);
 
 $labelprint = 0;
 if ($sqdb == 'udvikling') $labelprint = 1;

--- a/includes/opdat_kostpriser.php
+++ b/includes/opdat_kostpriser.php
@@ -38,7 +38,6 @@ include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
 
-ini_set("display_errors", "1");
 	print "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 	<html>
 		<head>

--- a/includes/udskriv.php
+++ b/includes/udskriv.php
@@ -45,7 +45,6 @@ header('Expires: Mon, 01 Jan 2017 05:00:00 GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate'); 
 header('Cache-Control: post-check=0, pre-check=0', FALSE); 
 header('Pragma: no-cache');
-ini_set("display_errors", "0");
 
 $css="../css/standard.css";		
 		

--- a/index/install.php
+++ b/index/install.php
@@ -48,7 +48,6 @@ if (file_exists("../includes/connect.php")) {
 	exit;
 }
 $noskriv=NULL;
-ini_set('display_errors',0);
 $timezone='Europe/Copenhagen';
 
 include("../includes/db_query.php");

--- a/kreditor/scanAttachments/getScan/paper_api_call.php
+++ b/kreditor/scanAttachments/getScan/paper_api_call.php
@@ -63,7 +63,6 @@ echo $s;
 
 /*
 
-ini_set('display_errors',1);
 // Initiate curl session in a variable (resource)
 $curl_handle = curl_init();
 //$url = ;

--- a/sager/ajax_loen.php
+++ b/sager/ajax_loen.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$id=if_isset($_GET['akkordlistevalg']);
 #$akkordlistevalg=45;
 #$id=45;	

--- a/sager/ajax_loenafregning.php
+++ b/sager/ajax_loenafregning.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$alle_ansatte_id=if_isset($_POST['alle_ansatte_id']);
 	$periode=if_isset($_POST['periode']);
 	

--- a/sager/ajax_planlaeg.php
+++ b/sager/ajax_planlaeg.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$id=if_isset($_POST['id']);
 	$planfra=if_isset($_POST['planfra']);
 	$plantil=if_isset($_POST['plantil']);

--- a/sager/ajax_planlaeg_sag.php
+++ b/sager/ajax_planlaeg_sag.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$opg_id=if_isset($_POST['opg_id']);
 	$id=if_isset($_POST['id']);
 	$planfra=if_isset($_POST['planfra']);

--- a/sager/ajax_planlaeg_sager.php
+++ b/sager/ajax_planlaeg_sager.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$opg_id=if_isset($_POST['opg_id']);
 	$id=if_isset($_POST['id']);
 	$planfra=if_isset($_POST['planfra']);

--- a/sager/ajax_statusupdate.php
+++ b/sager/ajax_statusupdate.php
@@ -11,7 +11,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$id=if_isset($_POST['sagid']);
 	$status=if_isset($_POST['status']);
 	

--- a/sager/ansatte.php
+++ b/sager/ansatte.php
@@ -32,7 +32,6 @@ $s_id=session_id();
 // 20151007 PK - Der er sat session på alle og aftrådte i leftmenu, så den husker søgning. Søg alleA eller tiltraadteA
 // 20170911 PK - Har sat validering på brugernavn så der ikke kommer duplikater. Søg 20170911 
 
-	//ini_set("display_errors", "1");
 	$bg="nix";
 	$header='nix';
 

--- a/sager/autocomplete.php
+++ b/sager/autocomplete.php
@@ -31,7 +31,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	$q=$_GET['q'];
 	switch ($_GET['mode']) {
 		case 'sagsnr': // til søgning af sagsnummer i loen.php

--- a/sager/kontrolskemaer.php
+++ b/sager/kontrolskemaer.php
@@ -54,7 +54,6 @@
 		($sag_id)?$funktion='':$funktion='kontrolskemaliste';  
 	}
 	*/
-ini_set("display_errors", "0");
 print "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 <html>
 	<head>

--- a/sager/mm_kontrolskemaer.php
+++ b/sager/mm_kontrolskemaer.php
@@ -54,7 +54,6 @@
 		($sag_id)?$funktion='':$funktion='kontrolskemaliste';  
 	}
 	*/
-ini_set("display_errors", "0");
 print "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 <html>
 	<head>

--- a/sager/sager.php
+++ b/sager/sager.php
@@ -79,7 +79,6 @@ $s_id=session_id();
 		($sag_id)?$funktion='':$funktion='sagsliste';  
 	}
 	
-ini_set("display_errors", "0");
 print "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 <html>
 	<head>

--- a/sager/sortmappe.php
+++ b/sager/sortmappe.php
@@ -12,7 +12,6 @@ include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
 
-ini_set("display_errors", "1");
 
 
 if (isset($_POST['orders'])) {

--- a/sager/template_form.php
+++ b/sager/template_form.php
@@ -17,7 +17,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 	
 $key = NULL;
 $field['tekst'] = NULL;

--- a/sager/template_list.php
+++ b/sager/template_list.php
@@ -17,7 +17,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 
 
 

--- a/sager/tilbud.php
+++ b/sager/tilbud.php
@@ -17,7 +17,6 @@
 	include("../includes/online.php");
 	include("../includes/std_func.php");
 	
-	ini_set("display_errors", "1");
 
 
 function visTemplates() {

--- a/soapklient/test.php
+++ b/soapklient/test.php
@@ -1,6 +1,5 @@
 <?php
 
-ini_set('display_errors','On');
 include ("saldi_connect.php");
 include("soapfunc.php");
 list($fejl,$s_id)=explode(chr(9),logon($regnskab,$brugernavn,$adgangskode));

--- a/systemdata/sys_div_func.php
+++ b/systemdata/sys_div_func.php
@@ -92,7 +92,6 @@
 
 	include("sys_div_func_includes/chooseProvision.php");
 
-ini_set('display_errors','0');
 
 function kontoindstillinger($regnskab,$skiftnavn) {
 	global $bgcolor,$bgcolor5,$sprog_id,$timezone;


### PR DESCRIPTION
## What are the changes about?
Display_errors should be set globally to `"0"` in the server's `php.ini` file in production and to `"1"`  only in development.
https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
