### PR TITLE
Fix: false unsaved popup when creating new creditor order

### DIFF
--- a/includes/kreditorOrderFuncIncludes/topLine_S.php
+++ b/includes/kreditorOrderFuncIncludes/topLine_S.php
@@ -64,7 +64,7 @@ print "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"><html><h
 	if (($kort!="../lager/varekort.php" && $returside != "ordre.php")&&($id)) {
 		
 		  print "<td width=\"5%\">$color
-           <a href=\"#\" onclick=\"if(confirm('$alerttekst')) { window.location='ordre.php?returside=ordreliste.php'; return false; }\" accesskey=N>
+           <a href=\"javascript:confirmClose('ordre.php?returside=ordreliste.php','$alerttekst')\" accesskey=N>
            <button type=\"button\" class='center-btn' style='$buttonStyle; width: 100%' onMouseOver=\"this.style.cursor = 'pointer'\">";
      print "$add_icon" .findtekst(39, $sprog_id)."</button></a></td>";
 

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -1377,10 +1377,11 @@ function prepareSearchTerm($searchTerm) {
 	}
 	print "</tbody></table></td></tr>\n";
 	print "</form>";
+	print "<script>docChange = false;</script>";
 	print "</tbody></table></td></tr></tbody></table></td></tr>\n";
 	print "<tr><td></td></tr>\n";
 
-		
+
 }# end function ordreside
 ######################################################################################################################################
 


### PR DESCRIPTION
## Summary
After saving a creditor order and pressing "New" to create a new 
one, a popup incorrectly appeared with the message "is not saved". 
Since the current order had already been saved, this warning should 
not appear.

## What are the changes about?
- Fixed the saved state tracking so it correctly resets after 
  a successful save
- Ensured the "New" button does not trigger the unsaved changes 
  popup when the order has already been saved

## Files Changed
- kreditor/ordre.php
- includes/kreditorOrderFuncIncludes/topLine_S.php

## How to Test
1. Log in to test_7 (Rotary)
2. Navigate to Creditors → Orders
3. Create a new creditor order and fill in the required fields
4. Save the order
5. Press "New" to create another creditor order
6. Verify no "is not saved" popup appears
7. Verify the popup still appears correctly when there ARE 
   unsaved changes and user tries to navigate away

## Acceptance Criteria
- No false "is not saved" popup after saving and pressing New ✅
- "is not saved" popup still appears correctly for unsaved changes ✅
- Fix verified on test_7 (Rotary) ✅
- No other order creation or navigation flows affected ✅

## Tested On
- test_7 (Rotary) ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
