### PR TITLE
Fix Serienumre list not showing sold serial numbers when searching by…

### DIFF
--- a/lager/lister/serialnumber.php
+++ b/lager/lister/serialnumber.php
@@ -28,6 +28,7 @@
 // 20260608 CL/PHR - Filter "ikke solgt": sn.salgslinje_id <= 0 i stedet for so.ordrenr IS NULL (retur-serienr. vises som tilgængelige)
 // 20260710 MJ Use COALESCE(v.varenr, kl.varenr, sl.varenr) so serienr records with stale/missing vare_id still appear and are searchable by varenr.
 // 20260710 MJ ABS(sn.kobslinje_id) i JOIN så negative kobslinje_id (retur til leverandør) også viser indkøbsordren.
+// 20260710 MJ Ekstra COALESCE-fallbacks via ordrelinjer.vare_id→varer og batch_kob.vare_id→varer så serienr med tom/manglende ordrelinjer.varenr stadig søges.
 
 @session_start();
 $s_id = session_id();
@@ -80,10 +81,10 @@ $columns[] =    array(
         $url = "../../lager/varekort.php?id=$row[vare_id]&returside=../lager/lister/serialnumber.php";
         return "<td align='$column[align]'><a href='$url'>$value</a></td>";
     },
-    "sqlOverride" => "COALESCE(v.varenr, kl.varenr, sl.varenr)",
+    "sqlOverride" => "COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr)",
     "generateSearch" => function ($column, $term) {
         $term = db_escape_string($term);
-        return "(COALESCE(v.varenr, kl.varenr, sl.varenr) ILIKE '%$term%')";
+        return "(COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr) ILIKE '%$term%')";
     },
     "width" => "0.5",
 );
@@ -91,7 +92,7 @@ $columns[] =    array(
     "field" => "beskrivelse",
     "headerName" => "Vare navn",
     "width" => "3",
-    "sqlOverride" => "COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse)"
+    "sqlOverride" => "COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse)"
 );
 $columns[] =    array(
     "field" => "stregkode",
@@ -251,8 +252,8 @@ $data = array(
     "query" => "SELECT
     sn.id AS id,
     sn.vare_id AS vare_id,
-    COALESCE(v.varenr, kl.varenr, sl.varenr) AS varenr,
-    COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse) AS beskrivelse,
+    COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr) AS varenr,
+    COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse) AS beskrivelse,
     v.stregkode AS stregkode,
     sn.serienr AS serienr,
 
@@ -275,6 +276,11 @@ LEFT JOIN ordrer ko ON kl.ordre_id = ko.id
 
 LEFT JOIN ordrelinjer sl ON ABS(sn.salgslinje_id) = sl.id
 LEFT JOIN ordrer so ON sl.ordre_id = so.id
+
+LEFT JOIN varer klv ON kl.vare_id = klv.id
+LEFT JOIN varer slv ON sl.vare_id = slv.id
+LEFT JOIN batch_kob bk ON ABS(sn.batch_kob_id) = bk.id
+LEFT JOIN varer bkv ON bk.vare_id = bkv.id
 
 WHERE
     {{WHERE}}

--- a/lager/lister/serialnumber.php
+++ b/lager/lister/serialnumber.php
@@ -27,6 +27,7 @@
 // 20260608 CL/PHR - ABS(sn.salgslinje_id) i JOIN så negative salgslinje_id (kreditnota-retur) også viser salgsordren
 // 20260608 CL/PHR - Filter "ikke solgt": sn.salgslinje_id <= 0 i stedet for so.ordrenr IS NULL (retur-serienr. vises som tilgængelige)
 // 20260710 MJ Use COALESCE(v.varenr, kl.varenr, sl.varenr) so serienr records with stale/missing vare_id still appear and are searchable by varenr.
+// 20260710 MJ ABS(sn.kobslinje_id) i JOIN så negative kobslinje_id (retur til leverandør) også viser indkøbsordren.
 
 @session_start();
 $s_id = session_id();
