### PR TITLE
Migrate from deprecated strftime to IntlDateFormatter

### DIFF
--- a/debitor/crmkalender.php
+++ b/debitor/crmkalender.php
@@ -24,6 +24,7 @@
 // ----------------------------------------------------------------------
 // 20240209 PHR Added indbetaling
 // 20240227 PHR Added $printfile and call to saldiprint.php
+// 20250207 migrate from strftime to IntlDateFormatter.
 
 @session_start();
 $s_id = session_id();
@@ -74,8 +75,6 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
 // Main Execution
 function render_crm_calendar()
 {
-    // Set locale for date handling
-    setlocale(LC_TIME, 'da_DK.UTF-8');
 
     // Determine selected year and month
     $selected_year = $_GET['year'] ?? date('Y');
@@ -136,8 +135,10 @@ function render_month_navigation($selected_year, $selected_month)
             </select>
             <select name="month" onchange="this.form.submit()">
                 <?php
+                $date_fmt = new IntlDateFormatter('da_DK');
+                $date_fmt->setPattern('MMMM');
                 for ($month = 1; $month <= 12; $month++) {
-                    $month_name = strftime('%B', mktime(0, 0, 0, $month, 1));
+                    $month_name = $date_fmt->format(mktime(0, 0, 0, $month, 1));
                     $selected = $month == $selected_month ? 'selected' : '';
                     echo "<option value='$month' $selected>" . ucfirst($month_name) . "</option>";
                 }

--- a/finans/budget.php
+++ b/finans/budget.php
@@ -35,6 +35,7 @@
 // 20190216 PHR	Ændret csv til ISO-8859-1.
 // 20210312 LOE Translated the former Danish text here to English and Applied findtekst function to this and the menu items
 // 20220926 MSC Removed a 2 number in title for budget
+// 20250207 Decrease arguments in call to periodeoverskrifter
 
 @session_start();
 $s_id=session_id();
@@ -269,7 +270,7 @@ print "<td><b>".findtekst(805, $sprog_id)."</b></td> ";
 #	print "<td width=20 title=\"$z. regnskabsm&aring;ned\"><b> MD_$z<b><br></td>";
 #}
 $budget_csvdata="\"Kontonr\";\"Kontonavn\";"; # 20150622 del 2 start
-$budget_csvdata.=periodeoverskrifter($maanedantal, $startaar, $startmaaned, 1, "regnskabsmaaned", $regnskabsaar);
+$budget_csvdata.=periodeoverskrifter($maanedantal, $startaar, $startmaaned, 1, $regnskabsaar);
 print "<td align=right><b> I alt</a></b></td> "; 
 $budget_csvdata.="\"I alt\"\n"; # 20150622 del 2 slut
 print "</tr>";

--- a/finans/regnskab.php
+++ b/finans/regnskab.php
@@ -41,6 +41,7 @@
 // 20210607 LOE updated the if function retrieving the data from kontoplan.txt file for Danish and English languages
 // 20210721 LOE translated some texts here and also updated title texts with translated ones.
 // 20220624 CA  rolled back retrieving data from kontoplan.txt DA and EN cause it overwrites existing accounting plans.
+// 20250207 Decrease arguments in call to periodeoverskrifter
 
 @session_start();
 $s_id=session_id();
@@ -336,7 +337,7 @@ fwrite($csv,";Primo");
 #for ($z=1; $z<=$maanedantal; $z++) {
 #	print "<td title=\"$z. regnskabsm&aring;ned\" align=right><b> MD_$z<b><br></td>";
 #}
-$tmp=periodeoverskrifter($maanedantal, $startaar, $startmaaned, 1, "regnskabsmaaned", $regnskabsaar);
+$tmp=periodeoverskrifter($maanedantal, $startaar, $startmaaned, 1, $regnskabsaar);
 fwrite($csv,";". str_replace('"','',$tmp) ."I alt\n");
 #$cols+=count(explode(";",$tmp));
 

--- a/includes/finansfunk.php
+++ b/includes/finansfunk.php
@@ -18,70 +18,29 @@
 // ----------------------------------------------------------------------------
 //
 // 20150622 CA  funktionen periodeoverskrifter returnere overskrifterne som CSV
+// 20250207 migrate from strftime to IntlDateFormatter. + strip function down to what is actually used.
 
 if (!function_exists('periodeoverskrifter')) {
-	function periodeoverskrifter ($periodeantal, $periode_aar, $periode_md, $periode_dag=1, $periode_laengde="regnskabsmaaned", $regnskabsaar="") {
-		# Periodelængder kan være dag, uge, maaned, regnskabsmaaned eller kvartal (eller blot det foerste bogstav)
-		setlocale(LC_TIME, "da_DK","da","da_DK.utf8");
-		$retur=""; # 20150622
+	function periodeoverskrifter ($periodeantal, $periode_aar, $periode_md, $periode_dag=1, $regnskabsaar="") {
+		$date_fmt = new IntlDateFormatter('da_DK');
+		$retur="";
 		$trin = 1;
-		$periode_laengde = strtolower(substr($periode_laengde, 0, 1));
-		if ( $periode_laengde == substr("uge", 0, 1) ) {
-			$trin = 7;
-			$periodeantal = $trin * $periodeantal;
-		}
-		if ( $periode_laengde == substr("kvartal", 0, 1) ) {
-			$trin = 3;
-			$periodeantal = $trin * $periodeantal;
-		}
 		for ($z=0; $z<$periodeantal; $z=$z+$trin) {
-			if ( $periode_laengde == substr("dag", 0, 1) ) {
-				$periode_tidsstempel = mktime(12, 0, 0, $periode_md, $periode_dag+$z, $periode_aar);
-				if ( strftime("%u", $periode_tidsstempel) > 5 ) { # Loerdag eller soendag med det danske oe i navnet
-					# $periode_kort = ucfirst(substr(strftime("%a", $periode_tidsstempel),0,3))."&nbsp;".date("j/n",$periode_tidsstempel);
-					$periode_kort = ucfirst(substr(strftime("%a", $periode_tidsstempel),0,1))."&oslash;&nbsp;".date("j/n",$periode_tidsstempel);
-				} else {
-					$periode_kort = ucfirst(substr(strftime("%a", $periode_tidsstempel),0,2))."&nbsp;".date("j/n",$periode_tidsstempel);
-				}
-				$periode_lang = ucfirst(strftime("%A %e. %B %Y",$periode_tidsstempel));
-			} elseif ( $periode_laengde == substr("uge", 0, 1) ) {
-				$periode_tidsstempel = mktime(12, 0, 0, $periode_md, $periode_dag+$z, $periode_aar);
-				$periode_ugedag = strftime("%u", $periode_tidsstempel);
-				$periode_start = mktime(12, 0, 0, $periode_md, $periode_dag+$z+1-$periode_ugedag, $periode_aar);
-				$periode_slut = mktime(12, 0, 0, $periode_md, $periode_dag+$z+7-$periode_ugedag, $periode_aar);
-				$periode_kort = strftime("u%V'%g",$periode_tidsstempel);
-				$periode_lang = strftime("Uge %V i &aring;r %G",$periode_tidsstempel);
-				$periode_lang .= " (".date("d/m",$periode_start)." - ".date("d/m",$periode_slut).")";
-			} else {
-				$periode_tidsstempel= mktime(12, 0, 0, $periode_md+$z, $periode_dag, $periode_aar);
-				if ( $periode_laengde == substr("kvartal", 0, 1) ) {
-					$periode_slut = mktime(12, 0, 0, $periode_md+$z+3, 0, $periode_aar);
-					$periode_kvartal = floor((date("m",$periode_tidsstempel)-1)/3)+1;
-					$periode_kort = $periode_kvartal.". kv'". strftime("%y",$periode_tidsstempel);
-					$periode_lang = $periode_kvartal.". kvartal ". strftime("%Y",$periode_tidsstempel);
-					$periode_lang .= " (".date("d/m",$periode_tidsstempel)." - ".date("d/m",$periode_slut).")";
-				} elseif ( $periode_laengde == substr("maaned", 0, 1) ) {
-					$periode_kort = ucfirst(strftime("%b'%y",$periode_tidsstempel));
-					$periode_lang = ucfirst(strftime("%B %Y",$periode_tidsstempel));
-				} elseif ( $periode_laengde == substr("regnskabsmaaned", 0, 1) ) {
-					$periode_kort = ucfirst(strftime("%b'%y",$periode_tidsstempel));
-					$periode_lang = ucfirst(strftime("%B %Y",$periode_tidsstempel));
-					$periode_lang .= " (".($z+1).". regnskabsm&aring;ned i regnskabs&aring;ret";
-					if ( $regnskabsaar ) $periode_lang .= " ".$regnskabsaar;
-					$periode_lang .= ")";
-					
-				} else {
-					$periode_kort = ($z+1).".";
-					$periode_lang = ($z+1).". periode";
-				}
-			}
+			$periode_tidsstempel= mktime(12, 0, 0, $periode_md+$z, $periode_dag, $periode_aar);
+
+			$date_fmt->setPattern("MMM''yy");
+			$periode_kort = ucfirst($date_fmt->format($periode_tidsstempel));
+
+			$date_fmt->setPattern("MMMM yyyy");
+			$periode_lang = ucfirst($date_fmt->format($periode_tidsstempel));
+			$periode_lang .= " (".($z+1).". regnskabsm&aring;ned i regnskabs&aring;ret";
+			if ( $regnskabsaar ) $periode_lang .= " ".$regnskabsaar;
+			$periode_lang .= ")";
 	
 			print "<td title=\"$periode_lang\" align=\"right\"><b>$periode_kort</b></td>\n";
-			$retur.="\"$periode_kort\";"; # 20150622
+			$retur.="\"$periode_kort\";";
 		}
-		return $retur; # 20150622
+		return $retur;
 	}
-
 }
 ?>
-

--- a/sager/vis_loen.php
+++ b/sager/vis_loen.php
@@ -1,4 +1,7 @@
 <?php
+
+// 20250207 migrate from strftime to IntlDateFormatter.
+
 function vis_loen($id) {
 	global $charset;
 	global $sprog_id;
@@ -243,12 +246,18 @@ function vis_loen($id) {
 		$datotext_error="style=\"border: 1px solid red;-webkit-padding-before: 1px;-webkit-padding-after: 1px;-webkit-padding-start: 1px;-webkit-padding-end: 1px;\"";
 	} else { 
 		$loendato=dkdato($loendate); 
-		setlocale(LC_TIME, "danish"); 
 		if ($loendate==NULL) {
 			$loen_datotext=NULL;
 		} else {
-			$loen_datotext = strftime('%A den %d. %B %Y',strtotime($loendate));
-			if ($db_encode=='UTF8') $loen_datotext=utf8_encode($loen_datotext); 
+			$date_fmt = new IntlDateFormatter(
+				'da_DK',
+				IntlDateFormatter::FULL,
+				IntlDateFormatter::NONE
+			);
+			$loen_datotext = $date_fmt->format(strtotime($loendate));
+			if ($db_encode != 'UTF8') {
+				$loen_datotext = $loen_datotext=mb_convert_encoding($loen_datotext, 'ISO-8859-1', 'UTF-8');
+			}
 			$dato = date('d-m-y');
 			$tid = date('H:i');
 		}


### PR DESCRIPTION
## What are the changes about?
Since [PHP 8.1](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.date) (November 2021) `strftime` has been deprecated and will be removed in the future.

This edit replaces all calls to that function with `IntlDateFormatter::format()`

> **Note** that this requires the `Intl` extension which may not be installed by default.

The custom function `periodeoverskrifter()` has been greatly reduced, since it was never called with a non-default value to `$periode_laengde="regnskabsmaaned"`

Further relevant info:
- [strftime manual](https://www.php.net/manual/en/function.strftime.php)
- [IntlDateFormatter::format() manual](https://www.php.net/manual/en/intldateformatter.format.php) 
- [PHP.watch article](https://php.watch/versions/8.1/strftime-gmstrftime-deprecated)


## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
