### PR TITLE
Fix VAT and debtor group REST endpoints

### DIFF
--- a/restapi/endpoints/v1/debitor/groups/index.php
+++ b/restapi/endpoints/v1/debitor/groups/index.php
@@ -1,0 +1,62 @@
+<?php
+// 20260715 CL/PHR Added read-only current-year debtor group endpoint.
+
+require_once __DIR__ . '/../../../../core/BaseEndpoint.php';
+
+class DebtorGroupsEndpoint extends BaseEndpoint
+{
+    protected function handleGet($id = null)
+    {
+        $q = db_select(
+            "SELECT kodenr FROM grupper WHERE art = 'RA' ORDER BY kodenr DESC LIMIT 1",
+            __FILE__ . " linje " . __LINE__
+        );
+        $yearRow = db_fetch_array($q);
+        if (!$yearRow) {
+            $this->sendResponse(false, null, 'Current fiscal year not found', 404);
+            return;
+        }
+
+        $fiscalYear = intval($yearRow['kodenr']);
+        $qtxt = "SELECT id, kodenr, beskrivelse, box1, box3, box4, box5, box7, box8, box9 "
+            . "FROM grupper WHERE art = 'DG' AND fiscal_year = '$fiscalYear' ORDER BY kodenr";
+        $q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
+
+        $groups = [];
+        while ($row = db_fetch_array($q)) {
+            $groups[] = [
+                'id' => intval($row['id']),
+                'number' => intval($row['kodenr']),
+                'description' => $row['beskrivelse'],
+                'vatGroup' => $row['box1'],
+                'currency' => $row['box3'],
+                'language' => $row['box4'],
+                'contraAccount' => $row['box5'],
+                'commissionPercentage' => $row['box7'],
+                'b2b' => $row['box8'] === 'on',
+                'reversePayment' => $row['box9'] === 'on',
+                'fiscalYear' => $fiscalYear,
+            ];
+        }
+
+        $this->sendResponse(true, $groups);
+    }
+
+    protected function handlePost($data)
+    {
+        $this->sendResponse(false, null, 'POST method not supported', 405);
+    }
+
+    protected function handlePut($data)
+    {
+        $this->sendResponse(false, null, 'PUT method not supported', 405);
+    }
+
+    protected function handleDelete($data)
+    {
+        $this->sendResponse(false, null, 'DELETE method not supported', 405);
+    }
+}
+
+$endpoint = new DebtorGroupsEndpoint();
+$endpoint->handleRequestMethod();

--- a/restapi/endpoints/v1/vat/index.php
+++ b/restapi/endpoints/v1/vat/index.php
@@ -1,53 +1,76 @@
 <?php
-/**
- * GET /vat-codes
- * Get list of VAT codes (momskoder)
- */
+// 20260715 CL/PHR Restored fiscal-year VAT retrieval through VatModel.
 
+require_once __DIR__ . '/../../../models/finans/VatModel.php';
 require_once __DIR__ . '/../../../core/BaseEndpoint.php';
-require_once __DIR__ . '/../../../core/JWT.php';
-require_once __DIR__ . '/../../../core/JWTAuth.php';
-require_once __DIR__ . '/../../../core/logging.php';
 
