### PR TITLE
Grid_order generic search bugfixes and numerical operation support.

### DIFF
--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -52,6 +52,8 @@
 // 20260603 Sawaneh Whole order line is now clickable (and right-clickable for "open in new tab/window"), not just the order number.
 // 20260609 LOE Enabled hvem column and migrated this user's settings from grupper to datatables grid for better persistence and flexibility.
 // 20260630 CDX/NTR Fixed land (country) column from printing the countries outside the table and searchable bar not existing.
+// 20260701 CDX/NTR Fixed the default search to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
+
 @session_start();
 $s_id = session_id();
 
@@ -653,14 +655,29 @@ $ialt_kostpris = 0;
 
 //Fetch ALL columns from the ordrer table
 $all_db_columns = array();
-$qtxt = "SELECT column_name, data_type 
+$qtxt = "SELECT column_name,
+                data_type,
+                CASE
+                    WHEN data_type IN ('smallint', 'integer', 'bigint', 'decimal', 'numeric', 'real', 'double precision') THEN 'number'
+                    WHEN data_type IN ('date', 'timestamp without time zone', 'timestamp with time zone') THEN 'date'
+                    ELSE 'text'
+                END AS grid_type,
+                CASE
+                    WHEN data_type IN ('smallint', 'integer', 'bigint') THEN 0
+                    WHEN numeric_scale IS NOT NULL THEN numeric_scale
+                    ELSE 2
+                END AS decimal_precision
          FROM information_schema.columns 
          WHERE table_schema = 'public' 
            AND table_name = 'ordrer' 
          ORDER BY ordinal_position";
 $q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
 while ($r = db_fetch_array($q)) {
-    $all_db_columns[$r['column_name']] = $r['data_type'];
+    $all_db_columns[$r['column_name']] = array(
+        'data_type' => $r['data_type'],
+        'grid_type' => $r['grid_type'],
+        'decimalPrecision' => (int)$r['decimal_precision'],
+    );
 }
 
 ###########date range
@@ -1360,7 +1377,9 @@ foreach ($custom_columns as $field_name => $column_def) {
 }
  
 // Auto-generated DB columns 
