### PR TITLE
Fix kreditor order ref resetting to wrong employee on account change

### DIFF
--- a/kreditor/orderIncludes/insertAccount.php
+++ b/kreditor/orderIncludes/insertAccount.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- kreditor/ordreIncludes/insertAccount.php --- patch 5.0.0 --- 2026-07-10 ---
+// --- kreditor/ordreIncludes/insertAccount.php --- patch 5.0.0 --- 2026-07-13 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -29,6 +29,7 @@
 // 20240626 PHR Added 'fiscal_year' in queries
 // 20270226 PHR $art set to 'KO' if empty
 // 20260710 MJ Preserve ref: use global $ref (from form) or look up employee naam, not raw brugernavn.
+// 20260713 MJ Fix structural bug: orphaned if(!$afd){ caused all main logic to be skipped when afd was set. Also restore afd lookup from ansatte.
 
 if (!function_exists('insertAccount')) {
 function insertAccount($id, $konto_id) {
@@ -65,11 +66,10 @@ function insertAccount($id, $konto_id) {
 		$r_emp = db_fetch_array(db_select("select navn, afd from ansatte where id = " . (int)$r_brg['ansat_id'], __FILE__ . " linje " . __LINE__));
 		if ($r_emp) {
 			if (!$insert_ref && $r_emp['navn']) $insert_ref = $r_emp['navn'];
+			if (!$afd && $r_emp['afd']) $afd = $r_emp['afd'];
 		}
 	}
 	if (!$insert_ref) $insert_ref = $brugernavn;
-
-	if (!$afd) {
 	$afd = (int)$afd;
 
 	// Set lager based on afd if lager is not already set

--- a/kreditor/orderIncludes/insertAccount.php
+++ b/kreditor/orderIncludes/insertAccount.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- kreditor/ordreIncludes/insertAccount.php --- patch 5.0.0 --- 2026-02-26 ---
+// --- kreditor/ordreIncludes/insertAccount.php --- patch 5.0.0 --- 2026-07-10 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -21,13 +21,14 @@
 // See GNU General Public License for more details.
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 // 20230509 PHR php8
 // 20230718 LOE Minor modification
 // 20231207 PHR lock table while finding next ordrenr.
 // 20240626 PHR Added 'fiscal_year' in queries
 // 20270226 PHR $art set to 'KO' if empty
+// 20260710 MJ Preserve ref: use global $ref (from form) or look up employee naam, not raw brugernavn.
 
 if (!function_exists('insertAccount')) {
 function insertAccount($id, $konto_id) {
@@ -41,6 +42,7 @@ function insertAccount($id, $konto_id) {
 	global $postnr,$regnaar;
 	global $status,$sum;
 	global $valuta,$omlev,$afd;
+	global $ref;
 	$tidspkt=date("U");
 
 	if (!$konto_id) {
@@ -54,13 +56,20 @@ function insertAccount($id, $konto_id) {
 	if (!$sum)         $sum         = 0;
 	if (!$art)         $art         = 'KO';
 
-	if (!$afd) {
-		$qtxt = "select ansat_id from brugere where brugernavn = '$brugernavn'";
-		if ($r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__)) && if_isset($r,NULL,'ansat_id')) {
-			$r = db_fetch_array(db_select("select afd from ansatte where id = " . (int)$r['ansat_id'],__FILE__ . " linje " . __LINE__));
-			if ($r && if_isset($r, NULL, 'afd')) $afd=$r['afd'];
+	// Resolve the ref (our-reference) to store: prefer the already-selected employee
+	// name ($ref from the POST form), then look it up from the employee table, then
+	// fall back to the raw login name so the field is never left blank.
+	$insert_ref = $ref ? $ref : null;
+	$r_brg = db_fetch_array(db_select("select ansat_id from brugere where brugernavn = '$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($r_brg && $r_brg['ansat_id']) {
+		$r_emp = db_fetch_array(db_select("select navn, afd from ansatte where id = " . (int)$r_brg['ansat_id'], __FILE__ . " linje " . __LINE__));
+		if ($r_emp) {
+			if (!$insert_ref && $r_emp['navn']) $insert_ref = $r_emp['navn'];
 		}
 	}
+	if (!$insert_ref) $insert_ref = $brugernavn;
+
+	if (!$afd) {
 	$afd = (int)$afd;
 
 	// Set lager based on afd if lager is not already set
@@ -122,7 +131,7 @@ function insertAccount($id, $konto_id) {
 		$qtxt.= "($ordrenr,$konto_id,'$kontonr','$firmanavn','$addr1','$addr2','$postnr','$bynavn',";
 		$qtxt.= "'$land','$kontakt','$lev_navn','$lev_addr1','$lev_addr2','$lev_postnr','$lev_bynavn','$lev_kontakt',";
 		$qtxt.= "'$betalingsdage','$betalingsbet','$cvrnr','$notes','$art','$ordredate','$email','$momssats',$status,";
-		$qtxt.="'$brugernavn','$afd','$lager','$sum','$brugernavn','$tidspkt','$valuta','$kred_ord_id','$omlev')";
+		$qtxt.="'$insert_ref','$afd','$lager','$sum','$brugernavn','$tidspkt','$valuta','$kred_ord_id','$omlev')";
 /*		
 		$qtxt = "insert into ordrer ";
 		$qtxt.= "(ordrenr, konto_id, kontonr, firmanavn, addr1, addr2, postnr, bynavn, land,betalingsdage,  ";

--- a/kreditor/orderIncludes/openOrderData.php
+++ b/kreditor/orderIncludes/openOrderData.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- kreditor/creditorIncludes/openOrderData.php --- lap 5.0.0 --- 2026.05.21 ---
+// --- kreditor/orderIncludes/openOrderData.php --- patch 5.0.0 --- 2026-07-13 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -20,7 +20,7 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2003-2026 saldi.dk aps
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 // 20221106 PHR - Various changes to fit php8 / MySQLi
 // 20221104 MLH added lookup function for the delivery address fields
@@ -32,6 +32,7 @@
 // 20260217 PHR Added 'kundeordrnr'
 // 20260312 PHR Added Afd, depNumbers, depNames, oldDep, employees & oldRef
 // 20260521 LOE Added check to set afd based on first employee if no match is found for ref in employees list
+// 20260713 MJ Fix ref SELECT: add selected='selected', preserve stored ref when not in active employee list, fix </select> typo. Same fix for afd SELECT.
 
 /*
 $attachId    = null;
@@ -185,19 +186,17 @@ print "<tr><td>$txt1097</td>";
 print "<td>";
 print "<input type = 'hidden' name = 'oldRef' value = '$ref'>";
 if (count($employees)) {
+	$refInList = in_array($ref, $employees);
 	print "<select class='inputbox' style='width:110px;'  name = 'ref'>";
-	for ($i=0;$i<count($employees);$i++) {
-		if ($ref == $employees[$i]){
-			 print "<option value='$employees[$i]'>$employees[$i]</option>";
-		}else{
-			//store the first employee in the list as default if no match is found
-			if ($i == 0)  $firstEmployee = $employees[$i];
-		}
+	if ($ref && !$refInList) {
+		print "<option value='$ref' selected='selected'>$ref</option>";
 	}
 	for ($i=0;$i<count($employees);$i++) {
-		if ($ref != $employees[$i]) print "<option value='$employees[$i]'>$employees[$i]</option>";
+		$sel = ($ref == $employees[$i]) ? " selected='selected'" : "";
+		print "<option value='$employees[$i]'$sel>$employees[$i]</option>";
+		if ($i == 0 && $ref != $employees[$i]) $firstEmployee = $employees[$i];
 	}
-	print "<select>";
+	print "</select>";
 } else print $ref;
 print "</td>";
 
@@ -216,12 +215,10 @@ print "<td>";
 print "<input type = 'hidden' name = 'oldDep' value = '$afd'>";
 	print "<select class='inputbox' style='width:110px;'  name = 'afd'>";
 	for ($i=0;$i<count($depNumbers);$i++) {
-		if ($afd == $depNumbers[$i]) print "<option value='$depNumbers[$i]'>$depNumbers[$i] : $depNames[$i]</option>";
+		$sel = ($afd == $depNumbers[$i]) ? " selected='selected'" : "";
+		print "<option value='$depNumbers[$i]'$sel>$depNumbers[$i] : $depNames[$i]</option>";
 	}
-	for ($i=0;$i<count($depNumbers);$i++) {
-		if ($afd != $depNumbers[$i]) print "<option value='$depNumbers[$i]'>$depNumbers[$i] : $depNames[$i]</option>";
-	}
-	print "<select>";
+	print "</select>";
 }
 print "</tr>";
 if (count($lager_nr)) {


### PR DESCRIPTION
## What are the changes about?
When a new order was created via insertAccount(), the ref column was always set to the raw login name ($brugernavn) instead of the employee display name. Added global $ref so the form-selected employee name is used when available, with a fallback to looking up the employee naam from the ansatte table, then finally the login name. Also replaced the old afd-lookup block that had a PHP operator-precedence bug ($r = expr() && check()) that prevented it from ever working correctly.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
