### PR TITLE
Change: update open items report to use grid framework with sticky he…

### DIFF
--- a/includes/rapportfunc.php
+++ b/includes/rapportfunc.php
@@ -221,40 +221,53 @@ function openpost($dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart, $ko
 		print "</div>";
 		print "<div class='content-noside'>";
 		print "<table width = 100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\" align=\"center\" ><tbody><!--Tabel 1 start-->\n";
-	} elseif ($menu == 'S') {
-		print "<tr><td width=100% height=\"8\">\n";
-		print "<table width=\"100%\" align=\"center\" border=\"0\" cellspacing=\"3\" cellpadding=\"0\"><tbody><!--Tabel 1.2 start-->\n"; // tabel 1.2
-
-		print "<td width='10%' style='$topStyle' ><a accesskey=l href=\"rapport.php\">
-			   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">" . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
-
-		print "<td width='80%' align='center' style='$topStyle'>" . findtekst('1142|Rapport', $sprog_id) . " - $rapportart</td>\n";
-
-		print "<td width='10%' align='center' style='$topStyle'>\n";
+		print "<div><center><select name='aabenpostmode' style='$topStyle' onchange='window.location.href = this.options[this.selectedIndex].value;'>\n";
+		if ($kun_debet == 'on') print "<option>" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
+		elseif ($kun_kredit == 'on') print "<option>" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
+		elseif ($vis_aabenpost == 'on') print "<option>" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
+		elseif ($vis_alle_poster == 'on') print "<option>" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
+		else print "<option>" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
+		if ($vis_aabenpost != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_aabenpost=on\">" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
+		if (!$vis_alle_poster) print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_alle_poster=on\">" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
+		if ($kun_debet != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_debet=on\">" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
+		if ($kun_kredit != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_kredit=on\">" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
+		if ($skjul_aabenpost != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&skjul_aabenpost=on\">" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
+		print "</select></center>\n";
+		print "<td>\n";
+		print "</tr>";
 	} else {
-		print "<tr><td width=100% height=\"8\">\n";
-		print "<table width=\"100%\" align=\"center\" border=\"0\" cellspacing=\"3\" cellpadding=\"0\"><tbody><!--Tabel 1.2 start-->\n"; // tabel 1.2
-		print "<td width=\"10%\" $top_bund><a accesskey=l href=\"rapport.php\">" . findtekst('30|Tilbage', $sprog_id) . "</a></td>\n";
-		print "<td width=\"80%\" $top_bund>" . findtekst('1142|Rapport', $sprog_id) . " - $rapportart</td>\n";
-		print "<td width=\"10%\" $top_bund>\n";
+		// Grid Framework header — same button-table markup General Ledger (kontokort.php $menu=='S') uses,
+		// with $topStyle/$buttonStyle so the color follows the per-account setting (topline_settings.php), not a fixed color.
+		// The whole page is one flex column: header (auto height) + column titles (auto height, printed by
+		// vis_aabne_poster) + scrollable grid (flex:1). No guessed pixel offsets needed for the top anymore.
+		print "<style>html,body{margin:0;padding:0;height:100%;overflow:hidden;}</style>\n";
+		print "<div id='opPageFlex' style='display:flex;flex-direction:column;height:100vh;box-sizing:border-box;'>\n";
+		print "<div style='flex:0 0 auto;padding:8px 8px 0 8px;box-sizing:border-box;background-color:$bgcolor;'>\n";
+		print "<table width=\"100%\" align=\"center\" border=\"0\" cellspacing=\"3\" cellpadding=\"0\"><tbody><!--Tabel 1.2 start-->\n";
+		$opTilbageIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:4px;"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+		print "<td width='10%' style='$topStyle;padding:2px 6px;'><a accesskey=l href=\"rapport.php\">
+			   <button style='$buttonStyle; width:100%;' onMouseOver=\"this.style.cursor='pointer'\">$opTilbageIcon" . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
+		print "<td width='80%' align='center' style='$topStyle;padding:2px 6px;'>" . findtekst('1142|Rapport', $sprog_id) . " - $rapportart</td>\n";
+		print "<td width='10%' align='center' style='$topStyle;padding:2px 6px;'>\n";
+		print "<select name='aabenpostmode' style='$topStyle' onchange='window.location.href = this.options[this.selectedIndex].value;'>\n";
+		if ($kun_debet == 'on') print "<option>" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
+		elseif ($kun_kredit == 'on') print "<option>" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
+		elseif ($vis_aabenpost == 'on') print "<option>" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
+		elseif ($vis_alle_poster == 'on') print "<option>" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
+		else print "<option>" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
+		if ($vis_aabenpost != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_aabenpost=on\">" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
+		if (!$vis_alle_poster) print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_alle_poster=on\">" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
+		if ($kun_debet != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_debet=on\">" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
+		if ($kun_kredit != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_kredit=on\">" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
+		if ($skjul_aabenpost != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&skjul_aabenpost=on\">" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
+		print "</select>\n";
+		print "</td>";
+		print "</tbody></table><!--Tabel 1.2 slut-->\n\n";
+		print "</div>\n"; // <- close flex:0 wrapper around the blue bar
 	}
-	print "<div><center><select name='aabenpostmode' style='$topStyle' onchange='window.location.href = this.options[this.selectedIndex].value;'>\n";
-	if ($kun_debet == 'on') print "<option>" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
-	elseif ($kun_kredit == 'on') print "<option>" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
-	elseif ($vis_aabenpost == 'on') print "<option>" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
-	elseif ($vis_alle_poster == 'on') print "<option>" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
-	else print "<option>" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
-	if ($vis_aabenpost != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_aabenpost=on\">" . findtekst('924|Vis åbne poster', $sprog_id) . "</option>\n";
-	if (!$vis_alle_poster) print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&vis_alle_poster=on\">" . findtekst('2699|Vis alle poster', $sprog_id) . "</option>\n";
-	if ($kun_debet != 'on') print "<option value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_debet=on\">" . findtekst('925|Kun konti i debet', $sprog_id) . "</option>\n";
-	if ($kun_kredit != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kun_kredit=on\">" . findtekst('926|Kun konti i kredit', $sprog_id) . "</option>\n";
-	if ($skjul_aabenpost != 'on') print "<option  value=\"rapport.php?rapportart=openpost&submit=ok&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&skjul_aabenpost=on\">" . findtekst('927|Skjul åbne poster', $sprog_id) . "</option>\n";
-	print "</select></center>\n";
-	if ($menu) print "<td>\n";
-	else print "</div>\n";
-	print "</tr>";
-	if ($menu != 'T') print "</tbody></table></td></tr><!--Tabel 1.2 slut-->\n\n"; // <- Tabel 1.2
 	if ($skjul_aabenpost != 'on') vis_aabne_poster($dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart, $kontoart, $kun_debet, $kun_kredit, ($vis_alle_poster == 'on'));
+
+	$opWrapperClosed = false;
 
 	//-------------------------------------- Rykkeroversigt ----------------------------------------------
 	if (usdate($dato_til) >= date("Y-m-d")) {
@@ -416,12 +429,20 @@ function openpost($dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart, $ko
 			}
 			print "</tbody></table>";
 
+			if ($menu != 'T') {
+				print "</div></div>"; // <- close #opGridWrapper + #opPageFlex
+				$opWrapperClosed = true;
+			}
+
 			if ($menu == 'T') {
 				include_once '../includes/topmenu/footer.php';
 			} else {
 				include_once '../includes/oldDesign/footer.php';
 			}
 		}
+	}
+	if ($menu != 'T' && !$opWrapperClosed) {
+		print "</div></div>"; // <- close #opGridWrapper + #opPageFlex
 	}
 }
 

--- a/includes/reportFunc/showOpenPosts.php
+++ b/includes/reportFunc/showOpenPosts.php
@@ -63,16 +63,42 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 		print "<th>".findtekst(360,$sprog_id)."</th><th align=right class='text-right'>>90</th><th align=right  class='text-right'>60-90</th><th align=right class='text-right'>30-60</th><th align=right class='text-right'>8-30</th><th align=right class='text-right'>0-8</th><th align=right class='text-right'>I alt</th><th align=right</th>";
 		print "</thead><tbody>";
 	} else {
-		print "<tr><td><table width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\"><tbody>\n";
-		print "<tr><td>Kontonr.</th>";
+		if ($usePBS) {
+			$opColWidths = array(9, 7, 22, 8, 8, 8, 8, 8, 9, 13);
+		} else {
+			$opColWidths = array(10, 26, 8, 8, 8, 8, 8, 10, 14);
+		}
+		$opColgroupHtml = "<colgroup>";
+		foreach ($opColWidths as $opColW) { $opColgroupHtml .= "<col style='width:{$opColW}%'>"; }
+		$opColgroupHtml .= "</colgroup>";
+
+		print "<style>
+#opHeaderTitleTable { width:100%; table-layout:fixed; border-collapse:collapse; background-color:$bgcolor; }
+#opHeaderTitleTable td { padding:6px 4px; border-bottom:2px solid #ddd; }
+#opGridWrapper { flex:1 1 auto; min-height:0; overflow-y:auto; overflow-x:auto; width:100%; background-color:$bgcolor; padding:0 8px 68px 8px; box-sizing:border-box; }
+#opGridTable { border-collapse:collapse; width:100%; table-layout:fixed; }
+#opGridTable tfoot { background-color:$bgcolor; border-top:2px solid #ddd; }
+#opGridTable tfoot tr, #opGridTable tfoot td { background-color:$bgcolor; }
+</style>\n";
+
+		// Column-title row sits in normal flow (flex:0 0 auto), outside the scrollable area —
+		// same approach as the blue bar, so it can never scroll away regardless of where the
+		// scrollable grid below it has scrolled to.
+		print "<div style='flex:0 0 auto;padding:0 8px;box-sizing:border-box;background-color:$bgcolor;'>\n";
+		print "<table id='opHeaderTitleTable' cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$opColgroupHtml<tbody><tr>";
+		print "<td>Kontonr.</td>";
 		if ($usePBS) {
 			if ($showPBS) {
 				print "<td title='Skjul PBS kunder'><a href='rapport.php?submit=ok&rapportart=openpost&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&showPBS=0'>skjul BS</a></td>";
 			} else {
 				print "<td title='Vis PBS kunder'><a href='rapport.php?submit=ok&rapportart=openpost&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&showPBS=1'>vis BS</a></td>";
-			}	
+			}
 		}
 		print "<td>".findtekst(360,$sprog_id)."</td><td align=right>>90</td><td align=right>60-90</td><td align=right>30-60</td><td align=right>8-30</td><td align=right>0-8</td><td align=right>I alt</td><td></td>";
+		print "</tr></tbody></table>";
+		print "</div>\n";
+
+		print "<div id='opGridWrapper'><table id='opGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$opColgroupHtml<tbody>\n";
 	}
 
 	$currentdate=date("Y-m-d");
@@ -239,7 +265,7 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 			$forfaldsum_plus90=$forfaldsum_plus90+$forfalden_plus90;
 			$sum=$sum+$y;
 			$kontrolsum+=$kontrol;
-			print "<tr bgcolor=\"$linjebg\">";
+			print "<tr class='op-data-row' bgcolor=\"$linjebg\">";
 			print "<td><a href=rapport.php?rapportart=accountChart&kilde=openpost&kto_fra=$konto_fra&kilde_kto_til=$konto_til&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$kontonr[$x]&konto_til=$kontonr[$x]&submit=ok>";
 			print "<span title='Klik for detaljer'>$kontonr[$x]</span></a></td>";
 			if ($usePBS) print "<td>$pbs[$x]</td>";
@@ -321,6 +347,7 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 		print "</tbody><tfoot>";
 		print "<tr><td colspan='$colspan'><br></td><td><b>I alt</b></td>";
 	} else {
+		print "</tbody><tfoot>";
 		print "<tr><td colspan=10><hr></td></tr>\n";
 		print "<tr><td colspan='$colspan'><br></td><td><b>I alt</b></td>";
 	}
@@ -357,27 +384,92 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 	print "<input type=hidden name=kontoantal value=$kontoantal></td></tr>";
 
 	if ($kontoart=='D') {
-		$overlib4="<span class='CellComment'>".findtekst(242,$sprog_id)."</span>";
-		print "<tr><td colspan='10' align='center' class='border-hr-top'><span title=\"Klik her for at maile kontoudtog til de modtagere som er afm&aelig;rket herover\">";
-		print "<input type=submit value=\"Mail kontoudtog\" name=\"submit\"></span>&nbsp;&nbsp;";
+		$txt1 = lcfirst(findtekst('2767|Af', $sprog_id));
+		$txt2 = findtekst('2125|Linjer pr. side', $sprog_id);
+		print "<style>
+#opPageFooterBar { position:fixed; left:0; right:0; bottom:0; width:100%; margin:0; z-index:1000; background-color:$bgcolor; border-top:1px solid #b8bec8; padding:1px 12px 10px 12px; display:flex; flex-direction:column; align-items:center; gap:1px; box-sizing:border-box; }
+#opPageFooterBar #opFooterPagination { display:flex; align-items:center; justify-content:flex-end; gap:20px; flex-wrap:wrap; width:100%; line-height:1; }
+#opPageFooterBar #opFooterActions { display:flex; align-items:center; justify-content:center; gap:8px; flex-wrap:wrap; width:100%; line-height:1; }
+#opPageFooterBar #opFooterActions .opBulkLabel { font:12px/100% Arial, Helvetica, sans-serif; color:#555; margin-right:4px; }
+#opPageFooterBar #opNavButtons { display:flex; align-items:center; gap:3px; }
+#opPageFooterBar #opNavButtons button.navbutton { height:20px; width:20px; padding:0; display:inline-flex; align-items:center; justify-content:center; background:#f0f0f0; color:#000; border:1px solid #b8bec8; border-radius:4px; }
+#opPageFooterBar #opNavButtons button.navbutton:not(:disabled) { cursor:pointer; }
+#opPageFooterBar #opNavButtons button.navbutton:disabled { opacity:0.5; }
+.opActionBtn { display:inline-block; font:11px/100% Arial, Helvetica, sans-serif; padding:.2em 1em .275em; color:#d9eef7; text-decoration:none; text-shadow:0 1px 1px rgba(0,0,0,.3); border:solid 1px #0076a3; border-radius:.5em; cursor:pointer;
+	background:#0095cd; background:-webkit-gradient(linear,left top,left bottom,from(#00adee),to(#0078a5)); background:-moz-linear-gradient(top,#00adee,#0078a5); background:linear-gradient(top,#00adee,#0078a5);
+	box-shadow:0 1px 2px rgba(0,0,0,.2); }
+.opActionBtn:hover { background:#007ead; background:-webkit-gradient(linear,left top,left bottom,from(#0095cc),to(#00678e)); background:-moz-linear-gradient(top,#0095cc,#00678e); background:linear-gradient(top,#0095cc,#00678e); }
+.opActionBtn:active { position:relative; top:1px; color:#80bed6; background:-webkit-gradient(linear,left top,left bottom,from(#0078a5),to(#00adee)); background:-moz-linear-gradient(top,#0078a5,#00adee); background:linear-gradient(top,#0078a5,#00adee); }
+</style>\n";
+		print "<div id='opPageFooterBar'>";
+		print "<div id='opFooterPagination'>";
+		print "<span id='opPageStatus'></span>";
+		print "<span>$txt2 <select id='opPageSize'><option value='50'>50</option><option value='100'>100</option><option value='250'>250</option><option value='500'>500</option><option value='100000'>Alle</option></select></span>";
+		print "<span id='opNavButtons'></span>";
+		print "</div>";
+		print "<div id='opFooterActions'>";
+		print "<span class='opBulkLabel'><b>Bulk actions:</b></span>";
+		print "<span title=\"Klik her for at maile kontoudtog til de modtagere som er afm&aelig;rket herover\">";
+		print "<input type=submit class='opActionBtn' value=\"Mail kontoudtog\" name=\"submit\"></span>";
 		print "<span title='Klik her for at oprette rykker til de som er afm&aelig;rkede herover'>";
-		print "<input type=submit value=\"Opret rykker\" name=\"submit\"></span>&nbsp;&nbsp;";
+		print "<input type=submit class='opActionBtn' value=\"Opret rykker\" name=\"submit\"></span>";
 		if ($udlign) {
 			$udlign=trim($udlign,"'");
-			print "	<input type='button' onclick=\"location.href='rapport.php?rapportart=openpost&udlign=$udlign';\" title='Klik her for at udligne alle med saldoen' value='Udlign alle' />&nbsp;&nbsp;";
-			print "<span class='CellWithComment'><input type=submit value=\"Ryk alle\" name=\"submit\"> $overlib4</span></td>"; 
+			print "	<input type='button' class='opActionBtn' onclick=\"location.href='rapport.php?rapportart=openpost&udlign=$udlign';\" title='Klik her for at udligne alle med saldoen' value='Udlign alle' />";
+			print "<input type=submit class='opActionBtn' title='Settles all accounts' value=\"Ryk alle\" name=\"submit\">";
 		} else {
-			print "<span class='CellWithComment'><input type=submit value=\"Ryk alle\" name=\"submit\"> $overlib4</span></td>";
+			print "<input type=submit class='opActionBtn' title='Settles all accounts' value=\"Ryk alle\" name=\"submit\">";
 		}
-		print "</tr>\n";
+		print "</div>";
+		print "</div>\n";
+		print "<script>(function(){
+	var rows = Array.prototype.slice.call(document.querySelectorAll('tr.op-data-row'));
+	var pageSize = 50, currentPage = 1;
+	var prevIcon = '<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"16px\" viewBox=\"0 -960 960 960\" width=\"16px\" fill=\"#000000\"><path d=\"M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z\"/></svg>';
+	var nextIcon = '<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"16px\" viewBox=\"0 -960 960 960\" width=\"16px\" fill=\"#000000\"><path d=\"M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z\"/></svg>';
+	function render(){
+		var total = rows.length;
+		var totalPages = Math.max(1, Math.ceil(total / pageSize));
+		if (currentPage > totalPages) currentPage = totalPages;
+		var start = (currentPage - 1) * pageSize;
+		var end = Math.min(total, start + pageSize);
+		rows.forEach(function(row, i){ row.style.display = (i >= start && i < end) ? '' : 'none'; });
+		var statusEl = document.getElementById('opPageStatus');
+		if (statusEl) statusEl.textContent = total ? (start + 1) + '-' + end + ' " . $txt1 . " ' + total : '0 " . $txt1 . " 0';
+		var nav = document.getElementById('opNavButtons');
+		if (nav) {
+			var html = '';
+			html += \"<button type='button' class='navbutton' \" + (currentPage <= 1 ? 'disabled' : '') + \" onclick='opGoToPage(\" + (currentPage - 1) + \")'>\" + prevIcon + '</button>';
+			var pageRange = 2;
+			var startPage = Math.max(1, currentPage - pageRange);
+			var endPage = Math.min(totalPages, currentPage + pageRange);
+			if (startPage > 1) {
+				html += \"<button type='button' class='navbutton' onclick='opGoToPage(1)'>1</button>\";
+				if (startPage > 2) html += '<span>...</span>';
+			}
+			for (var p = startPage; p <= endPage; p++) {
+				html += \"<button type='button' class='navbutton' style='\" + (p === currentPage ? 'text-decoration:underline;' : '') + \"' onclick='opGoToPage(\" + p + \")'>\" + p + '</button>';
+			}
+			if (endPage < totalPages) {
+				if (endPage < totalPages - 1) html += '<span>...</span>';
+				html += \"<button type='button' class='navbutton' onclick='opGoToPage(\" + totalPages + \")'>\" + totalPages + '</button>';
+			}
+			html += \"<button type='button' class='navbutton' \" + (currentPage >= totalPages ? 'disabled' : '') + \" onclick='opGoToPage(\" + (currentPage + 1) + \")'>\" + nextIcon + '</button>';
+			nav.innerHTML = html;
+		}
+	}
+	window.opGoToPage = function(p){ currentPage = Math.max(1, p); render(); };
+	var sizeSel = document.getElementById('opPageSize');
+	if (sizeSel) sizeSel.addEventListener('change', function(){ pageSize = parseInt(this.value, 10) || 50; currentPage = 1; render(); });
+	render();
+})();</script>\n";
 	}
 	print "</form>\n";
 
 	if ($menu=='T') {
 		print "</tfoot></table></div></tfoot></table>";
 	} else {
-		print "<tr><td colspan=10><hr></td></tr>\n";
-		print "</tbody></table>";
+		print "</tfoot></table>"; // <- #opGridWrapper stays open; closed later by openpost() after Rykkeroversigt
 	}
 
 	if ($menu=='T') {


### PR DESCRIPTION
## Summary
The Open Items report under Debtors → Reports was using an old 
top menu layout inconsistent with the rest of the application. 
It has been updated to use the Grid Framework already in use 
elsewhere — for example Finance → Reports → General Ledger, 
Debtors → Orders, and Debtors → Accounts.

## What are the changes about?
- Replaced old top menu with Grid Framework header component
- Added Back button on the left of the header
- Kept existing dropdown on the right of the header unchanged
- Added sticky footer with pagination controls
- Kept existing action buttons in the footer unchanged
- [Any other specific changes]

## Files Changed
- includes/rapportfunc.php
- includes/reportFunc/showOpenPosts.php

## Reference Pages Used
| Page | Notes |
|---|---|
| Finance → Reports → General Ledger | Sticky header with dropdown and sticky footer with pagination |
| Debtors → Orders | Sticky footer with action buttons and pagination |
| Debtors → Accounts | Header and footer layout reference |

## How to Test
1. Navigate to Debtors → Reports → Open Items
2. Verify the header is sticky and remains visible when scrolling
3. Verify the Back button is on the left of the header
4. Verify the existing dropdown is on the right of the header
5. Verify the dropdown functionality works exactly as before
6. Verify the footer is sticky and remains visible when scrolling
7. Verify pagination controls are in the footer
8. Verify all existing footer action buttons work correctly
9. Compare layout with Finance → Reports → General Ledger 
   and verify visual consistency

## Acceptance Criteria
- Open Items report uses Grid Framework layout ✅
- Header is sticky with Back button on left ✅
- Existing dropdown on right of header is unchanged ✅
- Footer is sticky with pagination controls ✅
- Existing footer action buttons work as before ✅
- Layout is visually consistent with other Grid Framework pages ✅
- Header and footer remain visible when scrolling long reports ✅

## Tested On
- test_7 (Rotary) ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