-foreach ($all_db_columns as $field_name => $data_type) {
+foreach ($all_db_columns as $field_name => $column_info) {
+    $grid_type = $column_info['grid_type'];
+    $decimalPrecision = $column_info['decimalPrecision'];
     $skip_fields = ['id', 'tidspkt', 'copied', 'scan_id'];
     if (in_array($field_name, $skip_fields) || isset($custom_columns[$field_name])) {
         continue;
@@ -1384,8 +1403,7 @@ foreach ($all_db_columns as $field_name => $data_type) {
     // This is the CRITICAL part - every column MUST have both functions
     
     // Date fields
-  if (strpos($field_name, 'date') !== false || 
-    in_array($field_name, ['ordredate', 'levdate', 'fakturadate', 'nextfakt', 'due_date', 'datotid', 'settletime'])) {
+  if ($grid_type == 'date') {
     
     $column_def['type'] = 'date';
     $column_def['align'] = 'left';
@@ -1435,30 +1453,11 @@ foreach ($all_db_columns as $field_name => $data_type) {
         $column_def['render'] = function ($value, $row, $column) {
             return "<td align='{$column['align']}'>" . ordreliste_safe_output($value) . "</td>";
         };
-    }elseif (in_array($field_name, ['ordrenr', 'fakturanr', 'kontonr', 'kundeordnr', 'cvrnr'])) {
-        // These "nr" fields should be displayed as plain text/integers without decimal formatting
-        $column_def['type'] = 'number';
-        $column_def['align'] = 'right';
-        $column_def['decimalPrecision'] = 0;
-        
-        // valueGetter: Return as integer (strip decimals) for numeric values
-        $column_def['valueGetter'] = function ($value, $row, $column) {
-            return $value !== null ? $value : '';
-        };
-        
-        // render: Display as plain text (no dkdecimal formatting)
-        $column_def['render'] = function ($value, $row, $column) {
-            return "<td align='{$column['align']}'>" . $value . "</td>";
-        };
-    }elseif ($data_type == 'numeric' || $data_type == 'integer' || 
-            strpos($field_name, 'sum') !== false || 
-            strpos($field_name, 'nr') !== false ||
-            strpos($field_name, 'id') !== false ||
-            in_array($field_name, ['kostpris', 'moms', 'procenttillag', 'netweight', 'grossweight', 'valutakurs', 'betalingsdage', 'kontakt_tlf', 'phone', 'report_number'])) {
+    }elseif ($grid_type == 'number') {
         
         $column_def['type'] = 'number';
         $column_def['align'] = 'right';
-        $column_def['decimalPrecision'] = ($data_type == 'integer') ? 0 : 2;
+        $column_def['decimalPrecision'] = $decimalPrecision;
 
 
         
@@ -1551,7 +1550,7 @@ foreach ($all_db_columns as $field_name => $data_type) {
         };
     }
     
-    $columns[] = $column_def;
+    $column_pool[$field_name] = $column_def;
 }
 
 ######
@@ -1718,7 +1717,7 @@ $debug_log[] = "base_where_conditions: $base_where_conditions";
 
 // IMPORTANT: Update the SQL query to include ALL columns dynamically
 $select_fields = "o.id as id";
-foreach ($all_db_columns as $field_name => $data_type) {
+foreach ($all_db_columns as $field_name => $column_info) {
     if ($field_name != 'id') {
         $select_fields .= ", o.$field_name as $field_name";
     }

--- a/includes/orderFuncIncludes/grid_order.php
+++ b/includes/orderFuncIncludes/grid_order.php
@@ -4,6 +4,7 @@
 // 20260601 Sawaneh Applied sqlOverride in build_count_query so ORDER BY uses the qualified column and avoids ambiguous-column error
 // 20260612 pk - Changed the size of the arrow buttons in pagination so that they are the same size as the number buttons
 // 20260630 Sawaneh render_table_row now wraps render-less column values in a <td> so raw values no longer leak as text above the grid
+// 20260701 CDX/NTR - Changed DEFAULT_GENERATE_SEARCH to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
 
 /** 
  * Extracts values from a specific column in a multi-dimensional array.
@@ -120,6 +121,28 @@ function DEFAULT_GENERATE_SEARCH($column, $term) {
     }
     $term = str_replace(";", ":", $term);
     
+    // Numeric comparison searches: >10, >=10, <10, <=10, 10+ (10 or more) and 10- (10 or less).
+    if ($art == 'BELOB') {
+        $precision = isset($column['decimalPrecision']) ? $column['decimalPrecision'] : 2;
+        $numericField = "round(COALESCE({$field}::numeric, 0), {$precision})";
+
+        if (preg_match('/^(>=|<=|>|<)\s*(.+)$/', $term, $matches)) {
+            $operator = $matches[1];
+            $numValue = usdecimal(trim($matches[2]));
+            return "({$numericField} {$operator} $numValue)";
+        }
+
+        if (preg_match('/^(.+)\+$/', $term, $matches)) {
+            $numValue = usdecimal(trim($matches[1]));
+            return "({$numericField} >= $numValue)";
+        }
+
+        if (preg_match('/^(.+)-$/', $term, $matches)) {
+            $numValue = usdecimal(trim($matches[1]));
+            return "({$numericField} <= $numValue)";
+        }
+    }
+
     // Special handling for single BELOB (number) values - create narrow range
     if ($art == 'BELOB' && strpos($term, ':') === false) {
         $numValue = usdecimal($term);
@@ -141,7 +164,8 @@ function DEFAULT_GENERATE_SEARCH($column, $term) {
             $tmp1 = usdecimal($tmp1);
             $tmp2 = usdecimal($tmp2);
             $precision = $column['decimalPrecision'];
-            return "(round({$field}::numeric, {$precision}) >= $tmp1 AND round({$field}::numeric, {$precision}) <= $tmp2)";
+            $numericField = "round(COALESCE({$field}::numeric, 0), {$precision})";
+            return "({$numericField} >= $tmp1 AND {$numericField} <= $tmp2)";
             
         } elseif ($art == "NR") {
             $tmp1 = round($tmp1 * 1, 2);
@@ -701,13 +725,14 @@ function fill_missing_values($firstArray, $secondArray) {
             continue;
         }
 
-        foreach ($columnsByField[$firstItem['field']] as $key => $value) {
-            if (!isset($firstItem[$key]) || $firstItem[$key] === "") {
-                $firstItem[$key] = $value;
+        $mergedItem = $columnsByField[$firstItem['field']];
+        foreach (array('headerName', 'description', 'width', 'align', 'hidden') as $key) {
+            if (isset($firstItem[$key]) && $firstItem[$key] !== "") {
+                $mergedItem[$key] = $firstItem[$key];
             }
         }
 
-        $merged[] = $firstItem;
+        $merged[] = $mergedItem;
     }
 
     return $merged;
@@ -841,7 +866,7 @@ function build_query($id, $grid_data, $columns, $filters, $searchTerms = [], $so
             if (isset($searchTerms[$column['field']]) && $searchTerms[$column['field']] !== '') {
                 $term = addslashes($searchTerms[$column['field']]);
                 // Convert both the column value and the search term to lowercase
-                if ($term) {
+                if ($term !== '') {
                     $searchConditions[] = $column['generateSearch']($column, $term);
                 }
             }
@@ -982,7 +1007,7 @@ function build_count_query($grid_data, $columns, $filters, $searchTerms = [], $s
         foreach ($searchableColumns as $column) {
             if (isset($searchTerms[$column['field']]) && $searchTerms[$column['field']] !== '') {
                 $term = addslashes($searchTerms[$column['field']]);
-                if ($term) {
+                if ($term !== '') {
                     $searchConditions[] = $column['generateSearch']($column, $term);
                 }
             }


### PR DESCRIPTION
Fixed grid_order's generic text search and added support for numerical operations like 10+, >=10, <100< <= 10 and 10-.

Added support for numerical NULL values in searches to treat them as 0, just like when it is displayed.

## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
