### PR TITLE
.vscode/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bilag/
 # Python stuff
 __pycache__/
 .pytest_cache
+
+# VS Code
+.vscode/


### PR DESCRIPTION
Please consider this update to .gitignore since I need the .vscode folder in the root for running XDebug