### PR TITLE
Fix: cash journal clips on create, delete cash journal, reduce body t…

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -2995,7 +2995,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 
 		if ($vis_bilag && !$fejl) { #20140425
 			#if ($kladde_id && $intern_bilag) print "<td title='".findtekst('1455|klik her for at vedhæfte et bilag', $sprog_id)."'><a href='../includes/bilag.php?kilde=kassekladde&bilag_id=$id[$x]&bilag=$bilag[$x]&ny=ja&kilde_id=$kladde_id&fokus=bila$x'><img  style='border: 0px solid' src='../ikoner/clip.png'></a></td>\n";
-			if ($kladde_id && $intern_bilag) {
+			if ($intern_bilag) {
 				$id[$y]        = (int)if_isset($id[$y],0);
 				$dokument[$y] = if_isset($dokument[$y],NULL);
 				$qtxt = "select id from documents where source = 'kassekladde' and source_id = '$id[$y]'";  //20230630
@@ -3227,7 +3227,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			print "<td align='center'><span title='" . findtekst('10000|Bilags Match', $sprog_id) . "'><input type='button' class='button green medium' style='width:120px;' value='" . findtekst('10000|Bilags Match', $sprog_id) . "' name='bilagsmatch' onclick='openPopup(); // from ./kassekladde_includes/bilagsmatch.php '></span></td>\n";
 			print "<td align='center'><span title='" . findtekst('1544|Klik her for at gemme', $sprog_id) . "'><input type='submit' class='button green medium' style='width:120px;' accesskey='g' value='" . findtekst('3|Gem', $sprog_id) . "' name='save' onclick='javascript:docChange = false;'></span></td>\n";
 			print "<td align='center'><span title='" . findtekst('1545|Opslag - din markørs placering angiver hvilken tabel, opslag foretages i', $sprog_id) . "'><input type='submit' class='button blue medium' style='width:120px;' accesskey='o' value='" . findtekst('644|Opslag', $sprog_id) . "' name='lookup' onclick='javascript:docChange = false;'></span></td>";
-			if ($kladde_id && !$fejl) {
+			if (!$fejl) {
 				print "<td align='center'><span title='" . findtekst('1546|Simulering af bogføring viser bevægelser i kontoplanen', $sprog_id) . "'><input type='submit' class='button gray medium' style='width:120px;' accesskey='s' value='" . findtekst('1064|Simulér', $sprog_id) . "' name='simulate' onclick='javascript:docChange = false;'></span></td>";
 				print "<td align='center'><span title='" . findtekst('1547|Bogfør - der foretages først en simulering, som du skal bekræfte', $sprog_id) . "'><input type='submit' class='button gray medium' style='width:120px;' accesskey='b' value='" . findtekst('1065|Bogfør', $sprog_id) . "' name='doPost' onclick='javascript:docChange = false;'></span></td>";
 				$qtxt = "select box5 from grupper where art = 'DIV' and kodenr = '3'";
@@ -4167,7 +4167,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
 ?>
 <style>
-	
+
+body {
+    padding: 8px !important;
+}
+
 /*scrollable container for the editable form */
 .kassekladde-scroll-container {
     height: calc(100vh - 98px);

--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -1,4 +1,3 @@
-<!doctype html>
 <?php
 //                ___   _   _   ___  _     ___  _ _
 //               / __| / \ | | |   \| |   |   \| / /
@@ -180,7 +179,10 @@ if (isset($_POST['delete_kladde'])) {
         exit;
     }
 }
-	
+?>
+<!doctype html>
+<?php
+
 $css="../css/standard.css";		
 $modulnr=2;	
 $title="kladdeliste";	


### PR DESCRIPTION
## Summary
Several fixes applied to the cash journal detail view including 
clip icon display on new lines, delete functionality and body 
tag padding issue.

## What are the changes about?
- Fixed clip icon not showing correctly on newly created cash journal lines
- Fixed delete cash journal functionality
- Fixed padding issue in the body tag

## Files Changed
- finans/kassekladde.php
- finans/kladdeliste.php

## How to Test
1. Log in to test_12 (Havemøbelland)
2. Go to Finance → Cash Journal


### Test Clips on Create
3. Create a new cash journal
4. Add a new line
5. Verify the clip icon shows correctly on new lines
6. Verify document attachment works on new lines

### Test Delete
7. Create an empty cash journal
8. Verify the delete button works correctly
9. Confirm the journal is removed from the list

### Test Body Padding
10. Open any cash journal
11. Verify the page layout looks correct with proper padding

## Acceptance Criteria
- Clip icon shows correctly on new cash journal lines ✅
- Delete cash journal works correctly ✅
- Body tag padding is fixed ✅
- Existing behaviour not broken ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