@@ -269,7 +270,7 @@ $data = array(
 FROM serienr sn
 LEFT JOIN varer v ON sn.vare_id = v.id
 
-LEFT JOIN ordrelinjer kl ON sn.kobslinje_id = kl.id
+LEFT JOIN ordrelinjer kl ON ABS(sn.kobslinje_id) = kl.id
 LEFT JOIN ordrer ko ON kl.ordre_id = ko.id
 
 LEFT JOIN ordrelinjer sl ON ABS(sn.salgslinje_id) = sl.id

--- a/lager/lister/serialnumber.php
+++ b/lager/lister/serialnumber.php
@@ -28,7 +28,7 @@
 // 20260608 CL/PHR - Filter "ikke solgt": sn.salgslinje_id <= 0 i stedet for so.ordrenr IS NULL (retur-serienr. vises som tilgængelige)
 // 20260710 MJ Use COALESCE(v.varenr, kl.varenr, sl.varenr) so serienr records with stale/missing vare_id still appear and are searchable by varenr.
 // 20260710 MJ ABS(sn.kobslinje_id) i JOIN så negative kobslinje_id (retur til leverandør) også viser indkøbsordren.
-// 20260710 MJ Ekstra COALESCE-fallbacks via ordrelinjer.vare_id→varer og batch_kob.vare_id→varer så serienr med tom/manglende ordrelinjer.varenr stadig søges.
+// 20260710 MJ Ekstra COALESCE-fallbacks via ordrelinjer.vare_id→varer og batch_kob/batch_salg.vare_id→varer så serienr med tom/manglende ordrelinjer.varenr stadig søges.
 
 @session_start();
 $s_id = session_id();
@@ -81,10 +81,10 @@ $columns[] =    array(
         $url = "../../lager/varekort.php?id=$row[vare_id]&returside=../lager/lister/serialnumber.php";
         return "<td align='$column[align]'><a href='$url'>$value</a></td>";
     },
-    "sqlOverride" => "COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr)",
+    "sqlOverride" => "COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr, bsv.varenr)",
     "generateSearch" => function ($column, $term) {
         $term = db_escape_string($term);
-        return "(COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr) ILIKE '%$term%')";
+        return "(COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr, bsv.varenr) ILIKE '%$term%')";
     },
     "width" => "0.5",
 );
@@ -92,7 +92,7 @@ $columns[] =    array(
     "field" => "beskrivelse",
     "headerName" => "Vare navn",
     "width" => "3",
-    "sqlOverride" => "COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse)"
+    "sqlOverride" => "COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse, bsv.beskrivelse)"
 );
 $columns[] =    array(
     "field" => "stregkode",
@@ -252,8 +252,8 @@ $data = array(
     "query" => "SELECT
     sn.id AS id,
     sn.vare_id AS vare_id,
-    COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr) AS varenr,
-    COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse) AS beskrivelse,
+    COALESCE(v.varenr, kl.varenr, sl.varenr, klv.varenr, slv.varenr, bkv.varenr, bsv.varenr) AS varenr,
+    COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse, klv.beskrivelse, slv.beskrivelse, bkv.beskrivelse, bsv.beskrivelse) AS beskrivelse,
     v.stregkode AS stregkode,
     sn.serienr AS serienr,
 
@@ -281,6 +281,8 @@ LEFT JOIN varer klv ON kl.vare_id = klv.id
 LEFT JOIN varer slv ON sl.vare_id = slv.id
 LEFT JOIN batch_kob bk ON ABS(sn.batch_kob_id) = bk.id
 LEFT JOIN varer bkv ON bk.vare_id = bkv.id
+LEFT JOIN batch_salg bs ON ABS(sn.batch_salg_id) = bs.id
+LEFT JOIN varer bsv ON bs.vare_id = bsv.id
 
 WHERE
     {{WHERE}}

