### PR TITLE
Add usdecimal_strict(): validating parser alongside legacy usdecimal() (factory ticket 0013)

### DIFF
--- a/includes/usdecimal.php
+++ b/includes/usdecimal.php
@@ -29,4 +29,15 @@ if (!function_exists('usdecimal'))
     return $tal;
   }
 }
+
+if (!function_exists('usdecimal_strict'))
+{
+  function usdecimal_strict(string $amount): float
+  {
+    if (substr_count($amount, ".") === 1 && strpos($amount, ",") === false && preg_match('/\.\d{2}$/', $amount)) {
+      throw new InvalidArgumentException("Ambiguous decimal amount: $amount");
+    }
+    return usdecimal($amount);
+  }
+}
 ?>

--- a/includes/usdecimal.test.php
+++ b/includes/usdecimal.test.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/usdecimal.php';
+
+final class usdecimal extends TestCase
+{
+    public function testStrictParserHasTheRequiredSignature(): void
+    {
+        self::assertTrue(function_exists('usdecimal_strict'));
+
+        $function = new ReflectionFunction('usdecimal_strict');
+        $parameters = $function->getParameters();
+
+        self::assertCount(1, $parameters);
+        self::assertSame('amount', $parameters[0]->getName());
+        self::assertSame('string', (string) $parameters[0]->getType());
+        self::assertSame('float', (string) $function->getReturnType());
+    }
+
+    /**
+     * @return array<string, array{string, float}>
+     */
+    public static function unambiguousDanishAmounts(): array
+    {
+        return [
+            'thousands and decimals' => ['1.234,56', 1234.56],
+            'plain integer'          => ['100', 100.0],
+            'decimal comma'          => ['12,34', 12.34],
+            'thousands only'         => ['1.234', 1234.0],
+        ];
+    }
+
+    #[DataProvider('unambiguousDanishAmounts')]
+    public function testStrictParserMatchesLegacyParserForUnambiguousDanishInput(
+        string $amount,
+        float $expected
+    ): void {
+        self::assertTrue(function_exists('usdecimal_strict'));
+        self::assertSame($expected, usdecimal($amount));
+        self::assertSame(usdecimal($amount), usdecimal_strict($amount));
+    }
+
+    /**
+     * @return array<string, array{string, float}>
+     */
+    public static function ambiguousUsDecimalAmounts(): array
+    {
+        return [
+            'ticket example' => ['1234.56', 123456.0],
+            'two digits before separator' => ['12.34', 1234.0],
+            'one digit before separator' => ['1.23', 123.0],
+            'negative amount' => ['-12.34', -1234.0],
+        ];
+    }
+
+    #[DataProvider('ambiguousUsDecimalAmounts')]
+    public function testStrictParserRejectsSingleDotFollowedByExactlyTwoDigits(
+        string $amount,
+        float $legacyResult
+    ): void {
+        self::assertSame($legacyResult, usdecimal($amount));
+        self::assertTrue(function_exists('usdecimal_strict'));
+
+        $this->expectException(InvalidArgumentException::class);
+        usdecimal_strict($amount);
+    }
+
+    public function testLegacyParserSignatureRemainsUnchanged(): void
+    {
+        $function = new ReflectionFunction('usdecimal');
+        $parameters = $function->getParameters();
+
+        self::assertCount(1, $parameters);
+        self::assertSame('tal', $parameters[0]->getName());
+        self::assertNull($parameters[0]->getType());
+        self::assertNull($function->getReturnType());
+    }
+
+    /**
+     * @return array<string, array{mixed, mixed}>
+     */
+    public static function legacyOutputs(): array
+    {
+        return [
+            'Danish amount'       => ['1.234,56', 1234.56],
+            'US decimal foot-gun' => ['1234.56', 123456.0],
+            'zero string'         => ['0', '0.00'],
+            'integer input'       => [7, 7.0],
+        ];
+    }
+
+    #[DataProvider('legacyOutputs')]
+    public function testLegacyParserOutputsRemainUnchanged(mixed $amount, mixed $expected): void
+    {
+        self::assertSame($expected, usdecimal($amount));
+    }
+}


### PR DESCRIPTION
First change produced end-to-end by the software factory's autonomous loop, on the one module that has a golden-master characterization suite.

## What it adds

`usdecimal_strict(string $amount): float` in `includes/usdecimal.php` - identical to `usdecimal()` for unambiguous Danish-format input, but **throws `InvalidArgumentException`** for ambiguous US-format input that the legacy parser silently misparses (`'1234.56'` -> `123456.0`). Nothing calls it yet; it is opt-in for future call sites.

**No existing function was touched** - and that is machine-proven, not promised: the 26-test characterization suite that pins `usdecimal()`'s current behavior still passes byte-identically.

## How it was produced (the factory loop)

1. Ticket `0013` written against the characterized module -> delivery-mode engine granted `auto_implement` (coverage, never urgency, decides this)
2. Test-author role (fresh context, spec only) wrote `includes/usdecimal.test.php` FIRST: 14 tests, red (9 failures)
3. Implementer agent made them green without touching the characterization baseline
4. Five-gate run: phpcs, php -l, test-ratchet, PHPUnit (acceptance 14/14 + characterization 26/26), Playwright execution proof against the live sandbox - all green
5. Human merge gate: **this PR - the decision is yours**

The advisory reviewer below should post its comment on this PR's real PHP diff shortly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict decimal parsing that accepts unambiguous amounts and rejects potentially ambiguous US-style decimals with an error.
  * Preserved the existing decimal parser and its behavior for compatibility.

* **Tests**
  * Added coverage for strict parsing, legacy parsing, supported formats, error handling, and signature compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->