### PR TITLE
Fix new issue in kladdeliste

### DIFF
--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -36,8 +36,13 @@ $title="kladdeliste";
 		
 include("../includes/connect.php");
 include("../includes/std_func.php");
-$query = db_select("SELECT * FROM settings WHERE var_name = 'apiKey' AND var_grp = 'easyUBL'", __FILE__ . " linje " . __LINE__);
-$apiKey = db_fetch_array($query)["var_value"];
+$query = "SELECT var_value FROM settings WHERE var_name = 'apiKey' AND var_grp = 'easyUBL'";
+if ($r=db_fetch_array(db_select($query, __FILE__ . " linje " . __LINE__))) {
+	$apiKey = $r["var_value"];
+	unset($r);
+} else {
+	$apiKey = "";
+}
 include("../includes/online.php");
 include("../includes/topline_settings.php");
 


### PR DESCRIPTION
## What are the changes about?
Today, a new possible undefined array was introduced in 59f1b5cc5305524a8ca05c729078719822740af1

The assignment to `$apiKey` expects a certain database record exists, which cannot be relied upon.

In my database, the settings table consists only of 10 rows all belonging to var_grp globals.
Therefore, a `PHP Warning:  Trying to access array offset on false in /var/www/html/danosoft/finans/kladdeliste.php on line 40` is thrown.

This fixes the issue. 

Note , that `$apiKey` is defaulted to an empty string, because the variable is used further down in the file, which would otherwise just move the issue.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
