### PR TITLE
Fix: missing All option in selling dropdown and malformed supplier la…

### DIFF
--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -265,6 +265,7 @@ function forside($date_from,$date_to,$varenr,$varenavn,$varegruppe,$detaljer,$ku
 	}
 	$ref_nr[0]='0';
 	$ref_navn[0]='Alle';
+	$ref_brugernavn[0]='';
 	$x=1;
 	$q = db_select("select * from brugere order by brugernavn",__FILE__ . " linje " . __LINE__);
 	while ($r = db_fetch_array($q)) {
@@ -300,7 +301,7 @@ function forside($date_from,$date_to,$varenr,$varenavn,$varegruppe,$detaljer,$ku
 		($trbg==$bgcolor)?$trbg=$bgcolor5:$trbg=$bgcolor;
 		print "<tr bgcolor='$trbg'><td>".findtekst('966|Leverandør', $sprog_id)."</td><td colspan=\"2\"><select class=\"inputbox\" name=\"lev\" style=\"width:200px;\">";
 		for ($x=0;$x<count($lev_id);$x++) {
-			if ($lev == $lev_id[$x]) print "<option value='$lev_id[$x]'>$lev_navn[$x]</option>";
+			if ($lev == $lev_id[$x]) print "<option value='$lev_id[$x]'>$lev_nr[$x] : $lev_navn[$x]</option>";
 		}
 		for ($x=0;$x<count($lev_id);$x++) {
 			if ($lev != $lev_id[$x]) print "<option value='$lev_id[$x]'>$lev_nr[$x] : $lev_navn[$x]</option>";


### PR DESCRIPTION
## Summary
The stock report filter bar had two issues:
1. The "Selling" dropdown was missing a blank / "All" option that 
   would allow the user to report across all selling categories.
2. The "Supplier" dropdown "All" entry was missing the "0:" prefix 
   and should read "0: All".

## What are the changes about?
- Restored the blank / "All" option as the first entry in the 
  Selling dropdown
- Fixed the Supplier dropdown "All" entry to show "0: All" 
  instead of just "All"

## Files Changed
- lager/rapport.php

## How to Test
1. Navigate to Stock → Reports
2. Open the filter bar or report options
3. Click on the "Selling" dropdown
4. Verify a blank or "All" option appears as the first entry
5. Select "All" and verify results return all selling categories
6. Click on the "Supplier" dropdown
7. Verify the all-option shows "0: All" with the prefix

## Acceptance Criteria
- Selling dropdown includes blank / "All" option as first entry ✅
- Selecting "All" in Selling returns results for all categories ✅
- Supplier dropdown shows "0: All" as the all-option ✅
- No other filter dropdowns on the stock report are affected ✅

## Tested On
- test_7 (Rotary) ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or javascript-files, that could compomise stabilaty
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
