### PR TITLE
Fix invoice extraction endpoint and upload duplication

### DIFF
--- a/includes/docsIncludes/docPool.php
+++ b/includes/docsIncludes/docPool.php
@@ -3944,38 +3944,34 @@ JS;
 			})
 			.then(async function(data) {
 				if (data && data.success) {
-					uploadedCount++;
-					lastUploadedFilename = data.filename;
 					if (isAutoExtractEnabled()) {
-					try {
-						console.time('[Upload] File ' + (index+1) + ' extract API');
-						const extractFormData = new FormData();
-						extractFormData.append('action', 'extract');
-						extractFormData.append('poolFile', data.filename);
-						extractFormData.append('db', '$db');
-						extractFormData.append('docFolder', '$docFolder');
-						const extRes = await fetch('docsIncludes/extractInvoiceHandler.php', { method: 'POST', body: extractFormData });
-						const extData = await extRes.json();
-						console.timeEnd('[Upload] File ' + (index+1) + ' extract API');
-						if (extData.success && extData.data) {
+						const extracted = data.extracted;
+						if (extracted) {
 							const svData = new FormData();
 							svData.append('action', 'save');
 							svData.append('poolFile', data.filename);
 							svData.append('db', '$db');
-							const d = extData.data;
-							if(d.amount) svData.append('newAmount', d.amount);
-							if(d.date) svData.append('newDate', d.date);
-							if(d.vendor) svData.append('newSubject', d.vendor);
-							if(d.invoiceNumber) svData.append('newInvoiceNumber', d.invoiceNumber);
-							if(d.description) svData.append('newDescription', d.description);
+							svData.append('docFolder', '$docFolder');
+							if (extracted.amount) svData.append('newAmount', extracted.amount);
+							if (extracted.date) svData.append('newDate', extracted.date);
+							if (extracted.vendor) svData.append('newSubject', extracted.vendor);
+							if (extracted.invoiceNumber) svData.append('newInvoiceNumber', extracted.invoiceNumber);
+							if (extracted.description) svData.append('newDescription', extracted.description);
+							if (extracted.currency) svData.append('newCurrency', extracted.currency);
 							console.time('[Upload] File ' + (index+1) + ' save extracted data');
-							await fetch('docsIncludes/extractInvoiceHandler.php', { method: 'POST', body: svData });
+							const saveResponse = await fetch('docsIncludes/extractInvoiceHandler.php', { method: 'POST', body: svData });
 							console.timeEnd('[Upload] File ' + (index+1) + ' save extracted data');
+							if (!saveResponse.ok) throw new Error('Metadata save failed (' + saveResponse.status + ')');
+							const saveResult = await saveResponse.json();
+							if (!saveResult.success) throw new Error(saveResult.error || 'Metadata save failed');
+						} else {
+							console.error('[Upload] File ' + (index+1) + ' automatic extraction returned no result; skipping save');
 						}
-					} catch(e) { console.error('Auto-extract failed', e); }
 					} else {
 						console.log('[Upload] File ' + (index+1) + ' auto-extract disabled, skipping');
 					}
+					uploadedCount++;
+					lastUploadedFilename = data.filename;
 				} else {
 					failedCount++;
 					console.error('Upload failed for ' + file.name + ':', data && data.message ? data.message : 'Unknown error');

--- a/includes/docsIncludes/invoiceExtractionApi.php
+++ b/includes/docsIncludes/invoiceExtractionApi.php
@@ -1,215 +1,159 @@
 <?php
 // --- includes/docsIncludes/invoiceExtractionApi.php -----
 // Helper functions for invoice extraction API integration
-// ----------------------------------------------------------------------
-// 
-// CONFIGURATION:
-// To enable invoice extraction, add the API URL to the settings table:
-// 
-// INSERT INTO settings (var_name, var_grp, var_value) 
-// VALUES ('invoiceExtractionApiUrl', 'api', 'https://your-api-endpoint.com/extract');
-// 
-// If the API URL is not configured, the function will return null and uploads
-// will proceed without extraction (graceful degradation).
-// ----------------------------------------------------------------------
 
-/**
- * Extract invoice data from PDF or image file using external API
- * 
- * @param string $filePath Full path to the PDF or image file (jpg, jpeg, png)
- * @param string $invoiceId Unique ID for the invoice (e.g., "invoice-001")
- * @return array|null Returns array with 'amount' and 'date' on success, null on failure
- */
-function extractInvoiceData($filePath, $invoiceId = null) {
-	// Get API URL from settings or use default
-	global $db;
-	
-/* 	// include connect to get master DB
-	include "connect.php";
-
-	$qtxt = "SELECT var_value FROM settings WHERE var_name = 'apikey' AND var_grp = 'app_api'";
-	if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-		$apiKey = $r['var_value'];
-	}
-
-	// include online.php to get user DB
-	include "online.php"; */
-	$apiUrl = "https://ai.saldi.dk/invoice-extraction";
-	include "../connect.php";
-	$query = db_select("SELECT var_value FROM settings WHERE var_name = 'apikey' AND var_grp = 'app_api'", __FILE__ . " linje " . __LINE__);
-	$row = db_fetch_array($query);
-	$apiKey = $row["var_value"];
-	//include "../online.php";
-	// Try to get API URL from settings
-	/* $qtxt = "SELECT var_value FROM settings WHERE var_name = 'invoiceExtractionApiUrl' AND var_grp = 'api'";
-	if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-		$apiUrl = $r['var_value'];
-	} */
-	
-	
-	// If not configured, return null (API call disabled)
-	if (empty($apiUrl)) {
-		error_log("Invoice extraction API URL not configured in settings");
+function invoiceExtractionApiResolveApiKey() {
+	if (!function_exists('db_select') || !function_exists('db_fetch_array')) {
+		error_log("Invoice extraction API key lookup is unavailable");
 		return null;
 	}
-	
-	// Generate invoice ID if not provided
-	if (empty($invoiceId)) {
-		$invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
+
+	$qtxt = "SELECT var_value FROM settings WHERE var_name = 'apikey' AND var_grp = 'app_api'";
+	$query = db_select($qtxt, __FILE__ . " linje " . __LINE__, true);
+	if (!$query || !($row = db_fetch_array($query))) return null;
+
+	$apiKey = trim($row['var_value'] ?? '');
+	return $apiKey !== '' ? $apiKey : null;
+}
+
+function invoiceExtractionApiCurlTransport($apiUrl, $headers, $body, $options) {
+	if (!function_exists('curl_init')) {
+		return array('response' => false, 'http_code' => 0, 'error' => 'cURL is not available', 'errno' => 0);
 	}
-	
-	// Check if file exists
+
+	$ch = curl_init($apiUrl);
+	if (!$ch) {
+		return array('response' => false, 'http_code' => 0, 'error' => 'Failed to initialize cURL', 'errno' => 0);
+	}
+
+	curl_setopt_array($ch, array(
+		CURLOPT_RETURNTRANSFER => true,
+		CURLOPT_POST => true,
+		CURLOPT_POSTFIELDS => $body,
+		CURLOPT_HTTPHEADER => $headers,
+		CURLOPT_CONNECTTIMEOUT => $options['connect_timeout'],
+		CURLOPT_TIMEOUT => $options['timeout']
+	));
+
+	$response = curl_exec($ch);
+	$result = array(
+		'response' => $response,
+		'http_code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
+		'error' => curl_error($ch),
+		'errno' => curl_errno($ch)
+	);
+	curl_close($ch);
+
+	return $result;
+}
+
+function invoiceExtractionApiDependencies() {
+	global $invoiceExtractionApiDependencies;
+	return is_array($invoiceExtractionApiDependencies ?? null) ? $invoiceExtractionApiDependencies : array();
+}
+
+/**
+ * Extract invoice data from a PDF or image file using the external API.
+ *
+ * @param string $filePath Full path to the PDF or image file (jpg, jpeg, png)
+ * @param string $invoiceId Unique ID for the invoice (e.g., "invoice-001")
+ * @return array|null Returns SALDI invoice fields on success, null on failure
+ */
+function extractInvoiceData($filePath, $invoiceId = null) {
+	$dependencies = invoiceExtractionApiDependencies();
+	$keyResolver = isset($dependencies['key_resolver']) && is_callable($dependencies['key_resolver'])
+		? $dependencies['key_resolver']
+		: 'invoiceExtractionApiResolveApiKey';
+	$transport = isset($dependencies['transport']) && is_callable($dependencies['transport'])
+		? $dependencies['transport']
+		: 'invoiceExtractionApiCurlTransport';
+
 	if (!file_exists($filePath)) {
 		error_log("File not found: $filePath");
 		return null;
 	}
-	
-	// Detect file type
+
 	$fileExt = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
-	$allowedTypes = ['pdf', 'jpg', 'jpeg', 'png'];
-	
+	$allowedTypes = array('pdf', 'jpg', 'jpeg', 'png');
 	if (!in_array($fileExt, $allowedTypes)) {
 		error_log("Unsupported file type for invoice extraction: $fileExt (file: $filePath)");
 		return null;
 	}
-	
-	// Track temporary file for cleanup
-	$tempImagePath = null;
-	$fileToProcess = $filePath;
-	
-	// If PDF, convert to image first
-	if ($fileExt === 'pdf') {
-		$tempImagePath = sys_get_temp_dir() . '/invoice_' . uniqid() . '.png';
-		
-		// Try using Imagick PHP extension first
-		if (class_exists('Imagick')) {
-			try {
-				$imagick = new Imagick();
-				$imagick->setResolution(150, 150); // Set resolution before reading
-				$imagick->readImage($filePath . '[0]'); // Read first page only
-				$imagick->setImageFormat('png');
-				$imagick->setImageCompressionQuality(90);
-				$imagick->writeImage($tempImagePath);
-				$imagick->clear();
-				$imagick->destroy();
-				$fileToProcess = $tempImagePath;
-			} catch (Exception $e) {
-				error_log("Imagick PDF conversion failed: " . $e->getMessage());
-				// Fall back to command line
-				$tempImagePath = null;
-			}
-		}
-		
-		// Fall back to ImageMagick command line if Imagick extension not available or failed
-		if ($tempImagePath === null || !file_exists($tempImagePath)) {
-			$tempImagePath = sys_get_temp_dir() . '/invoice_' . uniqid() . '.png';
-			$escapedInput = escapeshellarg($filePath . '[0]');
-			$escapedOutput = escapeshellarg($tempImagePath);
-			$command = "convert -density 150 $escapedInput -quality 90 $escapedOutput 2>&1";
-			exec($command, $output, $returnCode);
-			
-			if ($returnCode !== 0 || !file_exists($tempImagePath)) {
-				error_log("ImageMagick PDF conversion failed. Return code: $returnCode, Output: " . implode("\n", $output));
-				if ($tempImagePath && file_exists($tempImagePath)) {
-					@unlink($tempImagePath);
-				}
-				return null;
-			}
-			$fileToProcess = $tempImagePath;
-		}
-	}
-	
-	// Read file content
-	$fileContent = file_get_contents($fileToProcess);
+
+	$fileContent = file_get_contents($filePath);
 	if ($fileContent === false) {
-		error_log("Failed to read file: $fileToProcess");
-		if ($tempImagePath && file_exists($tempImagePath)) {
-			@unlink($tempImagePath);
-		}
+		error_log("Failed to read file: $filePath");
 		return null;
 	}
-	
-	// Verify file is not empty
 	if (strlen($fileContent) === 0) {
-		error_log("File is empty: $fileToProcess");
-		if ($tempImagePath && file_exists($tempImagePath)) {
-			@unlink($tempImagePath);
-		}
+		error_log("File is empty: $filePath");
 		return null;
 	}
-	
-	// For images (including converted PDFs), verify it's a valid image file using getimagesize
-	if ($fileExt !== 'pdf' || $tempImagePath !== null) {
-		$imageInfo = @getimagesize($fileToProcess);
-		if ($imageInfo === false) {
-			error_log("File is not a valid image: $fileToProcess");
-			if ($tempImagePath && file_exists($tempImagePath)) {
-				@unlink($tempImagePath);
-			}
-			return null;
-		}
+
+	// PDFs are sent unchanged so the extraction service can inspect every page.
+	if ($fileExt !== 'pdf' && @getimagesize($filePath) === false) {
+		error_log("File is not a valid image: $filePath");
+		return null;
 	}
-	
-	// Base64 encode the image content
-	$base64Image = base64_encode($fileContent);
-	
-	// Clean up temporary file now that we have the content
-	if ($tempImagePath && file_exists($tempImagePath)) {
-		@unlink($tempImagePath);
+
+	$apiKey = call_user_func($keyResolver);
+	if (empty($apiKey)) {
+		error_log("Invoice extraction API key is not configured");
+		return null;
 	}
-	
-	// Prepare API request data
+
+	if (empty($invoiceId)) $invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
+
 	$requestData = array(
 		'id' => $invoiceId,
-		'image' => $base64Image,
+		'image' => base64_encode($fileContent),
 		'skip_classification' => true
 	);
-	
-	// Make API call using cURL
-	$ch = curl_init($apiUrl);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	curl_setopt($ch, CURLOPT_POST, true);
-	curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($requestData));
-	curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+	$requestBody = json_encode($requestData);
+	if ($requestBody === false) {
+		error_log("Failed to encode invoice extraction API request");
+		return null;
+	}
+
+	$headers = array(
 		'Content-Type: application/json',
 		'Accept: application/json',
 		'Authorization: Bearer ' . $apiKey
-	));
-	curl_setopt($ch, CURLOPT_TIMEOUT, 30); // 30 second timeout
-	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10); // 10 second connection timeout
-	
-	// Execute request
-	$response = curl_exec($ch);
-	$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	$curlError = curl_error($ch);
-	curl_close($ch);
+	);
+	$options = array('connect_timeout' => 10, 'timeout' => 120);
+	$transportResult = call_user_func($transport, 'https://ai.saldi.dk/extract-invoice', $headers, $requestBody, $options);
 
-	// Check for cURL errors
-	if ($curlError) {
-		error_log("cURL error calling invoice extraction API: $curlError");
+	if (!is_array($transportResult)) {
+		error_log("Invoice extraction API transport returned an invalid result");
 		return null;
 	}
-	
-	// Check HTTP status code
+
+	$response = $transportResult['response'] ?? false;
+	$httpCode = (int) ($transportResult['http_code'] ?? 0);
+	$curlError = $transportResult['error'] ?? '';
+	$curlErrorNo = (int) ($transportResult['errno'] ?? 0);
+	if ($curlError !== '') {
+		if ($curlErrorNo === 28) error_log("Invoice extraction API request timed out: $curlError");
+		else error_log("cURL error calling invoice extraction API: $curlError");
+		return null;
+	}
+
 	if ($httpCode < 200 || $httpCode >= 300) {
-		error_log("Invoice extraction API returned HTTP $httpCode. Response: " . substr($response, 0, 500));
+		error_log("Invoice extraction API returned HTTP $httpCode. Response: " . substr((string) $response, 0, 500));
 		return null;
 	}
-	
-	// Parse JSON response
+
 	$responseData = json_decode($response, true);
 	if (json_last_error() !== JSON_ERROR_NONE) {
 		error_log("Failed to parse JSON response from invoice extraction API: " . json_last_error_msg());
 		return null;
 	}
-	
-	// Check if response indicates success
-	if (isset($responseData['status']) && $responseData['status'] !== 'success') {
-		error_log("Invoice extraction API returned non-success status: " . ($responseData['status'] ?? 'unknown'));
+
+	if (isset($responseData['status']) && !in_array($responseData['status'], array('success', 'partial_success'), true)) {
+		error_log("Invoice extraction API returned non-success status: " . $responseData['status']);
 		return null;
 	}
-	
-	// Extract amount and date from response
+
 	$amount = null;
 	$date = null;
 	$vendor = null;
@@ -218,66 +162,26 @@ function extractInvoiceData($filePath, $invoiceId = null) {
 	$currency = null;
 	if (isset($responseData['extracted_data'])) {
 		$extractedData = $responseData['extracted_data'];
-		
-		// Get total_amount
-		if (isset($extractedData['total_amount'])) {
-			$amount = $extractedData['total_amount'];
-		}
+		if (isset($extractedData['total_amount'])) $amount = $extractedData['total_amount'];
+		if (isset($extractedData['invoice_number'])) $invoiceNumber = $extractedData['invoice_number'];
+		if (isset($extractedData['invoice_description'])) $description = $extractedData['invoice_description'];
 
-		// Get invoice_number
-		if (isset($extractedData['invoice_number'])) {
-			$invoiceNumber = $extractedData['invoice_number'];
-		}
-
-		// Get invoice_description
-		if (isset($extractedData['invoice_description'])) {
-			$description = $extractedData['invoice_description'];
-		}
-		
-		// Get invoice_date
 		if (isset($extractedData['invoice_date'])) {
 			$rawDate = $extractedData['invoice_date'];
-			$date = null;
-			
-			// Try to convert date to YYYY-MM-DD format
-			// Handle DD-MM-YY format first
 			if (preg_match('/^(\d{2})[-\/](\d{2})[-\/](\d{2})$/', $rawDate, $matches)) {
-				$day = $matches[1];
-				$month = $matches[2];
-				$year2digit = $matches[3];
-				$year4digit = '20' . $year2digit;
-				$date = $year4digit . '-' . $month . '-' . $day;
-			}
-			// Handle DD-MM-YYYY format
-			elseif (preg_match('/^(\d{2})[-\/](\d{2})[-\/](\d{4})$/', $rawDate, $matches)) {
-				$day = $matches[1];
-				$month = $matches[2];
-				$year = $matches[3];
-				$date = $year . '-' . $month . '-' . $day;
-			}
-			// Use strtotime for other formats (handles "January 26, 2026", "2026-01-26", etc.)
-			else {
+				$date = '20' . $matches[3] . '-' . $matches[2] . '-' . $matches[1];
+			} elseif (preg_match('/^(\d{2})[-\/](\d{2})[-\/](\d{4})$/', $rawDate, $matches)) {
+				$date = $matches[3] . '-' . $matches[2] . '-' . $matches[1];
+			} else {
 				$timestamp = strtotime($rawDate);
-				if ($timestamp !== false && $timestamp > 0) {
-					$date = date('Y-m-d', $timestamp);
-				} else {
-					$date = $rawDate; // Keep original if parsing fails
-				}
+				$date = $timestamp !== false && $timestamp > 0 ? date('Y-m-d', $timestamp) : $rawDate;
 			}
-		}
-		
-		// Get vendor
-		if (isset($extractedData['vendor'])) {
-			$vendor = $extractedData['vendor'];
 		}
 
-		// Get currency
-		if (isset($extractedData['currency'])) {
-			$currency = $extractedData['currency'];
-		}
+		if (isset($extractedData['vendor'])) $vendor = $extractedData['vendor'];
+		if (isset($extractedData['currency'])) $currency = $extractedData['currency'];
 	}
-	
-	// Return extracted data
+
 	if ($amount !== null || $date !== null || $vendor !== null || $invoiceNumber !== null || $description !== null || $currency !== null) {
 		return array(
 			'amount' => $amount,
@@ -288,8 +192,7 @@ function extractInvoiceData($filePath, $invoiceId = null) {
 			'currency' => $currency
 		);
 	}
-	
-	// No data extracted
+
 	return null;
 }
-
+?>

--- a/tests/test_doc_pool_upload_exactly_once.php
+++ b/tests/test_doc_pool_upload_exactly_once.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Focused regression checks for the drag/drop upload callback in docPool.php.
+ * Run: php tests/test_doc_pool_upload_exactly_once.php
+ */
+
+$passed = 0;
+$failed = 0;
+
+function check($condition, $message) {
+	global $passed, $failed;
+	if ($condition) {
+		$passed++;
+		echo "PASS  $message\n";
+	} else {
+		$failed++;
+		echo "FAIL  $message\n";
+	}
+}
+
+$source = file_get_contents(__DIR__ . '/../includes/docsIncludes/docPool.php');
+$start = strpos($source, 'function uploadFiles(files)');
+$end = strpos($source, "document.addEventListener('DOMContentLoaded'", $start);
+$uploadBlock = $start !== false && $end !== false ? substr($source, $start, $end - $start) : '';
+
+check($uploadBlock !== '', 'isolates the drag/drop upload callback');
+check(strpos($uploadBlock, "const extracted = data.extracted;") !== false, 'reuses extracted data returned by upload');
+check(strpos($uploadBlock, "extractFormData.append('action', 'extract')") === false, 'does not issue a second extract action from upload');
+check(strpos($uploadBlock, "svData.append('action', 'save')") !== false, 'sends the save action');
+check(strpos($uploadBlock, "svData.append('docFolder', '\$docFolder')") !== false, 'forwards docFolder during save');
+check(strpos($uploadBlock, "svData.append('newCurrency', extracted.currency)") !== false, 'forwards extracted currency during save');
+check(strpos($uploadBlock, "svData.append('poolFile', data.filename)") !== false, 'saves using the final upload filename');
+check(strpos($uploadBlock, 'if (!saveResponse.ok)') !== false, 'rejects an unsuccessful metadata save response');
+check(strpos($uploadBlock, 'if (!saveResult.success)') !== false, 'rejects a metadata save error payload');
+check(strpos($uploadBlock, 'uploadedCount++;') > strpos($uploadBlock, 'if (!saveResult.success)'), 'counts upload success only after metadata is saved');
+check(strpos($uploadBlock, 'automatic extraction returned no result; skipping save') !== false, 'logs and skips save when upload returns no extraction result');
+
+echo "\nResults: $passed passed, $failed failed\n";
+exit($failed ? 1 : 0);

--- a/tests/test_invoice_extraction_api.php
+++ b/tests/test_invoice_extraction_api.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Focused tests for includes/docsIncludes/invoiceExtractionApi.php.
+ * Run: php tests/test_invoice_extraction_api.php
+ */
+
+$passed = 0;
+$failed = 0;
+
+function check($condition, $message) {
+	global $passed, $failed;
+	if ($condition) {
+		$passed++;
+		echo "PASS  $message\n";
+	} else {
+		$failed++;
+		echo "FAIL  $message\n";
+	}
+}
+
+function db_select($query, $source, $global = false) {
+	global $dbSelectCalls, $dbSelectResult;
+	$dbSelectCalls[] = array($query, $source, $global);
+	return $dbSelectResult;
+}
+
+function db_fetch_array($query) {
+	return $query;
+}
+
+include __DIR__ . '/../includes/docsIncludes/invoiceExtractionApi.php';
+
+$tempDir = sys_get_temp_dir() . '/saldi_invoice_extraction_' . uniqid();
+mkdir($tempDir);
+$pdfPath = $tempDir . '/invoice.pdf';
+$pdfBytes = "%PDF-1.7\npage-one\fpage-two\n%%EOF";
+file_put_contents($pdfPath, $pdfBytes);
+
+$dbSelectCalls = array();
+$dbSelectResult = array('var_value' => 'global-key');
+check(invoiceExtractionApiResolveApiKey() === 'global-key', 'resolves the global API key');
+check(count($dbSelectCalls) === 1 && $dbSelectCalls[0][2] === true, 'uses db_select global connection');
+check(strpos($dbSelectCalls[0][0], "var_name = 'apikey'") !== false && strpos($dbSelectCalls[0][0], "var_grp = 'app_api'") !== false, 'queries the app_api key setting');
+
+$captured = array();
+$invoiceExtractionApiDependencies = array(
+	'key_resolver' => function () { return 'test-key'; },
+	'transport' => function ($url, $headers, $body, $options) use (&$captured) {
+		$captured = array($url, $headers, json_decode($body, true), $options);
+		return array('response' => json_encode(array(
+			'status' => 'partial_success',
+			'extracted_data' => array('total_amount' => '123.45', 'invoice_date' => '26-01-2026', 'vendor' => 'Acme', 'invoice_number' => 'A-1', 'invoice_description' => 'Widgets', 'currency' => 'DKK')
+		)), 'http_code' => 200, 'error' => '', 'errno' => 0);
+	}
+);
+$result = extractInvoiceData($pdfPath, 'invoice-test');
+check($captured[0] === 'https://ai.saldi.dk/extract-invoice', 'uses the extraction route');
+check(in_array('Authorization: Bearer test-key', $captured[1], true), 'sends bearer authentication');
+check($captured[2]['id'] === 'invoice-test' && $captured[2]['skip_classification'] === true, 'sends required payload fields');
+check(base64_decode($captured[2]['image']) === $pdfBytes, 'passes original multi-page PDF bytes unchanged');
+check($captured[3] === array('connect_timeout' => 10, 'timeout' => 120), 'uses required timeouts');
+check($result === array('amount' => '123.45', 'date' => '2026-01-26', 'vendor' => 'Acme', 'invoiceNumber' => 'A-1', 'description' => 'Widgets', 'currency' => 'DKK'), 'accepts partial success and preserves SALDI fields');
+
+$transportCalls = 0;
+$invoiceExtractionApiDependencies = array(
+	'key_resolver' => function () { return null; },
+	'transport' => function () use (&$transportCalls) { $transportCalls++; return array(); }
+);
+check(extractInvoiceData($pdfPath, 'missing-key') === null && $transportCalls === 0, 'does not call transport without an API key');
+
+foreach (array(
+	'HTTP failure' => array('response' => 'gateway unavailable', 'http_code' => 503, 'error' => '', 'errno' => 0),
+	'transport failure' => array('response' => false, 'http_code' => 0, 'error' => 'Could not resolve host', 'errno' => 6),
+	'timeout' => array('response' => false, 'http_code' => 0, 'error' => 'Operation timed out', 'errno' => 28)
+) as $label => $transportResult) {
+	$invoiceExtractionApiDependencies = array(
+		'key_resolver' => function () { return 'test-key'; },
+		'transport' => function () use ($transportResult) { return $transportResult; }
+	);
+	check(extractInvoiceData($pdfPath, 'failure-test') === null, "returns null for $label");
+}
+
+unset($invoiceExtractionApiDependencies);
+unlink($pdfPath);
+rmdir($tempDir);
+
+echo "\nResults: $passed passed, $failed failed\n";
+exit($failed ? 1 : 0);


### PR DESCRIPTION
## Summary

- point SALDI at the deployed `/extract-invoice` route and preserve the active tenant connection while reading the global API key
- send original multi-page PDFs, allow 120 seconds for OCR, and consume usable `partial_success` responses
- reuse the upload response instead of performing OCR twice, while validating metadata persistence and preserving currency
- add dependency-free regression tests for the HTTP contract and exactly-once upload flow

## Root cause

SALDI posted to `https://ai.saldi.dk/invoice-extraction`, which currently returns 404 in production. The deployed compatibility route is `https://ai.saldi.dk/extract-invoice`.

## Validation

- `php -l includes/docsIncludes/invoiceExtractionApi.php`
- `php -l includes/docsIncludes/docPool.php`
- `php -l includes/docsIncludes/extractInvoiceHandler.php`
- `php tests/test_invoice_extraction_api.php` — 13 passed
- `php tests/test_doc_pool_upload_exactly_once.php` — 11 passed
- live unauthenticated route probe: `/extract-invoice` reaches authentication (401); `/invoice-extraction` returns 404
- fresh review completed; metadata-save failure handling was tightened and re-reviewed with no remaining findings

Authenticated SALDI UI validation was not run because no production credential was exposed to the test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)