### PR TITLE
Fix: remove Close button from Creditor Accounts list view top menu

### DIFF
--- a/kreditor/kreditor.php
+++ b/kreditor/kreditor.php
@@ -116,8 +116,6 @@ if ($menu == 'T') {
 } elseif ($menu == 'S') {
 
 	#####################
-	$back_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
-
 
 	$add_icon = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M440-280h80v-160h160v-80H520v-160h-80v160H280v80h160v160Zm40 200q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/></svg>';
 	
@@ -126,8 +124,7 @@ if ($menu == 'T') {
 	print "<tr><td height = 25 align=center valign=top>";
 	print "<table width=100% align=center border=0 cellspacing=2 cellpadding=0><tbody>\n";
 	print "<tr id='topTr'><td width=5% style='$topStyle'>";
-	print "<a href='$returside'><span class='headerbtn' style='$buttonStyle'>"
-	. $back_icon . findtekst('30|Tilbage', $sprog_id) . "</span></a>";
+	print "<span></span>";
 	print "</td>";
 
 	print "<td width = 75% align=center style='$topStyle'>" . findtekst(607, $sprog_id) . "</td>";


### PR DESCRIPTION
## What are the changes about?
## Problem
Close button was incorrectly showing in the top menu 
of the Creditor Accounts list view. Clicking it 
redirected the user to the Dashboard.

## Fix
Removed the Close button from the top menu in 
kreditor/kreditor.php. Only the New button remains.

## File changed
kreditor/kreditor.php - line 127

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