--- a/lager/lister/serialnumber.php
+++ b/lager/lister/serialnumber.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// ---- index/main.php --- lap 4.1.0 --- 2024.02.09 ---
+// ---- lager/lister/serialnumber.php --- patch 5.0.0 --- 2026-07-10 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -20,12 +20,13 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY. See
 // GNU General Public License for more details.
 //
-// Copyright (c) 2024-2024 saldi.dk aps
+// Copyright (c) 2024-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 // 17042024 MMK - Added suport for reloading page, and keeping current URI, DELETED old system that didnt work
 // 17-10-2024 PBLM - Added link to booking
 // 20260608 CL/PHR - ABS(sn.salgslinje_id) i JOIN så negative salgslinje_id (kreditnota-retur) også viser salgsordren
 // 20260608 CL/PHR - Filter "ikke solgt": sn.salgslinje_id <= 0 i stedet for so.ordrenr IS NULL (retur-serienr. vises som tilgængelige)
+// 20260710 MJ Use COALESCE(v.varenr, kl.varenr, sl.varenr) so serienr records with stale/missing vare_id still appear and are searchable by varenr.
 
 @session_start();
 $s_id = session_id();
@@ -78,14 +79,18 @@ $columns[] =    array(
         $url = "../../lager/varekort.php?id=$row[vare_id]&returside=../lager/lister/serialnumber.php";
         return "<td align='$column[align]'><a href='$url'>$value</a></td>";
     },
-    "sqlOverride" => "v.varenr",
+    "sqlOverride" => "COALESCE(v.varenr, kl.varenr, sl.varenr)",
+    "generateSearch" => function ($column, $term) {
+        $term = db_escape_string($term);
+        return "(COALESCE(v.varenr, kl.varenr, sl.varenr) ILIKE '%$term%')";
+    },
     "width" => "0.5",
 );
 $columns[] =    array(
     "field" => "beskrivelse",
     "headerName" => "Vare navn",
     "width" => "3",
-    "sqlOverride" => "v.beskrivelse"
+    "sqlOverride" => "COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse)"
 );
 $columns[] =    array(
     "field" => "stregkode",
@@ -242,15 +247,15 @@ $filters[] = array(
 $data = array(
     "table_name" => "serienr",
 
-    "query" => "SELECT 
-    sn.id AS id, 
-    sn.vare_id AS vare_id, 
-    v.varenr AS varenr,
-    v.beskrivelse AS beskrivelse,
+    "query" => "SELECT
+    sn.id AS id,
+    sn.vare_id AS vare_id,
+    COALESCE(v.varenr, kl.varenr, sl.varenr) AS varenr,
+    COALESCE(v.beskrivelse, kl.beskrivelse, sl.beskrivelse) AS beskrivelse,
     v.stregkode AS stregkode,
-    sn.serienr AS serienr, 
+    sn.serienr AS serienr,
 
-    kl.ordre_id AS kobs_ordre, 
+    kl.ordre_id AS kobs_ordre,
     ko.ordrenr AS kobs_ordre_nr,
     ko.konto_id AS kobs_konto,
     ko.kontonr AS kobs_kontonr,
@@ -270,9 +275,9 @@ LEFT JOIN ordrer ko ON kl.ordre_id = ko.id
 LEFT JOIN ordrelinjer sl ON ABS(sn.salgslinje_id) = sl.id
 LEFT JOIN ordrer so ON sl.ordre_id = so.id
 
-WHERE 
-    {{WHERE}} 
-ORDER BY 
+WHERE
+    {{WHERE}}
+ORDER BY
     {{SORT}}
 ",
 


### PR DESCRIPTION
## What are the changes about?
When serienr records have a stale or missing vare_id (not matching varer.id), the LEFT JOIN to varer returns NULL so v.varenr ILIKE search excludes them. Use COALESCE(v.varenr, kl.varenr, sl.varenr) in both the SELECT and the varenr search so the item number is sourced from the purchase or sales order line as fallback, making all matching serial numbers visible and searchable.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
