### PR TITLE
Change + Fix: add grid framework to sales statistics report and fix m…

### DIFF
--- a/includes/salgsstat.php
+++ b/includes/salgsstat.php
@@ -29,6 +29,8 @@
 // 20220905 MSC - Implementing new design
 // 01-05-2023 PBLM Fixed minor errors
 // 20231213 MSC - Copy pasted new design into code
+// 20260704 SZ Added Grid Framework sticky header and footer to Sales Statistics report
+// 20260704 SZ Fixed misaligned columns in Sales Statistics report list
 
 @session_start();
 $s_id=session_id();
@@ -59,6 +61,13 @@ $varetekst=if_isset($_GET['varetekst']);
 $detaljer=if_isset($_GET['detaljer']);
 $ret=if_isset($_GET['ret']);
 $art=if_isset($_GET['art']);
+// Real (server-side) pagination for the Grid Framework ($menu=='S') footer — same $ss_page/$ss_per_page
+// query-param pattern kontokort() uses for Finance -> Reports -> General Ledger's footer.
+$ssValidPageSizes=array(50,100,250,500,100000);
+$ssPerPage=(int) if_isset($_GET['ss_per_page']);
+if (!in_array($ssPerPage,$ssValidPageSizes)) $ssPerPage=50;
+$ssPage=(int) if_isset($_GET['ss_page']);
+if ($ssPage<1) $ssPage=1;
 if ($ret) {
 	begraens($dato_fra,$dato_til,$konto_fra,$konto_til,$kontonr,$firmanavn,$adresse,$postnr,$bynavn,$varenr,$varetekst,$detaljer,$art);
 	exit;
@@ -99,19 +108,62 @@ if ($menu=='T') {
 	print "</div>";
 	print "<div class='content-noside'>";
 } elseif ($menu=='S') {
-	include_once '../includes/oldDesign/header.php';
-	print "<table width = 100% cellpadding='0' cellspacing='0' border='0'><tbody>";
-	print "<tr><td colspan='4' height='8'>";
-	print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>"; #B
-	$tekst=findtekst('2704|Klik her for at lukke \"Top100\"', $sprog_id);
-	print "<td width='10%' title='$tekst'><a href='$luk' accesskey=L><button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">";
-	print findtekst('30|Tilbage', $sprog_id)."</button></a></td>";
-	print "<td width='80%' style='$topStyle' align='center'>".findtekst('922|Salgstatsstik', $sprog_id)."</td>";
-	print "<td width='10%' title='$rtekst'><a href=salgsstat.php?dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kontonr=$kontonr&firmanavn=$firmanavn&adresse=$adresse&postnr=$postnr&bynavn=$bynavn&varenr=$varenr&varetekst=$varetekst&detaljer=$detaljer&art=$art&ret=on accesskey=B>";
-	print "<button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">".findtekst('913|Søg', $sprog_id)."<br></button></a></td>";
-	print "</tbody></table>";
-	print "</td></tr>\n";
-	print "<tr><td width='100%'>"; 
+	// Grid Framework header — mirrors Debtors -> Reports -> Open items / Account balance / General ledger
+	// (openpost()/kontosaldo()/kontokort() in includes/rapportfunc.php). The whole page is one flex
+	// column: header bar (auto height) + column-title row (auto height, printed just below, before the
+	// account loop) + scrollable grid (flex:1) + fixed footer (printed after the account loop). No
+	// external stylesheet is loaded here (same as the three reference reports) — every style needed is
+	// inline/embedded below.
+	$ssTilbageIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+	$ssLukTekst = findtekst('2704|Klik her for at lukke \"Top100\"', $sprog_id);
+
+	print "<style>html,body{margin:0;padding:0;height:100%;overflow:hidden;}</style>\n";
+	print "<div id='ssPageFlex' style='display:flex;flex-direction:column;height:100vh;box-sizing:border-box;'>\n";
+	print "<div style='flex:0 0 auto;padding:8px 8px 0 8px;box-sizing:border-box;background-color:$bgcolor;'>\n";
+	// The Back button is taller than a plain text button because its 20x20 SVG icon forces a larger
+	// minimum content height; height:100% on a <td> child doesn't reliably work (percentage heights
+	// only resolve against an explicit, not row-stretched/auto, parent height). Instead, give the
+	// Search button the same 20px minimum content height directly via min-height — sidesteps the
+	// parent-height quirk entirely and matches the Back button's actual rendered size.
+	print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody><tr>";
+	print "<td width='10%' align='left' title='$ssLukTekst'><a href='$luk' accesskey=L>
+		   <button style='$buttonStyle; width:100%; display:flex; align-items:center; gap:5px; justify-content:flex-start; padding-left:3px;' onMouseOver=\"this.style.cursor='pointer'\">$ssTilbageIcon" . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>";
+	print "<td width='80%' align='center' style='$topStyle'>" . findtekst('922|Salgstatsstik', $sprog_id) . "</td>";
+	print "<td width='10%' align='center' title='$rtekst'><a href='salgsstat.php?dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til&kontonr=$kontonr&firmanavn=$firmanavn&adresse=$adresse&postnr=$postnr&bynavn=$bynavn&varenr=$varenr&varetekst=$varetekst&detaljer=$detaljer&art=$art&ret=on' accesskey=B>
+		   <button style='$buttonStyle; width:100%; min-height:20px; display:flex; align-items:center; gap:5px; justify-content:center;' onMouseOver=\"this.style.cursor='pointer'\">" . findtekst('913|Søg', $sprog_id) . "</button></a></td>";
+	print "</tr></tbody></table>";
+	print "</div>\n"; // <- close flex:0 wrapper around the blue header bar
+
+	// Same colgroup widths drive both the column-title row and every data row below it (they live in
+	// the same #ssGridTable), so the header can never drift out of alignment with the data — this is
+	// the fix for the reported "header columns don't match data columns" bug. The previous code built
+	// the column-title row in a *separate* <table> that never included a "Dato" column at all, while
+	// the data rows below (in "vis detaljer" mode) had one prepended as their first cell — shifting
+	// every subsequent data column one position right of its header. Column count/order here now
+	// matches the data rows exactly for both modes.
+	if ($summeret) {
+		$ssColgroupHtml = "<colgroup><col style='width:12%'><col style='width:43%'><col style='width:15%'><col style='width:15%'><col style='width:15%'></colgroup>";
+	} else {
+		$ssColgroupHtml = "<colgroup><col style='width:10%'><col style='width:10%'><col style='width:30%'><col style='width:12%'><col style='width:13%'><col style='width:12%'><col style='width:13%'></colgroup>";
+	}
+	print "<style>
+#ssGridWrapper { flex:1 1 auto; min-height:0; overflow-y:auto; overscroll-behavior:contain; width:100%; background-color:$bgcolor; padding:0 8px 68px 8px; box-sizing:border-box; }
+#ssGridTable { border-collapse:separate; border-spacing:0; width:100%; table-layout:fixed; }
+#ssGridTable th { position:sticky; top:0; z-index:10; padding:6px 4px; background-color:$bgcolor; box-sizing:border-box; text-align:left; }
+#ssGridTable td { box-sizing:border-box; padding:4px; }
+#ssGridTable th.text-right { text-align:right; }
+#ssGridTable tr.ss-account-row td { padding:2px 4px; }
+#ssGridTable tbody.ss-account-block ~ tbody.ss-account-block tr.ss-account-row:first-child td { padding-top:10px; border-top:2px solid #ddd; }
+#ssGridTable tr.ss-col-title-row th { border-top:2px solid #ddd; }
+#ssGridTable tr.ss-col-title-row.ss-stuck th { border-top:none; border-bottom:2px solid #ddd; }
+</style>\n";
+	// Sticky is applied per-<th> rather than on <thead> — more reliably supported across browsers when
+	// combined with table-layout:fixed + percentage colgroup widths (same technique kontokort() uses).
+	// The <th> row itself is NOT printed here — per explicit request it stays matching the old table's
+	// placement (below the first account's "Account No:/Company Name:" block, not above it) — see the
+	// $ssHeaderPrinted flag in the account loop below, which prints it once, in that position.
+	print "<div id='ssGridWrapper'><table id='ssGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$ssColgroupHtml";
+	$ssHeaderPrinted = false;
 } else {
 	include_once '../includes/oldDesign/header.php';
 	print "<table width = 100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\"><tbody>";
@@ -138,6 +190,7 @@ while($r=db_fetch_array($q)){
 */
 $x=0;
 $y=0;
+$q_konto_id=array();
 
 $qtxt="select ordrelinjer.vare_id,ordrelinjer.varenr,ordrelinjer.beskrivelse,ordrelinjer.antal,ordrelinjer.pris,ordrelinjer.rabat,";
 $qtxt.="ordrer.konto_id,ordrer.kontonr,ordrer.firmanavn,ordrer.id,ordrer.fakturadate from ordrer,ordrelinjer,adresser ";
@@ -154,7 +207,7 @@ if ($varetekst) $qtxt.="and ordrelinjer.beskrivelse like '".str_replace('*','%',
 $qtxt.="order by ordrer.kontonr,ordrelinjer.varenr";
 $q=db_select($qtxt,__FILE__ . " linje " . __LINE__);
 while($r=db_fetch_array($q)){
-	if (isset($q_konto_id) && $q_konto_id[$x] && $q_konto_id[$x]!=$r['konto_id']) {
+	if (isset($q_konto_id[$x]) && $q_konto_id[$x] && $q_konto_id[$x]!=$r['konto_id']) {
 		$x++;
 		$y=0;
 		$q_vare_id[$x]=array();
@@ -189,6 +242,24 @@ while($r=db_fetch_array($q)){
 	}
 } 
 ($summeret)?$cols='5':$cols='7';
+
+if ($menu=='S') {
+	// Every matching row is already sitting in the $q_* arrays from the query above (this report has
+	// no per-row DB lookups to skip, unlike General Ledger), so "server-side" pagination here means:
+	// compute which global row-range the requested page covers, then only PRINT rows in that range
+	// during the account loop below — same end result (only the current page's rows ever reach the
+	// browser, real page-reload links, not client-side re-slicing) as kontokort()'s footer.
+	$ssTotalRows=0;
+	for ($ssCx=0;$ssCx<count($q_konto_id);$ssCx++) {
+		$ssTotalRows+=count($q_vare_id[$ssCx]);
+	}
+	$ssTotalPages=max(1,ceil($ssTotalRows/$ssPerPage));
+	if ($ssPage>$ssTotalPages) $ssPage=$ssTotalPages;
+	$ssPageStart=($ssPage-1)*$ssPerPage;
+	$ssPageEnd=$ssPageStart+$ssPerPage;
+	$ssGlobalRowIndex=0;
+}
+
 if ($menu=='T') {
 	print "<center style='padding-bottom:5px;'>	<input onclick=\"location.href='#nav'\" style='width:450px;' type=\"button\" title='Klik her for at søge' value=\"".findtekst('913|Søg', $sprog_id)."\">";
 	print "<div class='expandableSearch' id='nav' style='padding-top:5px;'>";
@@ -200,6 +271,64 @@ if ($menu=='T') {
 }
 
 for ($x=0;$x<count($q_konto_id);$x++) {
+	if ($menu=='S') {
+		// Grid Framework data rows — printed straight into the page-level #ssGridTable opened once
+		// before this loop started (see the $menu=='S' header block above). Real server-side pagination
+		// (see $ssPageStart/$ssPageEnd computed above, same technique kontokort() uses for General
+		// Ledger): only rows whose running global index falls inside the requested page window are
+		// printed at all, and an account's group-title row is skipped entirely if none of its rows
+		// land on the current page.
+		$ssAccountTotal=count($q_vare_id[$x]);
+		$ssAccountStart=$ssGlobalRowIndex;
+		$ssAccountEnd=$ssGlobalRowIndex+$ssAccountTotal;
+		if ($ssAccountEnd>$ssPageStart && $ssAccountStart<$ssPageEnd) {
+			print "<tbody class='ss-account-block'>";
+			// Same two-line "Account No: / Company Name:" labeled format as the original table
+			// (not the single merged "Company • Account" row the other Grid Framework reports use) —
+			// kept as-is per explicit request, only the header/footer/column-alignment were in scope.
+			print "<tr class='ss-account-row'><td colspan='$cols'><b>".findtekst('284|Kontonr', $sprog_id).":</b> $q_kontonr[$x]</td></tr>";
+			// Hardcoded rather than findtekst('360|Firmanavn', ...) — the live database's tekster table
+			// (or a session-cached copy of it) was returning "Company_name" instead of "Company Name"
+			// here, even though the CSV translation source has the correct value; this bypasses that
+			// stale/incorrect lookup entirely for this specific label.
+			print "<tr class='ss-account-row'><td colspan='$cols'><b>Company Name:</b> ".stripslashes($q_firmanavn[$x])."</td></tr>";
+			if (!$ssHeaderPrinted) {
+				// Column-title row prints once, right here — below the first visible account's
+				// "Account No:/Company Name:" block, matching the old table's placement, not above it.
+				// It stays sticky (see #ssGridTable th CSS above) so it pins to the top of the scroll
+				// area once the page is scrolled far enough for it to reach the top.
+				print "<tr class='ss-col-title-row'>";
+				if (!$summeret) print "<th>" . findtekst('635|Dato', $sprog_id) . "</th>";
+				print "<th>" . findtekst('917|Varenr.', $sprog_id) . "</th>";
+				print "<th>" . findtekst('914|Beskrivelse', $sprog_id) . "</th>";
+				print "<th class='text-right'>" . findtekst('916|Antal', $sprog_id) . "</th>";
+				print "<th class='text-right'>" . findtekst('915|Pris', $sprog_id) . "</th>";
+				if (!$summeret) print "<th class='text-right'>" . findtekst('428|Rabat', $sprog_id) . "</th>";
+				print "<th class='text-right'>Sum</th>";
+				print "</tr>";
+				$ssHeaderPrinted = true;
+			}
+			for ($y=0;$y<$ssAccountTotal;$y++) {
+				$ssRowIndex=$ssGlobalRowIndex+$y;
+				if ($ssRowIndex>=$ssPageStart && $ssRowIndex<$ssPageEnd) {
+					print "<tr class='ss-data-row'>";
+					if (!$summeret) print "<td>".$q_faktdato[$x][$y]."</td>";
+					print "<td>".$q_varenr[$x][$y]."</td>";
+					print "<td>".stripslashes($q_beskrivelse[$x][$y])."</td>";
+					print "<td align=\"right\">".dkdecimal($q_antal[$x][$y])."</td>";
+					print "<td align=\"right\">".dkdecimal($q_pris[$x][$y])."</td>";
+					if (!$summeret) {
+						print "<td align=\"right\">".dkdecimal($q_rabat[$x][$y])."</td>";
+					}
+					print "<td align=\"right\">".dkdecimal($q_sum[$x][$y])."</td>";
+					print "</tr>";
+				}
+			}
+			print "</tbody>";
+		}
+		$ssGlobalRowIndex+=$ssAccountTotal;
+		continue;
+	}
 	print"<div class='dataTablediv'><table width=\"100%\" class='dataTable'><tbody>";
 #	print "<tr><td>$konto_id[$x]</td></tr>";
 	if ($menu=='T') {
@@ -241,6 +370,118 @@ for ($x=0;$x<count($q_konto_id);$x++) {
 
 	}
 
+	if ($menu=='S') {
+		if (!$ssHeaderPrinted) {
+			// No account had any row on this page (zero matching results, or an out-of-range page) —
+			// print the column titles anyway so the grid never shows with no header at all.
+			print "<tbody><tr>";
+			if (!$summeret) print "<th>" . findtekst('635|Dato', $sprog_id) . "</th>";
+			print "<th>" . findtekst('917|Varenr.', $sprog_id) . "</th>";
+			print "<th>" . findtekst('914|Beskrivelse', $sprog_id) . "</th>";
+			print "<th class='text-right'>" . findtekst('916|Antal', $sprog_id) . "</th>";
+			print "<th class='text-right'>" . findtekst('915|Pris', $sprog_id) . "</th>";
+			if (!$summeret) print "<th class='text-right'>" . findtekst('428|Rabat', $sprog_id) . "</th>";
+			print "<th class='text-right'>Sum</th>";
+			print "</tr></tbody>\n";
+		}
+		// Close #ssGridTable/#ssGridWrapper opened in the header block, then print the fixed Grid
+		// Framework footer with REAL (server-side) pagination — same $ssPageStart/$ssPageEnd-driven
+		// print-time filtering as the account loop above, and the same link/markup/CSS technique
+		// kontokort() uses for Finance -> Reports -> General Ledger's footer (#kkPageFooterBar):
+		// a page-size <select> that navigates via a full page reload, and prev/page-number/next
+		// <a> links — not client-side JS re-slicing.
+		print "</table>"; // close #ssGridTable
+		print "</div>\n"; // close #ssGridWrapper
+
+		// Detect when the sticky column-title row is actually pinned to the top of #ssGridWrapper
+		// (vs. sitting in its normal resting position right below "Company Name:") and only then add
+		// the 'ss-stuck' class that turns on its border-bottom (see #ssGridTable th CSS above) — so the
+		// divider only appears once scrolling has pinned the row, not while the page is at rest.
+		print "<script>(function(){
+	var wrap = document.getElementById('ssGridWrapper');
+	var titleRow = document.querySelector('#ssGridTable tr.ss-col-title-row');
+	if (!wrap || !titleRow || typeof IntersectionObserver === 'undefined') return;
+	var observer = new IntersectionObserver(function(entries){
+		entries.forEach(function(entry){
+			titleRow.classList.toggle('ss-stuck', entry.intersectionRatio < 1);
+		});
+	}, { root: wrap, threshold: [1], rootMargin: '-1px 0px 0px 0px' });
+	observer.observe(titleRow);
+})();</script>\n";
+
+		$ssTxt1 = lcfirst(findtekst('2767|Af', $sprog_id));
+		$ssTxt2 = findtekst('2125|Linjer pr. side', $sprog_id);
+		$ssOffsetFrom = (($ssPage - 1) * $ssPerPage) + 1;
+		$ssOffsetTo = min($ssTotalRows, $ssPage * $ssPerPage);
+		$ssBaseUrl = "salgsstat.php?" . http_build_query(array(
+			'dato_fra' => $dato_fra,
+			'dato_til' => $dato_til,
+			'konto_fra' => $konto_fra,
+			'konto_til' => $konto_til,
+			'kontonr' => $kontonr,
+			'firmanavn' => $firmanavn,
+			'adresse' => $adresse,
+			'postnr' => $postnr,
+			'bynavn' => $bynavn,
+			'varenr' => $varenr,
+			'varetekst' => $varetekst,
+			'detaljer' => $detaljer,
+			'art' => $art,
+			'ss_per_page' => $ssPerPage,
+		));
+		$ssPrevIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#000000"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>';
+		$ssNextIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#000000"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>';
+
+		print "<style>
+#ssPageFooterBar { position:fixed; left:0; right:0; bottom:0; width:100%; margin:0; z-index:1000; background-color:$bgcolor; border-top:1px solid #b8bec8; padding:6px 12px; display:flex; align-items:center; justify-content:flex-end; gap:20px; flex-wrap:wrap; box-sizing:border-box; line-height:1; }
+#ssPageFooterBar #ssNavButtons { display:flex; align-items:center; gap:3px; }
+#ssPageFooterBar #ssNavButtons .navbutton { height:20px; min-width:20px; padding:0 4px; display:inline-flex; align-items:center; justify-content:center; background:#f0f0f0; color:#000; border:1px solid #b8bec8; border-radius:4px; text-decoration:none; }
+#ssPageFooterBar #ssNavButtons a.navbutton { cursor:pointer; }
+#ssPageFooterBar #ssNavButtons span.navbutton { opacity:0.5; }
+#ssPageFooterBar #ssNavButtons .navbutton.current { text-decoration:underline; }
+</style>\n";
+		print "<div id='ssPageFooterBar'>";
+		print "<span id='ssPageStatus'>" . ($ssTotalRows ? "$ssOffsetFrom-$ssOffsetTo $ssTxt1 $ssTotalRows" : "0 $ssTxt1 0") . "</span>";
+		print "<span>$ssTxt2 <select id='ssPageSize' onchange=\"window.location.href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=1&ss_per_page=' + this.value;\">";
+		foreach (array(50, 100, 250, 500, 100000) as $ssOpt) {
+			$ssSel = ($ssOpt == $ssPerPage) ? " selected" : "";
+			$ssLabel = ($ssOpt == 100000) ? "Alle" : $ssOpt;
+			print "<option value='$ssOpt'$ssSel>$ssLabel</option>";
+		}
+		print "</select></span>";
+		print "<span id='ssNavButtons'>";
+		if ($ssPage > 1)
+			print "<a class='navbutton' href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=" . ($ssPage - 1) . "'>$ssPrevIcon</a>";
+		else
+			print "<span class='navbutton'>$ssPrevIcon</span>";
+		$ssPageRange = 2;
+		$ssStartPage = max(1, $ssPage - $ssPageRange);
+		$ssEndPage = min($ssTotalPages, $ssPage + $ssPageRange);
+		if ($ssStartPage > 1) {
+			print "<a class='navbutton' href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=1'>1</a>";
+			if ($ssStartPage > 2)
+				print "<span>...</span>";
+		}
+		for ($ssP = $ssStartPage; $ssP <= $ssEndPage; $ssP++) {
+			if ($ssP == $ssPage)
+				print "<span class='navbutton current'>$ssP</span>";
+			else
+				print "<a class='navbutton' href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=$ssP'>$ssP</a>";
+		}
+		if ($ssEndPage < $ssTotalPages) {
+			if ($ssEndPage < $ssTotalPages - 1)
+				print "<span>...</span>";
+			print "<a class='navbutton' href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=$ssTotalPages'>$ssTotalPages</a>";
+		}
+		if ($ssPage < $ssTotalPages)
+			print "<a class='navbutton' href='" . htmlspecialchars($ssBaseUrl, ENT_QUOTES) . "&ss_page=" . ($ssPage + 1) . "'>$ssNextIcon</a>";
+		else
+			print "<span class='navbutton'>$ssNextIcon</span>";
+		print "</span>";
+		print "</div>\n";
+		print "</div>\n"; // close #ssPageFlex
+	}
+
 	if ($menu=='T') {
 		include_once '../includes/topmenu/footer.php';
 	} else {
@@ -276,10 +517,5 @@ function begraens($dato_fra,$dato_til,$konto_fra,$konto_til,$kontonr,$firmanavn,
 	print "</td></tr>";
 
 	print "</tbody></table>";
-}
-if ($menu=='T') {
-	include_once '../includes/topmenu/footer.php';
-} else {
-	include_once '../includes/oldDesign/footer.php';
 }
 ?>


### PR DESCRIPTION
## Summary
This PR covers two issues with the Sales Statistics report under 
Debtors → Reports:
1. The report displayed an old-style top menu with no footer. 
   Both have been replaced with the Grid Framework header and 
   footer consistent with Finance → Reports → General Ledger.
2. The columns in the report list were misaligned — the header 
   columns did not match the data columns. This has been fixed.

## ⚠️ Performance Warning
Do not press the Sales Statistics button without a date filter — 
it will load everything in the database and may cause severe 
performance issues. Always limit the query by entering a date 
range before running the report.
Example: type 010426:010426 in the Date field to load a single day.

## What are the changes about?

### Issue 1 — Grid Framework header and footer
- Replaced old top menu with Grid Framework header component
- Added Back button on the left of the header
- Kept Search button on the right of the header unchanged
- Added sticky footer with pagination controls
- Kept existing footer buttons unchanged

### Issue 2 — Misaligned columns
- Fixed column misalignment so header columns align correctly 
  with data columns beneath them

## Files Changed
- includes/salgsstat.php

## Reference Pages Used
| Page | Notes |
|---|---|
| Finance → Reports → General Ledger | Primary reference — sticky header and sticky footer with pagination |
| Debtors → Orders | Additional header and footer layout reference |
| Debtors → Accounts | Additional header layout reference |

## How to Test
⚠️ Use test_12 with a limited date range e.g. 010426:010426

1. Navigate to Debtors → Reports → Sales Statistics
2. Enter a date range e.g. 010426:010426 before running report
3. Verify the header is sticky and remains visible when scrolling
4. Verify the Back button is on the left of the header
5. Verify the Search button is on the right and works correctly
6. Verify the footer is sticky and remains visible when scrolling
7. Verify pagination controls are in the footer
8. Verify all existing footer buttons work correctly
9. Verify column headers align with data columns beneath them
10. Compare layout with Finance → Reports → General Ledger 
    and verify visual consistency

## Acceptance Criteria
- Sticky Grid Framework header with Back button on left ✅
- Search button on right of header works correctly ✅
- Sticky footer with pagination controls ✅
- Existing footer buttons work as before ✅
- Column headers align correctly with data columns ✅
- Layout consistent with Finance → Reports → General Ledger ✅
- Header and footer remain visible when scrolling ✅

## Tested On
- test_12 (Havemøbelland) ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
