### PR TITLE
Fix: restore reminder popup/email system broken by commented-out incl…

### DIFF
--- a/debitor/rykkertjek.php
+++ b/debitor/rykkertjek.php
@@ -1,5 +1,5 @@
 <?php
-// --- debitor/rykkertjek.php --- lap 4.0.8 --- 2023-05-24 ---
+// --- debitor/rykkertjek.php --- patch 5.0.0 --- 2026-07-07 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -15,10 +15,11 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2003-2023 saldi.dk aps
+// Copyright (c) 2003-2026 Danosoft.ApS
 // -----------------------------------------------------------
 // 20200918 Ckeck bypassed if no email.
 // 20230524 PHR php8
+// 20260707 MJ Fix fatal re-declaration of std_func when included from login; fix missing globals in reminderCheck; fix BODY onLoad popup
 
 @session_start();
 $s_id=session_id();
@@ -29,7 +30,7 @@ $email = NULL;
 
 include("../includes/connect.php");
 include("../includes/online.php");
-include("../includes/std_func.php");
+if (!function_exists('findtekst')) include("../includes/std_func.php");
 include("../includes/forfaldsdag.php");
 
 if(!class_exists('phpmailer')) {
@@ -51,6 +52,7 @@ if ($r = db_fetch_array(db_select("select * from grupper where art='DIV' and kod
 if ($email) reminderCheck ($mailmodt_id,$email,$ffdage,$chkdate);
 
 function reminderCheck ($mailmodt_id,$email,$ffdage,$chkdate) {
+	global $dd, $bruger_id, $sprog_id;
 	if (!$ffdage || $chkdate==$dd) echo '';
 	else {
 		$rykkerdate=usdate(forfaldsdag($dd,'netto',$ffdage));
@@ -64,7 +66,7 @@ function reminderCheck ($mailmodt_id,$email,$ffdage,$chkdate) {
 			$rykkerdate=usdate(forfaldsdag($r['forfaldsdate'],'netto',$ffdage));
 #	echo "$rykkerdate <= $dd<br>";
 			if ($rykkerdate <= $dd) {
-				if (!db_fetch_array(db_select("select id from ordrelinjer where enhed = '$r[id]'",__FILE__ . " linje " . __LINE__))) { #Tjekker om der allerede eksisterer en rykker på ordren.
+				if (!db_fetch_array(db_select("select id from ordrelinjer where enhed = '$r[id]'",__FILE__ . " linje " . __LINE__))) { #Tjekker om der allerede eksisterer en rykker pï¿½ ordren.
 					if (!in_array($r['konto_id'],$konto_id)) {
 						$konto_id[$x]=$r['konto_id']; #Liste over konto id numre der skal rykkes
 						$x++;
@@ -86,7 +88,7 @@ function reminderCheck ($mailmodt_id,$email,$ffdage,$chkdate) {
 #echo "$ff_antal && $bruger_id == $mailmodt_id<br>";
 			$tmp=findtekst(240,$sprog_id);
 #echo "$tmp<br>";
-			print "<BODY onLoad=\"javascript:alert('$tmp')\">";
+			print "<script>alert(" . json_encode((string)$tmp) . ");</script>";
 		}
 # exit;
 	}

--- a/index/login.php
+++ b/index/login.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- index/login.php --- patch 5.0.0 --- 2026-04-29 ---
+// --- index/login.php --- patch 5.0.0 --- 2026-07-07 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -21,7 +21,7 @@
 // See GNU General Public License for more details.
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 
 // 20220118 PHR - Added 'if ($db != $sqdb && $dbver > '4.0.4')'
@@ -46,6 +46,7 @@
 // 20260422 PHR Fixed cancel not working.
 // 20260422 LOE Updated sanitize_input function to allow more characters for email address like usernames.
 // 20260425 LOE Fixed a bug where same account name with different case could cause login issues. Now first tries to find exact match and only if that fails, it tries case-insensitive match.
+// 20260707 MJ Restore rykkertjek.php include at login (was commented out)
 
 ob_start(); //Starter output buffering 
 @session_start();
@@ -854,7 +855,7 @@ if(!isset($afbryd)){
 				}
 			}
 		}
-		#if (substr($rettigheder,5,1)=='1') include("../debitor/rykkertjek.php");
+		if (substr($rettigheder,5,1)=='1') include("../debitor/rykkertjek.php");
 		# Lager status mail
 		if (file_exists("../lager/lagerstatusmail.php")) {
 			$email = get_settings_value("mail", "lagerstatus", "");


### PR DESCRIPTION
## What are the changes about?
- Uncomment rykkertjek.php include in index/login.php (was prefixed with # causing total disable)
- Guard std_func.php include in rykkertjek.php with function_exists to prevent fatal re-declaration when included from login.php
- Add global declarations for $dd, $bruger_id, $sprog_id in reminderCheck() (were silently NULL inside function scope)
- Replace BODY onLoad alert with inline script tag (BODY onLoad has no effect mid-page)

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
