### PR TITLE
Add Docker Compose support for one-command installation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# dotenv file only used with docker compose setup to configure mailsever
+# Copy this file to .env and fill in your values.
+
+# SMTP configuration for outgoing email.
+# By default (no config), all emails are caught by the built-in Mailpit service
+# and are NOT delivered. View them at http://localhost:5002
+#
+# To send real emails, uncomment and fill in the settings below.
+
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_FROM=noreply@example.com
+# SMTP_USER=your@email.com
+# SMTP_PASS=yourpassword
+# SMTP_TLS=off
+# SMTP_STARTTLS=on   # use on for port 587
+
+# Examples:
+#
+# Gmail (requires an App Password, not your regular password):
+#   SMTP_HOST=smtp.gmail.com
+#   SMTP_PORT=587
+#   SMTP_STARTTLS=on
+#   SMTP_USER=you@gmail.com
+#   SMTP_PASS=your-app-password
+#
+# Office 365:
+#   SMTP_HOST=smtp.office365.com
+#   SMTP_PORT=587
+#   SMTP_STARTTLS=on
+#   SMTP_USER=you@company.com
+#   SMTP_PASS=yourpassword
+#
+# Custom mail server (plain, port 25):
+#   SMTP_HOST=mail.yourdomain.com
+#   SMTP_PORT=25

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ includes/connect.php
 testshop.php
 saldiinfo.php
 phpmailer/*
+phpmailer
+vendor
 */phpmailer/*
 includes/vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Suppress PHP warnings/notices from being rendered in the browser
 RUN echo "display_errors = Off" > /usr/local/etc/php/conf.d/suppress-errors.ini \
- && printf "upload_max_filesize = 512M\npost_max_size = 512M\nmemory_limit = 512M\nmax_execution_time = 300\n" > /usr/local/etc/php/conf.d/uploads.ini \
+ && printf "upload_max_filesize = 512M\npost_max_size = 512M\nmemory_limit = 512M\nmax_execution_time = 300\noutput_buffering = 4096\n" > /usr/local/etc/php/conf.d/uploads.ini \
  && printf "log_errors = On\nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/logging.ini
 
 # Suppress Apache ServerName warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:8.3-apache
+
+# Install PostgreSQL client libs and PHP pgsql extensions
+RUN apt-get update && apt-get install -y \
+        libpq-dev \
+        postgresql-client \
+        unzip \
+        git \
+        pdftk-java \
+        ghostscript \
+        msmtp \
+        msmtp-mta \
+    && docker-php-ext-install pgsql pdo_pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
+# msmtp config is generated at container startup from env vars (see docker-entrypoint.sh)
+RUN echo 'sendmail_path = "/usr/bin/msmtp -t --read-envelope-from"' \
+    > /usr/local/etc/php/conf.d/mail.ini
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Suppress PHP warnings/notices from being rendered in the browser
+RUN echo "display_errors = Off" > /usr/local/etc/php/conf.d/suppress-errors.ini \
+ && printf "upload_max_filesize = 512M\npost_max_size = 512M\nmemory_limit = 512M\nmax_execution_time = 300\n" > /usr/local/etc/php/conf.d/uploads.ini \
+ && printf "log_errors = On\nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/logging.ini
+
+# Suppress Apache ServerName warning
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Allow symlinks and .htaccess in the webroot
+RUN sed -i 's|<Directory /var/www/>|<Directory /var/www/>\n\tOptions FollowSymLinks|' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
         git \
         pdftk-java \
         ghostscript \
+        imagemagick \
         msmtp \
         msmtp-mta \
     && docker-php-ext-install pgsql pdo_pgsql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
         pdftk-java \
         ghostscript \
         imagemagick \
+        barcode \
         msmtp \
         msmtp-mta \
     && docker-php-ext-install pgsql pdo_pgsql \

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,11 +1,18 @@
-Installation of SALDI
-================================================= ===========================
+# Installation of SALDI
 
-NOTICE:
-See updated installation guide at INSTALLATION.md, this installation guide 
-includes how to setup optional docker container for saldi, and what is essentially 
-a one command install of the system
+## Client Requirements
 
+Web browser with cookies and JavaScript enabled, supporting pop-up windows.
+
+Tested browsers: Google Chrome / Chromium, Vivaldi.
+> Browsers from Microsoft are generally buggy and not recommended.
+
+---
+
+<details>
+<summary><strong>Option A — Standard Installation (Linux + Apache + PostgreSQL)</strong></summary>
+
+```
 System requirements for server:
 ----------------------
 Linux or other Unix-like system with web server with PHP support
@@ -23,23 +30,12 @@ copy.
 It is not recommended to use other database servers, as it is likely that there
 errors will occur when upgrading where there has been a change in the database model.
 
-System requirements for client:
-----------------------
-Web browser where cookies and JavaScript are enabled and which supports new ones
-windows and pop-ups.
-
-Saldi is developed for and tested with the web browsers:
-- Google Chrome / Chromium
-- Vivaldi
-
-Browsers from Microsoft are generally buggy and not recommended
-
 
 The installation itself:
 ---------------------
 0. We assume you have already initialized git. Then, Clone it from github to your root directory without adding in into extra directory.
 
-e.g www/  
+e.g www/
 
 www$ clone https://github.com/DANOSOFT/saldi.git
 
@@ -47,8 +43,8 @@ or www/html/
 
 www/html$ git clone https://github.com/DANOSOFT/saldi.git
 
-Note: if you don't need the extra directory that comes with the clonning, 
-i.) 
+Note: if you don't need the extra directory that comes with the clonning,
+i.)
 Go to your working directory and run these commands:
 	$ git remote add origin https://github.com/DANOSOFT/saldi.git
 	$ git fetch origin
@@ -64,7 +60,7 @@ Go to your working directory and run these commands:
 
  sudo sed -i 's/^\(balances:.*[a-z0-9]\)$/\1,www-data/' /etc/group
  sudo sed -i 's/^\(balances:.*\\)$/\1www-data/' /etc/group
- 
+
 3. Manually create these directories inside the root of saldi: 'temp' and 'logolib'.
 e.g saldi/loglib etc.
 
@@ -79,8 +75,8 @@ e.g saldi/loglib etc.
  or if you are down in the Saldi catalog itself:
 
  sudo chmod 775 includes logolib temp
- 
- If that permission didn't work during installation, you can use 777. 
+
+ If that permission didn't work during installation, you can use 777.
 
  In the includes directory the file connect.php is created, so after
  creation, it can be changed to 555. In the catalog logolib
@@ -97,10 +93,10 @@ e.g saldi/loglib etc.
 
 7. Specify the address of the web server and the directory under the web server
  hierarchy where you copied the Balances files to. For example:
- 
+
 	#domain/saldi
 
-       # http://localhost/saldi 
+       # http://localhost/saldi
 
 8. It may be that the browser complains that the page is trying to
  open pop-up windows. You must accept this. If not, it takes you to the installation page.
@@ -144,8 +140,121 @@ e.g saldi/loglib etc.
 
 16. Now it is time to set up the accounts in Balances. See the link
  "User guide" under "Support" on the website https://saldi.dk/
+```
 
-================================================= =====================
-Last modified 2024-07-09 by Lawrence Ojomon E. <loe@saldi.dk>
+</details>
 
-© Saldi.dk ApS - http://saldi.dk/
+---
+
+<details>
+<summary><strong>Option B — Docker Compose Installation</strong></summary>
+
+### Requirements
+
+- [Docker](https://docs.docker.com/get-docker/) with Docker Compose
+
+No system-level PHP, Apache, or PostgreSQL needed — everything runs in containers.
+
+### Steps
+
+**1.** Clone the repository:
+
+```bash
+git clone https://github.com/DANOSOFT/saldi.git
+cd saldi
+```
+
+**2.** *(Optional)* Configure email. By default, all outgoing emails are caught
+by the built-in Mailpit service and **not delivered**. To send real emails,
+copy the example env file and fill in your SMTP credentials:
+
+```bash
+cp .env.example .env
+# Edit .env with your SMTP details
+```
+
+**3.** Build and start all services:
+
+```bash
+docker compose up --build
+```
+
+**4.** Open your browser and go to `http://localhost:5000/saldi`. Allow pop-ups if prompted.
+
+**5.** The installation wizard opens. Fill in:
+
+| Field | Value |
+|---|---|
+| Database server | PostgreSQL |
+| Character set | UTF8 |
+| Server name | `postgres` ← use this, **not** localhost |
+| Database name | `saldi` |
+| DB administrator | `user` |
+| DB password | `password` |
+| SALDI admin | your choice |
+
+Click **Install**.
+
+**6.** After installation completes, click **Næste** and log in.
+
+**7.** Choose **"Opret Regnskab"**, fill in account details, click **Gem/Opdater**.
+
+**8.** Select the account from **"Vis regnskaber"** and begin using it.
+
+### Services
+
+| Service | URL | Purpose |
+|---|---|---|
+| SALDI | http://localhost:5000/saldi | Main application |
+| Adminer | http://localhost:5001 | Database browser |
+| Mailpit | http://localhost:5002 | Inspect outgoing emails (default) |
+
+**Adminer login:** System `PostgreSQL` · Server `postgres` · User `user` · Password `password`
+
+### Email Configuration
+
+Set these in your `.env` file to deliver real emails (see `.env.example`):
+
+| Variable | Description | Default |
+|---|---|---|
+| `SMTP_HOST` | SMTP server hostname | `mailpit` (caught locally) |
+| `SMTP_PORT` | SMTP port | `1025` |
+| `SMTP_FROM` | Envelope from address | `noreply@example.com` |
+| `SMTP_USER` | SMTP username | *(none)* |
+| `SMTP_PASS` | SMTP password | *(none)* |
+| `SMTP_TLS` | `on`/`off` | `off` |
+| `SMTP_STARTTLS` | `on`/`off` — use for port 587 | `off` |
+
+**Gmail** (requires a [Google App Password](https://support.google.com/accounts/answer/185833)):
+```env
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_STARTTLS=on
+SMTP_USER=you@gmail.com
+SMTP_PASS=your-app-password
+```
+
+**Office 365:**
+```env
+SMTP_HOST=smtp.office365.com
+SMTP_PORT=587
+SMTP_STARTTLS=on
+SMTP_USER=you@company.com
+SMTP_PASS=yourpassword
+```
+
+### Useful Commands
+
+```bash
+docker compose up -d          # Start in background
+docker compose down           # Stop all services
+docker compose logs -f web    # Follow web server logs
+docker compose exec web bash  # Shell into the web container
+docker compose up --build     # Rebuild after Dockerfile changes
+```
+
+</details>
+
+---
+
+*© Saldi.dk ApS — https://saldi.dk/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use SALDI, clone the repository:
 
 
 ## Installation 
-- [INSTALLATION/](INSTALLATION.txt): INSTALLATION.txt
+- [INSTALLATION/](INSTALLATION.md): INSTALLATION.md
 
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+services:
+  web:
+    build: .
+    ports:
+      - "5000:80"
+    volumes:
+      - .:/var/www/html/saldi
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SMTP_HOST: ${SMTP_HOST:-mailpit}
+      SMTP_PORT: ${SMTP_PORT:-1025}
+      SMTP_FROM: ${SMTP_FROM:-noreply@example.com}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_TLS: ${SMTP_TLS:-off}
+      SMTP_STARTTLS: ${SMTP_STARTTLS:-off}
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: saldi
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    # Allow the postgres superuser to connect without a password (needed for
+    # the backup/restore feature — see INSTALLATION.txt pg_hba.conf note).
+    command: >
+      postgres
+        -c hba_file=/etc/postgresql/pg_hba.conf
+    configs:
+      - source: pg_hba
+        target: /etc/postgresql/pg_hba.conf
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d saldi"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "5002:8025"   # web UI to inspect caught emails
+    restart: unless-stopped
+
+  adminer:
+    image: adminer
+    ports:
+      - "5001:8080"
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
+configs:
+  pg_hba:
+    content: |
+      # TYPE  DATABASE  USER      ADDRESS     METHOD
+      local   all       postgres              trust
+      local   all       all                   md5
+      host    all       all       0.0.0.0/0   scram-sha-256
+      host    all       all       ::/0        scram-sha-256
+
+volumes:
+  pgdata:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# ---------------------------------------------------------------------------
+# Generate msmtp config from environment variables.
+# Set these in your .env file or docker-compose environment section:
+#   SMTP_HOST     - SMTP server hostname          (default: localhost)
+#   SMTP_PORT     - SMTP port                     (default: 25)
+#   SMTP_FROM     - Envelope from address         (default: noreply@example.com)
+#   SMTP_USER     - SMTP username (optional)
+#   SMTP_PASS     - SMTP password (optional)
+#   SMTP_TLS      - on/off                        (default: off)
+#   SMTP_STARTTLS - on/off (STARTTLS/opportunistic)(default: off)
+#   SMTP_AUTH     - on/off                        (default: off if no user set)
+# ---------------------------------------------------------------------------
+SMTP_HOST="${SMTP_HOST:-mailpit}"
+SMTP_PORT="${SMTP_PORT:-1025}"
+SMTP_FROM="${SMTP_FROM:-noreply@example.com}"
+SMTP_TLS="${SMTP_TLS:-off}"
+SMTP_STARTTLS="${SMTP_STARTTLS:-off}"
+
+if [ -n "$SMTP_USER" ]; then
+    SMTP_AUTH="${SMTP_AUTH:-on}"
+else
+    SMTP_AUTH="${SMTP_AUTH:-off}"
+fi
+
+{
+    echo "defaults"
+    echo "auth $SMTP_AUTH"
+    echo "tls $SMTP_TLS"
+    echo "tls_starttls $SMTP_STARTTLS"
+    echo "tls_certcheck off"
+    echo ""
+    echo "account default"
+    echo "host $SMTP_HOST"
+    echo "port $SMTP_PORT"
+    echo "from $SMTP_FROM"
+    [ -n "$SMTP_USER" ] && echo "user $SMTP_USER"
+    [ -n "$SMTP_PASS" ] && echo "password $SMTP_PASS"
+} > /etc/msmtprc
+chmod 644 /etc/msmtprc
+
+# Install Composer dependencies if vendor dir is missing.
+# composer.json lives in includes/ but the app expects vendor/ at the project root,
+# so we install there and create a symlink from root/vendor -> includes/vendor.
+if [ ! -d /var/www/html/saldi/vendor ] && [ -f /var/www/html/saldi/includes/composer.json ]; then
+    echo "Installing Composer dependencies..."
+    composer install --no-dev --working-dir=/var/www/html/saldi/includes
+    ln -sf /var/www/html/saldi/includes/vendor /var/www/html/saldi/vendor
+fi
+
+# Ensure required writable directories exist with correct permissions
+for dir in includes logolib temp; do
+    mkdir -p /var/www/html/saldi/$dir
+    chmod 777 /var/www/html/saldi/$dir
+done
+
+# Create vendor symlink at /var/www/html/vendor/ so relative paths like
+# ../../vendor/autoload.php resolve correctly when CWD is saldi/debitor/
+ln -sf /var/www/html/saldi/includes/vendor /var/www/html/vendor 2>/dev/null || true
+
+# Create phpmailer symlink for the legacy fallback (code looks for phpmailer/
+# but the directory is named phpmailerOld/)
+if [ ! -e /var/www/html/saldi/phpmailer ]; then
+    ln -sf /var/www/html/saldi/phpmailerOld /var/www/html/saldi/phpmailer
+fi
+
+exec "$@"

--- a/index/install.php
+++ b/index/install.php
@@ -360,14 +360,14 @@ if (isset($_POST['opret'])){
 		exit;
 	}		
 } else {
-	$db_encode    = if_isset($_SESSION['db_encode']);
-	$db_type      = if_isset($_SESSION['db_type']);
-	$db_host      = if_isset($_SESSION['db_host']);
-	$db_navn      = if_isset($_SESSION['db_navn']);
-	$db_bruger    = if_isset($_SESSION['db_bruger']);
-	$db_password  = if_isset($_SESSION['db_password']);
-	$adm_navn     = if_isset($_SESSION['adm_navn']);
-	$adm_password = if_isset($_SESSION['adm_password']);
+	$db_encode    = if_isset($_SESSION, '', 'db_encode');
+	$db_type      = if_isset($_SESSION, '', 'db_type');
+	$db_host      = if_isset($_SESSION, '', 'db_host');
+	$db_navn      = if_isset($_SESSION, '', 'db_navn');
+	$db_bruger    = if_isset($_SESSION, '', 'db_bruger');
+	$db_password  = if_isset($_SESSION, '', 'db_password');
+	$adm_navn     = if_isset($_SESSION, '', 'adm_navn');
+	$adm_password = if_isset($_SESSION, '', 'adm_password');
 	if(!if_isset($sprog_id,1));
 	if(isset( $_SESSION['language'])){
 		$sprog_id = $_SESSION['language'];


### PR DESCRIPTION
## What are the changes about?
- Adds a complete Docker Compose setup (`Dockerfile`, `docker-compose.yml`, `docker-entrypoint.sh`) so the system can be run with a single `docker compose up --build` command
- Services included: PHP 8.3 + Apache (web), PostgreSQL 16 (database), Mailpit (email catcher), Adminer (database browser)
- All outgoing emails are caught by Mailpit by default; users can configure a real SMTP server via a `.env` file without rebuilding the image
- Fixes PHP 8 undefined array key warnings in `index/install.php` by using the safe `if_isset($array, $default, $key)` calling convention
- Adds `INSTALLATION.md` with two collapsible sections, one preserving the original standard installation instructions verbatim, one covering the Docker Compose setup

## What's included

| File | Purpose |
|---|---|
| `Dockerfile` | PHP 8.3 + Apache with `pgsql`, `pdftk`, `ghostscript`, `msmtp` |
| `docker-compose.yml` | Orchestrates web, postgres, mailpit, adminer |
| `docker-entrypoint.sh` | Sets permissions, installs Composer deps, generates msmtp config from env vars |
| `.env.example` | SMTP configuration template for users |
| `INSTALLATION.md` | Updated installation guide with standard + Docker sections |



## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
