### PR TITLE
Fix passing of NULL to explode during soring logic

### DIFF
--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -41,21 +41,23 @@ $apiKey = db_fetch_array($query)["var_value"];
 include("../includes/online.php");
 include("../includes/topline_settings.php");
 
-if (!isset ($_COOKIE['saldi_kladdeliste'])) $_COOKIE['saldi_kladdeliste'] = NULL;
-
-$sort=isset($_GET['sort'])? $_GET['sort']:Null;
-$rf=isset($_GET['rf'])? $_GET['rf']:Null;
-$vis=isset($_GET['vis'])? $_GET['vis']:Null;
-print "<meta http-equiv=\"refresh\" content=\"150;URL=kladdeliste.php?sort=$sort&rf=$rf&vis=$vis\">";
-
-if (isset($_GET['sort'])) {
+list($sort,$rf,$vis) = [
+	isset($_GET['sort']) ? $_GET['sort'] : NULL,
+	isset($_GET['rf']) ? $_GET['rf']: NULL,
+	isset($_GET['vis']) ? $_GET['vis']: NULL
+];
+if (isset($sort)) {
 	$cookievalue="$sort;$rf;$vis";
 	setcookie("saldi_kladdeliste", $cookievalue, strtotime('+30 days'));
-} else list ($sort,$rf,$vis) = array_pad(explode(";", $_COOKIE['saldi_kladdeliste']), 3, null);
-if (!$sort) {
+} elseif (isset($_COOKIE['saldi_kladdeliste'])) {
+	list($sort,$rf,$vis) = array_pad(explode(";", $_COOKIE['saldi_kladdeliste']), 3, NULL);
+}
+else {
 	$sort = "id";
 	$rf = "desc";
 }
+print "<meta http-equiv=\"refresh\" content=\"150;URL=kladdeliste.php?sort=$sort&rf=$rf&vis=$vis\">";
+
 if (strpos(findtekst(639,$sprog_id),'undtrykke')) {
 	$qtxt = "update tekster set tekst = '' where tekst_id >= '600'";
 	db_modify($qtxt,__FILE__ . " linje " . __LINE__);


### PR DESCRIPTION
## What are the changes about?
On the initial entry into `finans/kladdeliste.php` the following warning is thrown:
```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/danosoft/finans/kladdeliste.php on line 54, referer: http://localhost/danosoft/index/menu.php
PHP Stack trace:, referer: http://localhost/danosoft/index/menu.php
PHP   1. {main}() /var/www/html/danosoft/finans/kladdeliste.php:0, referer: http://localhost/danosoft/index/menu.php
PHP   2. explode($separator = ';', $string = NULL) /var/www/html/danosoft/finans/kladdeliste.php:54, referer: http://localhost/danosoft/index/menu.php
```

This is because, if the cookie `saldi_kladdeliste` does not exists, at line 54, `NULL` will be passed to `explode()`.

This PR rearranges the logic to make sure, no undefined variables are relied on. Also see specific line notes.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