-include_once __DIR__ . '/../../../../includes/db_query.php';
-include_once __DIR__ . '/../../../../includes/connect.php';
-
-class VatCodesEndpoint extends BaseEndpoint
+class VatEndpoint extends BaseEndpoint
 {
-    private $db;
-    
-    public function __construct()
+    private function mapEnglishToDanish($field)
     {
-        parent::__construct();
+        $fieldMap = [
+            'description' => 'beskrivelse',
+            'vatCode' => 'kode',
+            'number' => 'kodenr',
+            'fiscalYear' => 'fiscal_year',
+        ];
+
+        return $fieldMap[$field] ?? $field;
     }
-    
 
     protected function handleGet($id = null)
     {
+        $vatCode = $_GET['vatcode'] ?? null;
 
-        
-        // Get VAT codes from grupper table where art = 'S' (momssatser)
-        $qtxt = "SELECT kodenr, box1 as rate, box2 as description FROM grupper WHERE art = 'S' ORDER BY kodenr";
-        $q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
-        
-        $vatCodes = [];
-        while ($r = db_fetch_array($q)) {
-            $vatCodes[] = [
-                'code' => (int)$r['kodenr'],
-                'rate' => (float)$r['rate'],
-                'description' => $r['description']
-            ];
+        if ($id) {
+            $vatItem = new VatModel(intval($id));
+            if (!$vatItem->getId()) {
+                $this->sendResponse(false, null, 'VAT item not found', 404);
+                return;
+            }
+            $this->sendResponse(true, $vatItem->toArray());
+            return;
         }
-        
-        $this->sendResponse(true, $vatCodes);
+
+        if ($vatCode) {
+            $vatItems = VatModel::loadFromVatcode(db_escape_string($vatCode));
+        } else {
+            $orderBy = $this->mapEnglishToDanish($_GET['orderBy'] ?? 'number');
+            $orderDirection = $_GET['orderDirection'] ?? 'ASC';
+            $field = isset($_GET['field']) ? $this->mapEnglishToDanish($_GET['field']) : null;
+            $value = $_GET['value'] ?? null;
+
+            $vatItems = $field && $value !== null
+                ? VatModel::findBy($field, db_escape_string($value))
+                : VatModel::getAllItems($orderBy, $orderDirection);
+        }
+
+        $items = [];
+        foreach ($vatItems as $vatItem) {
+            $items[] = $vatItem->toArray();
+        }
+        $limit = intval($_GET['limit'] ?? 50);
+        if ($limit < 1 || $limit > 200) {
+            $limit = 50;
+        }
+        $this->sendResponse(true, array_slice($items, 0, $limit));
     }
-    
+
     protected function handlePost($data)
     {
         $this->sendResponse(false, null, 'POST method not supported', 405);
     }
+
+    protected function handlePut($data)
+    {
+        $this->sendResponse(false, null, 'PUT method not supported', 405);
+    }
+
+    protected function handleDelete($data)
+    {
+        $this->sendResponse(false, null, 'DELETE method not supported', 405);
+    }
 }
 
-$endpoint = new VatCodesEndpoint();
+$endpoint = new VatEndpoint();
 $endpoint->handleRequestMethod();
-

--- a/restapi/swagger.yaml
+++ b/restapi/swagger.yaml
@@ -997,6 +997,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  # Debtor Groups
+  /debitor/groups/:
+    get:
+      tags:
+        - Debtor Groups
+      summary: Get current fiscal year's debtor groups
+      responses:
+        '200':
+          description: List of debtor groups
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DebtorGroupResponse'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   # Customers (Debitors)
   /debitor/customers/:
     get:
@@ -4194,6 +4223,32 @@ components:
         art:
           type: string
           example: "D"
+
+    DebtorGroupResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        number:
+          type: integer
+        description:
+          type: string
+        vatGroup:
+          type: string
+        currency:
+          type: string
+        language:
+          type: string
+        contraAccount:
+          type: string
+        commissionPercentage:
+          type: string
+        b2b:
+          type: boolean
+        reversePayment:
+          type: boolean
+        fiscalYear:
+          type: integer
 
     CustomerListResponse:
       type: object


### PR DESCRIPTION
## Summary
- restore fiscal-year VAT retrieval through the existing VatModel
- add the missing read-only debtor groups endpoint for the current fiscal year
- document the debtor groups response in the OpenAPI specification

## Problem
- GET /restapi/endpoints/v1/vat/ returned HTTP 500 after querying the wrong grupper art
- GET /restapi/endpoints/v1/debitor/groups/ returned 404 because no index.php existed

## Validation
- php -l restapi/endpoints/v1/vat/index.php
- php -l restapi/endpoints/v1/debitor/groups/index.php
- parsed restapi/swagger.yaml successfully
- git diff --check

Only the three REST API/OpenAPI files are included; unrelated local changes were excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)