### PR TITLE
Fix/pbs bs10605 two spaces

### DIFF
--- a/debitor/pbsfile.php
+++ b/debitor/pbsfile.php
@@ -39,7 +39,7 @@
 // 20260320 PHR Replaced kontonr(numeric) with ktonr(varchar)
 // 20260321 PHR Reversed above as ktonr does not exist in all accounts
 // 20260601 PHR Removed PBS from CVR nr.
-// 20260711 MJ Two spaces after BS10605 in leverance BS002 header line og efter BS10601 i inset_ordrer BS002 linje.
+// 20260711 MJ Two spaces after BS10605 in leverance BS002 header line.
 
 @session_start();
 $s_id=session_id();
@@ -604,7 +604,7 @@ function inset_ordrer($antal_ordrer,$leverance_id,$dkdd,$ordre_id,$cvrnr,$bank_r
 	$r052lin=0;
 
 	$lnr++;
-	$linje[$lnr]="BS002".$cvrnr[0].$delsystem."0601  ".$leverance_id.filler(19," ").$dkdd."\n";
+	$linje[$lnr]="BS002".$cvrnr[0].$delsystem."0601".$leverance_id.filler(19," ").$dkdd."\n";
 	if ($afslut) db_modify("insert into pbs_linjer (liste_id,linje) values ('$id','$linje[$lnr]')",__FILE__ . " linje " . __LINE__);
 
 	$lnr++;

--- a/debitor/pbsfile.php
+++ b/debitor/pbsfile.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- debitor/pbsfile.php --- patchh 5.0.0 --- 2026-06-01 ---
+// --- debitor/pbsfile.php --- patch 5.0.0 --- 2026-07-11 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -21,7 +21,7 @@
 // See GNU General Public License for more details.
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 
 // 23.08.2012 Tilretning til Leverandørservice
@@ -39,6 +39,7 @@
 // 20260320 PHR Replaced kontonr(numeric) with ktonr(varchar)
 // 20260321 PHR Reversed above as ktonr does not exist in all accounts
 // 20260601 PHR Removed PBS from CVR nr.
+// 20260711 MJ Two spaces after BS10605 in leverance BS002 header line og efter BS10601 i inset_ordrer BS002 linje.
 
 @session_start();
 $s_id=session_id();
@@ -158,7 +159,7 @@ if (!$afsendt) {
 
 	if ($lev_pbs!='L') {
 		$lnr++;
-		$linje[$lnr]="BS002".$cvrnr[0]."BS10605".$leverance_id.filler(19," ").$dkdd."\n";
+		$linje[$lnr]="BS002".$cvrnr[0]."BS10605  ".$leverance_id.filler(19," ").$dkdd."\n";
 		$linjeoid[$lnr]=0;
 		if ($afslut) db_modify("insert into pbs_linjer (liste_id,linje) values ('$id','$linje[$lnr]')",__FILE__ . " linje " . __LINE__);
 	}
@@ -603,7 +604,7 @@ function inset_ordrer($antal_ordrer,$leverance_id,$dkdd,$ordre_id,$cvrnr,$bank_r
 	$r052lin=0;
 
 	$lnr++;
-	$linje[$lnr]="BS002".$cvrnr[0].$delsystem."0601".$leverance_id.filler(19," ").$dkdd."\n";
+	$linje[$lnr]="BS002".$cvrnr[0].$delsystem."0601  ".$leverance_id.filler(19," ").$dkdd."\n";
 	if ($afslut) db_modify("insert into pbs_linjer (liste_id,linje) values ('$id','$linje[$lnr]')",__FILE__ . " linje " . __LINE__);
 
 	$lnr++;


### PR DESCRIPTION
## What are the changes about?
Added two extra spaces to meet convention for the pbs file

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
