### PR TITLE
Fix kreditor order split producing blank page

### DIFF
--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- kreditor/orderIncludes/moveOrderLines.php --- lap 5.0.0 --- 2026-06-02 ---
+// --- kreditor/orderIncludes/moveOrderLines.php --- patch 5.0.0 --- 2026-07-08 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -20,22 +20,26 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2008-2026 Saldi.dk ApS
+// Copyright (c) 2008-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 //
 // 20230118 PHR Added '$mSQt[$x] !=	 0 && ' as orders with some qty less than 0 could not split. 
 // 20230206 PHR id_seq id now updated after inserting new orderlines.
 // 20260226 PHR Changed posnr=posnr+1000000 to posnr=posnr+1000 as posnr is smallint
 // 20260602 PHR Definet $mQt as array if empty.
+// 20260708 MJ Guard all POST arrays; fetch antal/leveret from DB to fix index mismatch causing blank page; guard setval for MySQL.
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
 
-$mQt    = $_POST['mQt'];
-$mSQt   = $_POST['mSQt'];
-$maxQt  = $_POST['maxQt'];
-$maxSQt = $_POST['maxSQt'];
-if (!$mQt) $mQt = array();
+$mQt    = isset($_POST['mQt'])    ? $_POST['mQt']    : array();
+$mSQt   = isset($_POST['mSQt'])   ? $_POST['mSQt']   : array();
+$maxQt  = isset($_POST['maxQt'])  ? $_POST['maxQt']  : array();
+$maxSQt = isset($_POST['maxSQt']) ? $_POST['maxSQt'] : array();
+if (!$mQt)    $mQt    = array();
+if (!$mSQt)   $mSQt   = array();
+if (!$maxQt)  $maxQt  = array();
+if (!$maxSQt) $maxSQt = array();
 for ($x = 1; $x <= count($mQt); $x++) {
 	if (usdecimal($mQt[$x], 3)  > $maxQt[$x]) {
 		$mQt[$x]  = $maxQt[$x];
@@ -61,13 +65,18 @@ else {
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		$qtxt = "INSERT INTO ordrer SELECT * FROM temp_table";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-		$qtxt = "SELECT setval('ordrer_id_seq', $newId)";
-		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+		if ($db_type != 'mysql' && $db_type != 'mysqli') {
+			$qtxt = "SELECT setval('ordrer_id_seq', $newId)";
+			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+		}
 		$qtxt = "DROP TABLE temp_table";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 	}
 	# Loop over each orderline
 	for ($x = 1; $x <= count($linje_id); $x++) {
+		$r = db_fetch_array(db_select("SELECT antal, leveret FROM ordrelinjer WHERE id='$linje_id[$x]'", __FILE__ . " linje " . __LINE__));
+		$antal[$x]   = $r ? usdecimal($r['antal'],   2) : 0;
+		$leveret[$x] = $r ? usdecimal($r['leveret'], 2) : 0;
 		if ($mQt[$x] && $antal[$x] == $mQt[$x]) {
 			$qtxt = "UPDATE ordrelinjer SET ordre_id = '$newId', posnr=posnr+1000 WHERE id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -83,8 +92,10 @@ else {
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "INSERT INTO ordrelinjer SELECT * FROM temp_table WHERE id='$newLineId'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-			$qtxt = "SELECT setval('ordrelinjer_id_seq', $newLineId)";
-			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+			if ($db_type != 'mysql' && $db_type != 'mysqli') {
+				$qtxt = "SELECT setval('ordrelinjer_id_seq', $newLineId)";
+				db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+			}
 			if (!$antal[$x]) $antal[$x] = 0;
 			if ($mQt[$x]) $antal[$x] = $antal[$x] - $mQt[$x];
 			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], posnr=posnr+1000 WHERE id='$linje_id[$x]'";
@@ -109,8 +120,10 @@ else {
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "INSERT INTO ordrelinjer SELECT * FROM temp_table WHERE id='$newLineId'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-			$qtxt = "SELECT setval('ordrelinjer_id_seq', $newLineId)";
-			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+			if ($db_type != 'mysql' && $db_type != 'mysqli') {
+				$qtxt = "SELECT setval('ordrelinjer_id_seq', $newLineId)";
+				db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+			}
 			$antal[$x] = $antal[$x] - $mSQt[$x];
 			$leveret[$x] = $leveret[$x] - $mSQt[$x];
 			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], posnr=posnr+1000 WHERE id='$linje_id[$x]'";


### PR DESCRIPTION
## What are the changes about?
- Guard all four POST arrays with isset() to handle disabled form inputs
- Fetch antal and leveret from DB in move loop to fix index mismatch (splitOrder uses 1-indexed fields, ordre.php loop sets 0-indexed), which caused last order line to always trigger partial split with zero antal
- Wrap SELECT setval() calls in PostgreSQL-only condition to prevent fatal db_modify failure on MySQL

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
