### PR TITLE
[codex] Integrate Chaty chatbot widget

### DIFF
--- a/includes/chaty_widget.php
+++ b/includes/chaty_widget.php
@@ -1,0 +1,8 @@
+<script
+    async
+    src="https://wuweiworkai.com/chaty-v2/widget.js"
+    data-widget-id="saldi-prod"
+    data-brand="SALDI.dk"
+    data-lang="da"
+    data-theme-color="#2872fa">
+</script>

--- a/includes/oldDesign/footer.php
+++ b/includes/oldDesign/footer.php
@@ -1,2 +1,4 @@
+<?php include_once __DIR__ . '/../chaty_widget.php'; ?>
+
     </body>
 </html>

--- a/includes/topmenu/footer.php
+++ b/includes/topmenu/footer.php
@@ -7,5 +7,7 @@
 </div>
 </div>
 
+<?php include_once __DIR__ . '/../chaty_widget.php'; ?>
+
     </body>
 </html>

--- a/includes/topmenu/footerDebRapporter.php
+++ b/includes/topmenu/footerDebRapporter.php
@@ -30,5 +30,7 @@ $(document).ready(function() {
 
 </script>
 
+<?php include_once __DIR__ . '/../chaty_widget.php'; ?>
+
     </body>
 </html>

--- a/oldDesign/footer.php
+++ b/oldDesign/footer.php
@@ -1,2 +1,4 @@
+<?php include_once __DIR__ . '/../includes/chaty_widget.php'; ?>
+
     </body>
 </html>

--- a/topmenu/footer.php
+++ b/topmenu/footer.php
@@ -7,5 +7,7 @@
 </div>
 </div>
 
+<?php include_once __DIR__ . '/../includes/chaty_widget.php'; ?>
+
     </body>
 </html>

--- a/topmenu/footerDebRapporter.php
+++ b/topmenu/footerDebRapporter.php
@@ -30,5 +30,7 @@ $(document).ready(function() {
 
 </script>
 
+<?php include_once __DIR__ . '/../includes/chaty_widget.php'; ?>
+
     </body>
 </html>


### PR DESCRIPTION
﻿## What changed

- Added a shared Chaty widget include with the SALDI production widget configuration.
- Included the widget immediately before `</body>` in the shared topmenu, report, and old-design footer variants.

## Why

SALDI can load the chatbot through the plain external JavaScript snippet without adding npm, React, Next.js, or any application build step.

## Validation

- `git diff --check`
- Verified include target exists for each updated footer file.
- Browser-checked a local rendered page containing the widget markup and confirmed the script URL, async flag, and expected `data-*` attributes.

Note: `php -l` could not be run because PHP is not installed on this machine's PATH.
