### PR TITLE
Feature: Auto-populate item note on order line

### DIFF
--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -212,7 +212,7 @@ foreach ($grid_params as $param) {
 		unset($_GET[$param]);
 	}
 }
-
+ 
 // Also filter array parameters that start with search, sort, etc.
 foreach ($_GET as $key => $value) {
 	if (is_array($value) || preg_match('/^(search|sort|offset|rowcount|menu)\[/', $key)) {
@@ -220,7 +220,7 @@ foreach ($_GET as $key => $value) {
 	}
 }
 #################
-
+ 
 $funktion = if_isset($_GET, NULL, 'funktion');
 $tidspkt = date("U"); #20210719
 
@@ -2288,6 +2288,37 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 
 					// If the order is created with an error display
 					if (!is_numeric($svar)) print "<BODY onLoad=\"javascript:alert('$svar')\">";
+
+					// Auto-populate item note on order line if 'note_on_orderline' is enabled on the item card
+					if (is_numeric($svar)) {
+						$noteQtxt = "SELECT notes, note_on_orderline FROM varer 
+									WHERE varenr = '" . db_escape_string($varenr[0]) . "' 
+									OR varenr_alias = '" . db_escape_string($varenr[0]) . "' 
+									OR stregkode = '" . db_escape_string($varenr[0]) . "' 
+									LIMIT 1";
+						if ($noteVare = db_fetch_array(db_select($noteQtxt, __FILE__ . " linje " . __LINE__))) {
+							$noteEnabled = (
+								$noteVare['note_on_orderline'] === 't' ||
+								$noteVare['note_on_orderline'] === true ||
+								$noteVare['note_on_orderline'] == 1
+							);
+							if ($noteEnabled && !empty(trim($noteVare['notes']))) {
+								$noteOrdrelinje = db_fetch_array(db_select(
+									"SELECT id, beskrivelse FROM ordrelinjer WHERE ordre_id='$id' ORDER BY id DESC LIMIT 1",
+									__FILE__ . " linje " . __LINE__
+								));
+								if ($noteOrdrelinje['id']) {
+									$noteItem     = db_escape_string(trim($noteVare['notes']));
+									$noteExisting = db_escape_string($noteOrdrelinje['beskrivelse']);
+									$noteNewDesc  = $noteExisting ? $noteExisting . "\n" . $noteItem : $noteItem;
+									db_modify(
+										"UPDATE ordrelinjer SET beskrivelse='$noteNewDesc' WHERE id='$noteOrdrelinje[id]'",
+										__FILE__ . " linje " . __LINE__
+									);
+								}
+							}
+						}
+					}
 					// Else link serial from GS1 barcode
 					else {
 						// Check the serial number was detected by GS1 parsing and the item is a serial number dependent item

--- a/lager/productCardIncludes/notesEtc.php
+++ b/lager/productCardIncludes/notesEtc.php
@@ -30,10 +30,19 @@
 print "\n<!-- productCardIncludes/notesEtc.php start -->\n";
 
 print "<tr><td valign='top' colspan='3'><table border='0' width='100%'><tbody>\n"; # Notetabel ->
-print "<tr><td valign='top'>".findtekst(391,$sprog_id)."</td>\n";
+ 
+$noteChecked = $note_on_orderline ? 'checked' : '';
+print "<tr><td valign='top'>".findtekst(391,$sprog_id)."&nbsp;
+<label title='When checked, the item note is automatically copied to the order line description when this item is added to an order'>\n
+<input class='inputbox' type='checkbox' name='note_on_orderline' $noteChecked>\n
+&nbsp;Add note to order line</label>\n
+</td>\n";
+
 print "<td colspan='6'><textarea name='notes' rows='4' cols='100'>$notes</textarea></td>\n";
+
 print "<td><button type='button' id='rentItem'>".findtekst(2050,$sprog_id)."</button></td>\n";
 print "</tr>\n";
+
 print "<tr><td valign='top'>".findtekst(2144,$sprog_id)."</td>\n";
 print "<td colspan='6'><textarea name='notesInternal' rows='".($notesInternal != "" ? 4 : 2)."' cols='100'>$notesInternal</textarea></td>\n";
 print "</tr><tr>\n";

--- a/lager/varekort.php
+++ b/lager/varekort.php
@@ -168,6 +168,12 @@ $qtxt = "SELECT column_name FROM information_schema.columns WHERE table_name='va
 if (!$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
     db_modify("ALTER table varer ADD column notesinternal text", __FILE__ . " linje " . __LINE__);
 }
+
+$qtxt = "SELECT column_name FROM information_schema.columns WHERE table_name='varer' and column_name='note_on_orderline'";
+if (!$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+    db_modify("ALTER TABLE varer ADD COLUMN note_on_orderline boolean DEFAULT false", __FILE__ . " linje " . __LINE__);
+}
+
 $qtxt = "SELECT column_name FROM information_schema.columns WHERE table_name='varer' and column_name='colli_webfragt'";
 if (!$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
     db_modify("ALTER table varer ADD column colli_webfragt float DEFAULT 0", __FILE__ . " linje " . __LINE__);
@@ -336,6 +342,7 @@ if ($saveItem || $submit = trim($submit)) {
     else $default_shelf_life_days = null;
     #   list ($gruppe)           =  explode (':', if_isset($_POST['gruppe']));
     $notes = db_escape_string(trim(if_isset($_POST['notes'])));
+    $note_on_orderline = (if_isset($_POST['note_on_orderline']) == 'on') ? true : false;
     $notesInternal = db_escape_string(trim(if_isset($_POST['notesInternal'])));
     $ordre_id = if_isset($_POST['ordre_id']);
     $returside = if_isset($_POST['returside']);
@@ -938,8 +945,11 @@ if ($saveItem || $submit = trim($submit)) {
             $qtxt .= "retail_price_method='$retail_price_method',retail_price_rounding='$retail_price_rounding',";// 20221004
             $qtxt .= "retail_price_multiplier='$retail_price_multiplier',provision='$provision',";// 20221004
             $qtxt .= "has_due_date=$has_due_date,";
-            $qtxt .= "default_shelf_life_days=" . ($default_shelf_life_days !== null ? "'$default_shelf_life_days'" : "NULL");
+            
+            $qtxt .= "default_shelf_life_days=" . ($default_shelf_life_days !== null ? "'$default_shelf_life_days'" : "NULL") . ",";
+            $qtxt .= "note_on_orderline=" . ($note_on_orderline ? 'true' : 'false');
             $qtxt .= " where id = '$id'";
+
          $saved  =  db_modify($qtxt, __FILE__ . " linje " . __LINE__);
             if ($submit == 'copy') {
                 $copyItemNo = "kopi_af_$varenr";
@@ -1284,6 +1294,9 @@ if ($id > 0) {
     $lukket = $row['lukket'];
     $notes = $row['notes'];
     $notesInternal = $row['notesinternal'];
+
+    $note_on_orderline = ($row['note_on_orderline'] === 't' || $row['note_on_orderline'] === true || $row['note_on_orderline'] == 1);
+
     $delvare = $row['delvare'];
     $samlevare = $row['samlevare'];
     $min_lager = $row['min_lager'];


### PR DESCRIPTION
## Summary
Implements the ability to automatically copy an item's note onto the order line 
description when that item is added to an order. This removes the need for users 
to manually copy and paste notes from the item card to the order line.

## What are the changes about?
 ### `lager/varekort.php`
- Added DB migration to add `note_on_orderline` boolean column to `varer` table 
  (defaults to `false`)
- Reads `note_on_orderline` checkbox value from POST on save
- Saves `note_on_orderline` value in the `UPDATE varer` query
- Reads `note_on_orderline` value from DB row when item card loads

### `lager/productCardIncludes/notesEtc.php`
- Added `Add note to order line` checkbox directly next to the existing note textarea
- Checkbox reflects persisted state from the item record

### `debitor/ordre.php`
- After a new order line is created via `opret_ordrelinje`, checks if the item has 
  `note_on_orderline` enabled
- If enabled and a note exists, appends the item note beneath the description on 
  the newly created order line
- No changes to existing order lines or unchecked items

---

## Behaviour
| Scenario | Result |
|----------|--------|
| Checkbox unchecked | Existing behaviour, no note added |
| Checkbox checked, note exists | Note appended under order line description |
| Checkbox checked, note empty | Nothing added to order line |
| Existing order lines | Not affected retroactively |
| Note on order line after auto-populate | Fully editable by user |

---
## Testing Checklist
- [ ] Checkbox appears on item card next to note field
- [ ] Checkbox state saves and persists after navigating away and back
- [ ] Item with checkbox checked + note → note appears under description on new order line
- [ ] Item with checkbox unchecked → no note added, existing behaviour unchanged
- [ ] Auto-populated note is editable on the order line
- [ ] Existing order lines unaffected
- [ ] Item with checkbox checked but empty note → nothing added to order line

---

## Related
> Ticket: `Auto-populate item note on order line` — Priority: Medium  
> Affects: `Inventory → Goods (Item card)` + `Order line population`

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
