### PR TITLE
Add atomic external paid invoice API

### DIFF
--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -23,6 +23,7 @@
 //
 // Copyright (c) 2003-2026 Saldi.dk ApS
 // ----------------------------------------------------------------------
+// 20260716 CL/PHR Added unique Stripe paid-invoice import key.
 
 
 
@@ -57,6 +58,12 @@ db_modify("CREATE INDEX IF NOT EXISTS kontoplan_kontonr_regnskabsaar_idx ON kont
 # primary key, so every item forced a full table scan of kostpriser to find its latest price -
 # on a large item report this is the same "no index on the hot per-row lookup" issue as above.
 db_modify("CREATE INDEX IF NOT EXISTS kostpriser_vare_id_transdate_idx ON kostpriser (vare_id, transdate)",__FILE__ . " linje " . __LINE__);
+
+$qtxt = "SELECT indexname FROM pg_indexes WHERE tablename = 'ordrer' AND indexname = 'ordrer_stripe_paid_invoice_uidx'";
+if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+	$qtxt = "CREATE UNIQUE INDEX ordrer_stripe_paid_invoice_uidx ON ordrer (kundeordnr) WHERE art = 'DO' AND shop_status = 'stripe_paid_bridge'";
+	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+}
 
 #####
 

--- a/includes/ordrefunc.php
+++ b/includes/ordrefunc.php
@@ -100,6 +100,7 @@
 // 20260618 Sawaneh Stock warning popup now triggers when sale quantity would leave stock below min_lager
 // 20260619 Sawaneh check_stock_warning reads stock from lagerstatus (sum across warehouses) like the order-line red-highlight, not the drifting varer.beholdning field
 // 20260630 CDX/PK Changed the cleanup so that negative lines are only deleted if there is also at least one normal line (item no. >= 0) on the same order.
+// 20260716 CL/PHR Passed caller-owned transactions through invoice numbering for atomic imports.
 
 function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 	/* echo "<!--function levering start-->"; */
@@ -1145,7 +1146,7 @@ function samlevare($id, $art, $linje_id, $v_id, $leveres)
 	#exit;
 } # endfunc samlevare
 ###############################################################
-function bogfor($id, $webservice=false)
+function bogfor($id, $webservice=false, $genfakt=false, $callerOwnsTransaction=false)
 {
 	/* print "<!--function bogfor start-->"; */
 
@@ -1437,7 +1438,7 @@ function bogfor($id, $webservice=false)
 		if ($art != "PO") {
 			// Generate unique invoice number using the thread-safe function
 			// Note: get_next_invoice_number now also sets fakturanr on the order atomically
-			$fakturanr = get_next_invoice_number($art, $id);
+			$fakturanr = get_next_invoice_number($art, $id, $callerOwnsTransaction);
 			$ny_id = array();
 			$x = 0;
 			$q = db_select("select * from ordrelinjer where pris != '0' and m_rabat != '0' and rabat = '0' and ordre_id='$id'", __FILE__ . " linje " . __LINE__);

--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -59,6 +59,7 @@
 // -------- As well as adding the ability to check for object properties if you pass an object instead of an array and the key is a string, so you can do if_isset($object, $default, 'property') to check for $object->property
 // -------- And changed it to treat boolean falses as "set" so the value it returned the value instead of a hardcoded null.
 // 20260604 CL/PHR cvrnr_land/cvrnr_omr: added $baseCountry param — single-letter+digit CVR (NIF) treated as domestic; home country configurable via settings.baseCountry
+// 20260716 CL/PHR Added caller-owned transaction support to order and invoice numbering.
 
 include(__DIR__ . '/stdFunc/dkDecimal.php');
 include(__DIR__ . '/stdFunc/nrCast.php');
@@ -2108,14 +2109,15 @@ if (!function_exists('get_next_number')) {
 }
 
 if (!function_exists('get_next_order_number')) {
-	function get_next_order_number($art = 'DO')
+	function get_next_order_number($art = 'DO', $callerOwnsTransaction = false)
 	{
 		/**
 		 * Generates the next available order number (ordrenr) for a given 'art' (type).
 		 * Uses database transactions and table locking to prevent race conditions and duplicate numbers.
 		 * 
 		 * @param string $art - The order type ('DO', 'DK', 'KO', 'KK', 'PO', etc.)
-		 * 
+		 * @param bool $callerOwnsTransaction - Skip transaction control when the caller owns it.
+		 *
 		 * @return int - The next available order number.
 		 * @throws Exception - If unable to generate unique order number after maximum attempts.
 		 */
@@ -2126,7 +2128,9 @@ if (!function_exists('get_next_order_number')) {
 		$ordrenr = null;
 
 		// Start transaction to ensure atomicity
-		transaktion('begin');
+		if (!$callerOwnsTransaction) {
+			transaktion('begin');
+		}
 		try {
 			while ($attempt < $max_attempts) {
 				$attempt++;
@@ -2163,7 +2167,9 @@ if (!function_exists('get_next_order_number')) {
 				
 				if (!$check_r || !$check_r['id']) {
 					// Order number is unique, commit transaction and return
-					transaktion('commit');
+					if (!$callerOwnsTransaction) {
+						transaktion('commit');
+					}
 					return $ordrenr;
 				} else {
 					// Order number already exists (shouldn't happen with proper locking)
@@ -2175,11 +2181,15 @@ if (!function_exists('get_next_order_number')) {
 			}
 			
 			// If we get here, we couldn't generate a unique number
-			transaktion('rollback');
+			if (!$callerOwnsTransaction) {
+				transaktion('rollback');
+			}
 			throw new Exception("Could not generate unique order number after $max_attempts attempts");
-			
+
 		} catch (Exception $e) {
-			transaktion('rollback');
+			if (!$callerOwnsTransaction) {
+				transaktion('rollback');
+			}
 			throw $e;
 		}
 	}
@@ -2187,7 +2197,7 @@ if (!function_exists('get_next_order_number')) {
 
 //                   ----------------------------- get_next_invoice_number ------------------------------
 if (!function_exists('get_next_invoice_number')) {
-	function get_next_invoice_number($art = 'DO', $id = null)
+	function get_next_invoice_number($art = 'DO', $id = null, $callerOwnsTransaction = false)
 	{
 		/**
 		 * Generates the next available invoice number (fakturanr) for a given 'art' (type).
@@ -2196,7 +2206,8 @@ if (!function_exists('get_next_invoice_number')) {
 		 * 
 		 * @param string $art - The order type ('DO', 'DK', 'PO', etc.)
 		 * @param int $id - The order ID to exclude from checks (optional)
-		 * 
+		 * @param bool $callerOwnsTransaction - Skip transaction control when the caller owns it.
+		 *
 		 * @return int - The next available invoice number.
 		 * @throws Exception - If unable to generate unique invoice number after maximum attempts.
 		 */
@@ -2241,7 +2252,9 @@ if (!function_exists('get_next_invoice_number')) {
 				if ($debug) echo "<pre>  Attempt $attempt/$max_attempts</pre>";
 
 				// Start a fresh transaction for each attempt
-				transaktion('begin');
+				if (!$callerOwnsTransaction) {
+					transaktion('begin');
+				}
 
 				// Lock the ordrer table to prevent concurrent access
 				global $connection;
@@ -2249,6 +2262,9 @@ if (!function_exists('get_next_invoice_number')) {
 				if (!$lock_result) {
 					$err = pg_last_error($connection);
 					if ($debug) echo "<pre>  LOCK failed: $err — rollback and retry</pre>";
+					if ($callerOwnsTransaction) {
+						throw new Exception("Could not lock orders for invoice numbering: $err");
+					}
 					transaktion('rollback');
 					usleep(rand(50000, 200000));
 					continue;
@@ -2265,6 +2281,9 @@ if (!function_exists('get_next_invoice_number')) {
 				if (!$r) {
 					$err = pg_last_error($connection);
 					if ($debug) echo "<pre>  SELECT MAX failed: $err — rollback and retry</pre>";
+					if ($callerOwnsTransaction) {
+						throw new Exception("Could not read invoice numbering: $err");
+					}
 					transaktion('rollback');
 					usleep(rand(50000, 200000));
 					continue;
@@ -2296,11 +2315,16 @@ if (!function_exists('get_next_invoice_number')) {
 					}
 
 					// Invoice number is unique, commit transaction and return
-					transaktion('commit');
+					if (!$callerOwnsTransaction) {
+						transaktion('commit');
+					}
 					if ($debug) echo "<pre>  OK — returning fakturanr=$fakturanr (attempt $attempt)</pre>";
 					return $fakturanr;
 				} else {
 					if ($debug) echo "<pre>  Duplicate! fakturanr=$fakturanr already on order id=" . $check_r['id'] . " — rollback and retry</pre>";
+					if ($callerOwnsTransaction) {
+						throw new Exception("Invoice number $fakturanr is already in use");
+					}
 					transaktion('rollback');
 					usleep(rand(10000, 50000));
 				}
@@ -2311,7 +2335,9 @@ if (!function_exists('get_next_invoice_number')) {
 			throw new Exception("Could not generate unique invoice number after $max_attempts attempts");
 
 		} catch (Exception $e) {
-			transaktion('rollback');
+			if (!$callerOwnsTransaction) {
+				transaktion('rollback');
+			}
 			if ($debug) echo "<pre>  EXCEPTION: " . $e->getMessage() . "</pre>";
 			throw $e;
 		}

--- a/restapi/endpoints/v1/debitor/external-paid-invoices/index.php
+++ b/restapi/endpoints/v1/debitor/external-paid-invoices/index.php
@@ -1,0 +1,66 @@
+<?php
+// 20260716 CL/PHR Added Stripe paid-invoice import endpoint.
+
+require_once __DIR__ . '/../../../../core/BaseEndpoint.php';
+require_once __DIR__ . '/../../../../services/ExternalPaidInvoiceImportService.php';
+include_once __DIR__ . '/../../../../../includes/ordrefunc.php';
+
+class ExternalPaidInvoicesEndpoint extends BaseEndpoint
+{
+    private $service;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->service = new ExternalPaidInvoiceImportService();
+    }
+
+    protected function handlePost($data)
+    {
+        if ($data === null) {
+            $this->sendResponse(false, null, 'Request body must be valid JSON', 400);
+            return;
+        }
+
+        $bufferLevel = ob_get_level();
+        ob_start();
+
+        try {
+            $result = $this->service->import($data, $this->username);
+        } finally {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+        }
+
+        $statusCode = $result['idempotent'] ? 200 : 201;
+        $message = $result['idempotent']
+            ? 'External paid invoice already imported'
+            : 'External paid invoice imported successfully';
+
+        $this->sendResponse(true, $result, $message, $statusCode);
+    }
+
+    protected function handleGet($id = null)
+    {
+        $this->sendResponse(false, null, 'GET method is not supported for external paid invoices', 405);
+    }
+
+    protected function handlePut($data)
+    {
+        $this->sendResponse(false, null, 'PUT method is not supported for external paid invoices', 405);
+    }
+
+    protected function handleDelete($data)
+    {
+        $this->sendResponse(false, null, 'DELETE method is not supported for external paid invoices', 405);
+    }
+
+    protected function handlePatch($data)
+    {
+        $this->sendResponse(false, null, 'PATCH method is not supported for external paid invoices', 405);
+    }
+}
+
+$endpoint = new ExternalPaidInvoicesEndpoint();
+$endpoint->handleRequestMethod();

--- a/restapi/services/ExternalPaidInvoiceImportService.php
+++ b/restapi/services/ExternalPaidInvoiceImportService.php
@@ -1,0 +1,967 @@
+<?php
+// 20260716 CL/PHR Added atomic, idempotent Stripe paid-invoice import service.
+
+require_once __DIR__ . '/../core/ApiException.php';
+
+class ExternalPaidInvoiceImportService
+{
+    const IMPORT_MARKER = 'stripe_paid_bridge';
+    const CARD_PAYMENT_TERM = 'Kreditkort';
+
+    public function import($request, $username)
+    {
+        $payload = $this->validatePayload($request);
+        $transactionOpen = false;
+
+        try {
+            $this->prepareLegacyGlobals($payload, $username);
+
+            $regnaar = $this->resolveFiscalYear($payload['invoiceDate']);
+            $GLOBALS['regnaar'] = $regnaar;
+
+            $baseCurrency = strtoupper($this->getSettingValue('baseCurrency', 'DKK'));
+            if ($baseCurrency !== 'DKK') {
+                throw new ApiException('The Stripe paid-invoice bridge only supports databases with DKK as baseCurrency', 422);
+            }
+
+            $cardClearingAccount = $this->requireCardClearingAccount($regnaar);
+            $debtorGroup = $this->requireDebtorGroup($payload['customer']['groupCode'], $regnaar);
+            $preparedLines = $this->prepareLines($payload['lines'], $regnaar);
+
+            transaktion('begin');
+            $transactionOpen = true;
+            $this->lockImportTables();
+
+            $existingOrders = $this->findExistingImports($payload['externalInvoiceId']);
+            if (count($existingOrders) > 1) {
+                throw new ApiException('externalInvoiceId is associated with multiple imported invoices', 409);
+            }
+            if (count($existingOrders) === 1) {
+                $existingOrder = $existingOrders[0];
+                if ((string) $existingOrder['betalings_id'] !== $payload['payloadHash']) {
+                    throw new ApiException('externalInvoiceId is already imported with a different payloadHash', 409);
+                }
+
+                $result = $this->buildPostedResponse((int) $existingOrder['id'], $payload, $cardClearingAccount, true);
+                transaktion('rollback');
+                $transactionOpen = false;
+
+                return $result;
+            }
+
+            $debtor = $this->findOrCreateDebtor($payload['customer'], $debtorGroup, $username);
+            $orderId = $this->createDraftOrder($payload, $debtor, $preparedLines['headerVatRate'], $username);
+
+            $this->insertOrderLines($orderId, $preparedLines['lines']);
+            $this->reconcileDraftTotals($orderId, $payload, $preparedLines['lines']);
+            $this->deliverAndPost($orderId);
+
+            $result = $this->buildPostedResponse($orderId, $payload, $cardClearingAccount, false);
+
+            transaktion('commit');
+            $transactionOpen = false;
+
+            return $result;
+        } catch (ApiException $exception) {
+            if ($transactionOpen) {
+                transaktion('rollback');
+            }
+            throw $exception;
+        } catch (Exception $exception) {
+            if ($transactionOpen) {
+                transaktion('rollback');
+            }
+            throw new ApiException('Stripe invoice import failed: ' . $exception->getMessage(), 500);
+        }
+    }
+
+    public function validatePayload($request)
+    {
+        $payload = $this->normalizeValue($request);
+        if (!is_array($payload)) {
+            throw new ApiException('Request body must be a JSON object', 400);
+        }
+
+        $this->rejectForbiddenKeys($payload);
+
+        $externalInvoiceId = $this->requireString($payload, 'externalInvoiceId');
+        if (!preg_match('/^in_[A-Za-z0-9]+$/', $externalInvoiceId)) {
+            throw new ApiException('externalInvoiceId must be a Stripe invoice id starting with in_', 422);
+        }
+
+        $payloadHash = $this->requireString($payload, 'payloadHash');
+        if (!preg_match('/^[A-Za-z0-9._:-]{8,128}$/', $payloadHash)) {
+            throw new ApiException('payloadHash must be 8-128 characters and only contain letters, digits, dot, underscore, colon or hyphen', 422);
+        }
+
+        $invoiceDate = $this->requireDate($payload, 'invoiceDate');
+        $currency = strtoupper($this->requireString($payload, 'currency'));
+        if ($currency !== 'DKK') {
+            throw new ApiException('Only DKK invoices are supported', 422);
+        }
+
+        $totals = $this->requireArray($payload, 'totals');
+        $netOre = $this->requireIntegerField($totals, 'netOre', true);
+        $vatOre = $this->requireIntegerField($totals, 'vatOre', false);
+        $grossOre = $this->requireIntegerField($totals, 'grossOre', true);
+        if ($grossOre !== $netOre + $vatOre) {
+            throw new ApiException('Invoice grossOre must equal netOre + vatOre', 422);
+        }
+
+        $customer = $this->requireArray($payload, 'customer');
+        $normalizedCustomer = $this->normalizeCustomer($customer);
+
+        $lines = $this->requireLines($payload);
+        $normalizedLines = array();
+        $lineNetOre = 0;
+        $lineVatOre = 0;
+        $lineGrossOre = 0;
+
+        for ($index = 0; $index < count($lines); $index++) {
+            $normalizedLine = $this->normalizeLine($lines[$index], $index + 1);
+            $this->deriveSupportedVatRate($normalizedLine['netOre'], $normalizedLine['vatOre'], 'lines[' . $index . ']');
+            $normalizedLines[] = $normalizedLine;
+            $lineNetOre += $normalizedLine['netOre'];
+            $lineVatOre += $normalizedLine['vatOre'];
+            $lineGrossOre += $normalizedLine['grossOre'];
+        }
+
+        if ($lineNetOre !== $netOre || $lineVatOre !== $vatOre || $lineGrossOre !== $grossOre) {
+            throw new ApiException('Invoice totals must reconcile exactly with the provided lines', 422);
+        }
+
+        return array(
+            'externalInvoiceId' => $externalInvoiceId,
+            'payloadHash' => $payloadHash,
+            'invoiceDate' => $invoiceDate,
+            'currency' => $currency,
+            'totals' => array(
+                'netOre' => $netOre,
+                'vatOre' => $vatOre,
+                'grossOre' => $grossOre,
+            ),
+            'customer' => $normalizedCustomer,
+            'lines' => $normalizedLines,
+        );
+    }
+
+    private function normalizeValue($value)
+    {
+        if (is_object($value)) {
+            $value = get_object_vars($value);
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $normalized = array();
+        foreach ($value as $key => $item) {
+            $normalized[$key] = $this->normalizeValue($item);
+        }
+
+        return $normalized;
+    }
+
+    private function rejectForbiddenKeys($value)
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $item) {
+            $normalizedKey = strtolower((string) $key);
+            if (in_array($normalizedKey, array('ean', 'eannumber', 'institution', 'oioubl', 'oio_ubl', 'oioublprofileid', 'endpointid'), true)) {
+                throw new ApiException('EAN and OIOUBL fields are not accepted by this endpoint', 422);
+            }
+            $this->rejectForbiddenKeys($item);
+        }
+    }
+
+    private function normalizeCustomer($customer)
+    {
+        $companyName = $this->optionalString($customer, 'companyName');
+        $contactName = $this->optionalString($customer, 'contactName');
+        if ($companyName === '' && $contactName === '') {
+            throw new ApiException('customer.companyName or customer.contactName is required', 422);
+        }
+
+        $cvr = preg_replace('/\s+/', '', $this->requireString($customer, 'cvr'));
+        if (!preg_match('/^[0-9]{8}$/', $cvr)) {
+            throw new ApiException('customer.cvr must be an 8-digit Danish CVR number', 422);
+        }
+
+        $email = $this->optionalString($customer, 'email');
+        if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new ApiException('customer.email must be a valid email address when provided', 422);
+        }
+
+        $phone = $this->optionalString($customer, 'phone');
+        $groupCode = $this->requireIntegerField($customer, 'groupCode', true);
+
+        return array(
+            'companyName' => $companyName,
+            'contactName' => $contactName,
+            'address1' => $this->requireString($customer, 'address1'),
+            'address2' => $this->optionalString($customer, 'address2'),
+            'postalCode' => $this->requireString($customer, 'postalCode'),
+            'city' => $this->requireString($customer, 'city'),
+            'country' => $this->requireString($customer, 'country'),
+            'cvr' => $cvr,
+            'email' => $email,
+            'phone' => $phone,
+            'groupCode' => $groupCode,
+        );
+    }
+
+    private function requireLines($payload)
+    {
+        if (!isset($payload['lines']) || !is_array($payload['lines']) || count($payload['lines']) === 0) {
+            throw new ApiException('At least one invoice line is required', 422);
+        }
+
+        return array_values($payload['lines']);
+    }
+
+    private function normalizeLine($line, $position)
+    {
+        if (!is_array($line)) {
+            throw new ApiException('lines[' . ($position - 1) . '] must be an object', 422);
+        }
+
+        $sku = $this->requireString($line, 'sku');
+        $quantityInfo = $this->normalizeQuantity($line, 'quantity');
+        $netOre = $this->requireIntegerField($line, 'netOre', true);
+        $vatOre = $this->requireIntegerField($line, 'vatOre', false);
+        $grossOre = $this->requireIntegerField($line, 'grossOre', true);
+
+        if ($grossOre !== $netOre + $vatOre) {
+            throw new ApiException('lines[' . ($position - 1) . '].grossOre must equal netOre + vatOre', 422);
+        }
+
+        return array(
+            'position' => $position,
+            'sku' => $sku,
+            'description' => $this->optionalString($line, 'description'),
+            'quantity' => $quantityInfo['string'],
+            'quantityMilli' => $quantityInfo['milli'],
+            'netOre' => $netOre,
+            'vatOre' => $vatOre,
+            'grossOre' => $grossOre,
+        );
+    }
+    private function normalizeQuantity($data, $field)
+    {
+        if (!array_key_exists($field, $data)) {
+            throw new ApiException($field . ' is required', 422);
+        }
+
+        $value = $data[$field];
+        if (is_int($value)) {
+            $quantity = (string) $value;
+        } elseif (is_float($value)) {
+            if (!is_finite($value) || $value <= 0) {
+                throw new ApiException($field . ' must be a positive finite quantity', 422);
+            }
+            if (abs(round($value, 3) - $value) > 0.0000001) {
+                throw new ApiException($field . ' may have at most three decimals', 422);
+            }
+            $quantity = number_format(round($value, 3), 3, '.', '');
+        } elseif (is_string($value)) {
+            $quantity = trim($value);
+        } else {
+            throw new ApiException($field . ' must be a positive finite quantity', 422);
+        }
+
+        if (!preg_match('/^[0-9]+(?:\.[0-9]{1,3})?$/', $quantity)) {
+            throw new ApiException($field . ' must be a positive quantity with up to three decimals', 422);
+        }
+
+        $quantity = rtrim(rtrim($quantity, '0'), '.');
+        if ($quantity === '') {
+            $quantity = '0';
+        }
+
+        $parts = explode('.', $quantity, 2);
+        $milli = ((int) $parts[0]) * 1000;
+        if (isset($parts[1])) {
+            $milli += (int) str_pad($parts[1], 3, '0', STR_PAD_RIGHT);
+        }
+
+        if ($milli <= 0) {
+            throw new ApiException($field . ' must be greater than zero', 422);
+        }
+
+        return array(
+            'string' => $quantity,
+            'milli' => $milli,
+        );
+    }
+
+    private function prepareLegacyGlobals($payload, $username)
+    {
+        $GLOBALS['brugernavn'] = $username;
+        $GLOBALS['webservice'] = true;
+        $GLOBALS['baseCurrency'] = $payload['currency'];
+        $GLOBALS['fakturadate'] = $payload['invoiceDate'];
+        $GLOBALS['levdate'] = $payload['invoiceDate'];
+        $GLOBALS['valutakurs'] = 100;
+    }
+
+    private function lockImportTables()
+    {
+        $query = 'LOCK TABLE ordrer, ordrelinjer, adresser, batch_salg, batch_kob, lagerstatus, reservation, transaktioner, openpost, pos_betalinger, kontoplan IN EXCLUSIVE MODE';
+        $this->execute($query);
+    }
+
+    private function findExistingImports($externalInvoiceId)
+    {
+        $externalInvoiceId = $this->escape($externalInvoiceId);
+        $marker = $this->escape(self::IMPORT_MARKER);
+        $query = "SELECT id, betalings_id, status, valuta FROM ordrer WHERE art = 'DO' AND shop_status = '$marker' AND kundeordnr = '$externalInvoiceId' ORDER BY id";
+
+        return $this->fetchAll($query);
+    }
+
+    private function resolveFiscalYear($invoiceDate)
+    {
+        $year = (int) substr($invoiceDate, 0, 4);
+        $month = (int) substr($invoiceDate, 5, 2);
+
+        $del1 = "(box1<='$month' and box2<='$year' and box3>='$month' and box4>='$year')";
+        $del2 = "(box1<='$month' and box2<='$year' and box3<'$month' and box4>'$year')";
+        $del3 = "(box1>'$month' and box2<'$year' and box3>='$month' and box4>='$year')";
+        $row = $this->fetchRow("SELECT kodenr FROM grupper WHERE art='RA' AND ($del1 OR $del2 OR $del3) ORDER BY kodenr DESC LIMIT 1");
+        if ($row && isset($row['kodenr'])) {
+            return (int) $row['kodenr'];
+        }
+
+        $fallback = $this->fetchRow("SELECT MAX(kodenr) AS kodenr FROM grupper WHERE art='RA'");
+        if ($fallback && isset($fallback['kodenr']) && $fallback['kodenr'] !== null && $fallback['kodenr'] !== '') {
+            return (int) $fallback['kodenr'];
+        }
+
+        throw new ApiException('No fiscal year is configured for invoiceDate ' . $invoiceDate, 422);
+    }
+
+    private function getSettingValue($name, $default = '')
+    {
+        $name = $this->escape($name);
+        $row = $this->fetchRow("SELECT var_value FROM settings WHERE var_name = '$name' LIMIT 1");
+        if ($row && array_key_exists('var_value', $row) && $row['var_value'] !== null && $row['var_value'] !== '') {
+            return $row['var_value'];
+        }
+
+        return $default;
+    }
+
+    private function requireCardClearingAccount($regnaar)
+    {
+        $row = $this->fetchRow("SELECT box10 FROM grupper WHERE art = 'DIV' AND kodenr = '3' LIMIT 1");
+        $kontonr = $row ? trim((string) $row['box10']) : '';
+        if ($kontonr === '' || !preg_match('/^[0-9]+$/', $kontonr)) {
+            throw new ApiException('Card clearing account is not configured in Indstillinger > Diverse > Ordrerelaterede valg', 422);
+        }
+
+        $kontonr = $this->escape($kontonr);
+        $exists = $this->fetchRow("SELECT kontonr FROM kontoplan WHERE kontonr = '$kontonr' AND regnskabsaar = '$regnaar' LIMIT 1");
+        if (!$exists) {
+            throw new ApiException('Configured credit-card clearing account does not exist in kontoplan for the invoice fiscal year', 422);
+        }
+
+        return (int) $kontonr;
+    }
+
+    private function requireDebtorGroup($groupCode, $regnaar)
+    {
+        $groupCode = (int) $groupCode;
+        if ($groupCode <= 0) {
+            throw new ApiException('customer.groupCode must be a positive integer', 422);
+        }
+
+        $query = "SELECT kodenr, box1 FROM grupper WHERE art = 'DG' AND kodenr = '$groupCode' AND fiscal_year = '$regnaar' LIMIT 1";
+        $row = $this->fetchRow($query);
+        if (!$row) {
+            throw new ApiException('Customer group ' . $groupCode . ' does not exist for the invoice fiscal year', 422);
+        }
+
+        return array(
+            'code' => $groupCode,
+            'box1' => isset($row['box1']) ? trim((string) $row['box1']) : '',
+        );
+    }
+
+    private function prepareLines($lines, $regnaar)
+    {
+        $prepared = array();
+        $headerVatRate = 0;
+
+        for ($index = 0; $index < count($lines); $index++) {
+            $line = $lines[$index];
+            $product = $this->requireProductBySku($line['sku']);
+            $this->assertProductCanBeImported($product, $line['sku']);
+
+            $requestedVatRate = $this->deriveSupportedVatRate($line['netOre'], $line['vatOre'], 'lines[' . $index . ']');
+            $configuredVatRate = $this->resolveProductVatRate($product['gruppe'], $regnaar, $line['sku']);
+            if ((float) $configuredVatRate !== (float) $requestedVatRate) {
+                throw new ApiException('Product ' . $line['sku'] . ' VAT setup does not match the requested line VAT', 422);
+            }
+
+            $unitPrice = round(($line['netOre'] * 10) / $line['quantityMilli'], 6);
+            $prepared[] = array(
+                'position' => $line['position'],
+                'sku' => $product['varenr'],
+                'description' => ($line['description'] !== '') ? $line['description'] : trim((string) $product['beskrivelse']),
+                'quantity' => $line['quantity'],
+                'quantityMilli' => $line['quantityMilli'],
+                'netOre' => $line['netOre'],
+                'vatOre' => $line['vatOre'],
+                'grossOre' => $line['grossOre'],
+                'vatRate' => $requestedVatRate,
+                'momsfri' => ($requestedVatRate == 0) ? 'on' : '',
+                'productId' => (int) $product['id'],
+                'unitPrice' => $this->formatDecimal($unitPrice, 6),
+            );
+
+            if ($requestedVatRate > $headerVatRate) {
+                $headerVatRate = $requestedVatRate;
+            }
+        }
+
+        return array(
+            'headerVatRate' => $headerVatRate,
+            'lines' => $prepared,
+        );
+    }
+
+    private function requireProductBySku($sku)
+    {
+        $sku = trim($sku);
+        $skuEscaped = $this->escape($sku);
+        $query = "SELECT id, varenr, varenr_alias, beskrivelse, gruppe, samlevare, m_antal, m_rabat FROM varer WHERE UPPER(varenr) = UPPER('$skuEscaped') OR UPPER(varenr_alias) = UPPER('$skuEscaped') ORDER BY id";
+        $rows = $this->fetchAll($query);
+
+        if (count($rows) === 0) {
+            throw new ApiException('Unknown product SKU: ' . $sku, 422);
+        }
+        if (count($rows) > 1) {
+            throw new ApiException('SKU ' . $sku . ' resolves to multiple products and must be made unique before import', 422);
+        }
+
+        return $rows[0];
+    }
+
+    private function assertProductCanBeImported($product, $sku)
+    {
+        if (trim((string) $product['samlevare']) === 'on') {
+            throw new ApiException('SKU ' . $sku . ' is a samlevare and cannot be imported through this bridge', 422);
+        }
+        if (trim((string) $product['m_antal']) !== '' || trim((string) $product['m_rabat']) !== '') {
+            throw new ApiException('SKU ' . $sku . ' has quantity discount configuration and cannot be imported safely through this bridge', 422);
+        }
+        if (!is_numeric($product['gruppe']) || (int) $product['gruppe'] <= 0) {
+            throw new ApiException('SKU ' . $sku . ' is missing a valid varegruppe', 422);
+        }
+    }
+
+    private function resolveProductVatRate($varegruppe, $regnaar, $sku)
+    {
+        $varegruppe = (int) $varegruppe;
+        $row = $this->fetchRow("SELECT box4 FROM grupper WHERE art = 'VG' AND kodenr = '$varegruppe' AND fiscal_year = '$regnaar' LIMIT 1");
+        if (!$row || trim((string) $row['box4']) === '') {
+            throw new ApiException('SKU ' . $sku . ' is missing a sales account on its varegruppe', 422);
+        }
+
+        $salesAccount = $this->escape(trim((string) $row['box4']));
+        $konto = $this->fetchRow("SELECT moms FROM kontoplan WHERE kontonr = '$salesAccount' AND regnskabsaar = '$regnaar' LIMIT 1");
+        if (!$konto || trim((string) $konto['moms']) === '') {
+            throw new ApiException('SKU ' . $sku . ' sales account is missing a moms code in kontoplan', 422);
+        }
+
+        $momsCode = (int) substr(trim((string) $konto['moms']), 1);
+        if ($momsCode <= 0) {
+            return 0;
+        }
+
+        $momsGroup = $this->fetchRow("SELECT box2 FROM grupper WHERE art = 'SM' AND kodenr = '$momsCode' AND fiscal_year = '$regnaar' LIMIT 1");
+        if (!$momsGroup) {
+            throw new ApiException('SKU ' . $sku . ' references an unknown momsgruppe', 422);
+        }
+
+        $vatRate = (float) $momsGroup['box2'];
+        if ($vatRate !== 0.0 && $vatRate !== 25.0) {
+            throw new ApiException('Only 0% and 25% VAT products are supported by this bridge', 422);
+        }
+
+        return $vatRate;
+    }
+
+    private function findOrCreateDebtor($customer, $debtorGroup, $username)
+    {
+        $firmName = ($customer['companyName'] !== '') ? $customer['companyName'] : $customer['contactName'];
+        $company = $this->escape($firmName);
+        $address1 = $this->escape($customer['address1']);
+        $address2 = $this->escape($customer['address2']);
+        $postalCode = $this->escape($customer['postalCode']);
+        $city = $this->escape($customer['city']);
+        $country = $this->escape($customer['country']);
+        $cvr = $this->escape($customer['cvr']);
+
+        $query = "SELECT id, kontonr, gruppe, sprog FROM adresser WHERE art = 'D' AND firmanavn = '$company' AND addr1 = '$address1' AND addr2 = '$address2' AND postnr = '$postalCode' AND bynavn = '$city' AND land = '$country' AND cvrnr = '$cvr' ORDER BY id";
+        $matches = $this->fetchAll($query);
+
+        if (count($matches) > 1) {
+            throw new ApiException('Multiple existing debtors match the provided customer identity and address. Merge them before using this endpoint.', 409);
+        }
+
+        if (count($matches) === 1) {
+            if ((int) $matches[0]['gruppe'] !== (int) $debtorGroup['code']) {
+                throw new ApiException('Existing debtor group does not match customer.groupCode', 409);
+            }
+
+            return array(
+                'id' => (int) $matches[0]['id'],
+                'kontonr' => trim((string) $matches[0]['kontonr']),
+                'sprog' => (int) (($matches[0]['sprog'] !== '' && $matches[0]['sprog'] !== null) ? $matches[0]['sprog'] : 1),
+                'firmName' => $firmName,
+            );
+        }
+
+        $kontonr = get_next_number('adresser', 'D');
+        $kontonr = (int) $kontonr;
+        if ($kontonr <= 0) {
+            throw new ApiException('Could not allocate a debtor account number', 500);
+        }
+
+        $contact = $this->escape($customer['contactName']);
+        $email = $this->escape($customer['email']);
+        $phone = $this->escape($customer['phone']);
+        $query = "INSERT INTO adresser (kontonr, firmanavn, addr1, addr2, postnr, bynavn, land, cvrnr, email, tlf, gruppe, art, betalingsbet, betalingsdage, kontakt, lev_firmanavn, lev_addr1, lev_addr2, lev_postnr, lev_bynavn, lev_land, lev_kontakt, lev_tlf, lev_email, lukket, oprettet_af) VALUES ('$kontonr', '$company', '$address1', '$address2', '$postalCode', '$city', '$country', '$cvr', '$email', '$phone', '{$debtorGroup['code']}', 'D', 'netto', '8', '$contact', '$company', '$address1', '$address2', '$postalCode', '$city', '$country', '$contact', '$phone', '$email', '', '" . $this->escape($username) . "')";
+        $this->execute($query);
+
+        $created = $this->fetchRow("SELECT id, sprog FROM adresser WHERE art = 'D' AND kontonr = '$kontonr' ORDER BY id DESC LIMIT 1");
+        if (!$created) {
+            throw new ApiException('Debtor creation failed', 500);
+        }
+
+        return array(
+            'id' => (int) $created['id'],
+            'kontonr' => (string) $kontonr,
+            'sprog' => (int) (($created['sprog'] !== '' && $created['sprog'] !== null) ? $created['sprog'] : 1),
+            'firmName' => $firmName,
+        );
+    }
+    private function createDraftOrder($payload, $debtor, $headerVatRate, $username)
+    {
+        $ordrenr = get_next_order_number('DO', true);
+        $invoiceDate = $this->escape($payload['invoiceDate']);
+        $firmName = $this->escape($debtor['firmName']);
+        $customer = $payload['customer'];
+        $contact = $this->escape($customer['contactName']);
+        $email = $this->escape($customer['email']);
+        $phone = $this->escape($customer['phone']);
+        $address1 = $this->escape($customer['address1']);
+        $address2 = $this->escape($customer['address2']);
+        $postalCode = $this->escape($customer['postalCode']);
+        $city = $this->escape($customer['city']);
+        $country = $this->escape($customer['country']);
+        $cvr = $this->escape($customer['cvr']);
+        $externalInvoiceId = $this->escape($payload['externalInvoiceId']);
+        $payloadHash = $this->escape($payload['payloadHash']);
+        $username = $this->escape($username);
+        $tidspkt = $this->escape(date('H:i'));
+        $currency = $this->escape($payload['currency']);
+        $netAmount = $this->formatOreAsDecimal($payload['totals']['netOre']);
+        $vatAmount = $this->formatOreAsDecimal($payload['totals']['vatOre']);
+
+        $query = "INSERT INTO ordrer (ordrenr, konto_id, kontonr, firmanavn, addr1, addr2, postnr, bynavn, land, kontakt, email, phone, art, momssats, betalingsbet, betalingsdage, betalings_id, status, ordredate, levdate, fakturadate, valuta, valutakurs, ref, hvem, kundeordnr, cvrnr, sum, moms, lev_navn, lev_addr1, lev_addr2, lev_postnr, lev_bynavn, lev_land, lev_kontakt, betalt, shop_status, notes, sprog, tidspkt, felt_1, felt_2, felt_3, felt_4, felt_5) VALUES ('$ordrenr', '{$debtor['id']}', '{$this->escape($debtor['kontonr'])}', '$firmName', '$address1', '$address2', '$postalCode', '$city', '$country', '$contact', '$email', '$phone', 'DO', '$headerVatRate', '" . self::CARD_PAYMENT_TERM . "', '0', '$payloadHash', '0', '$invoiceDate', '$invoiceDate', '$invoiceDate', '$currency', '100', '$username', '$username', '$externalInvoiceId', '$cvr', '$netAmount', '$vatAmount', '$firmName', '$address1', '$address2', '$postalCode', '$city', '$country', '$contact', 'on', '" . self::IMPORT_MARKER . "', 'Stripe paid invoice bridge import', '{$debtor['sprog']}', '$tidspkt', '', '', '', '', '')";
+        $this->execute($query);
+
+        $row = $this->fetchRow("SELECT id FROM ordrer WHERE ordrenr = '$ordrenr' AND art = 'DO' AND shop_status = '" . self::IMPORT_MARKER . "' ORDER BY id DESC LIMIT 1");
+        if (!$row) {
+            throw new ApiException('Draft order creation failed', 500);
+        }
+
+        return (int) $row['id'];
+    }
+
+    private function insertOrderLines($orderId, $lines)
+    {
+        for ($index = 0; $index < count($lines); $index++) {
+            $line = $lines[$index];
+            $result = opret_ordrelinje(
+                $orderId,
+                $line['productId'],
+                $line['sku'],
+                $line['quantity'],
+                $line['description'],
+                $line['unitPrice'],
+                0,
+                100,
+                'DO',
+                $line['momsfri'],
+                $line['position'],
+                0,
+                0,
+                '',
+                '',
+                0,
+                0,
+                0,
+                '',
+                0,
+                ''
+            );
+
+            if (is_string($result) && trim($result) !== '') {
+                throw new ApiException('Order line import failed for SKU ' . $line['sku'] . ': ' . $result, 422);
+            }
+        }
+    }
+
+    private function reconcileDraftTotals($orderId, $payload, $lines)
+    {
+        $momsupdatResult = momsupdat($orderId);
+        if ($momsupdatResult !== 'OK') {
+            throw new ApiException('Failed to reconcile draft VAT totals: ' . $momsupdatResult, 422);
+        }
+
+        $orderRow = $this->fetchRequiredOrder($orderId);
+        $lineRows = $this->fetchOrderLines($orderId);
+        if (count($lineRows) !== count($lines)) {
+            throw new ApiException('Legacy line creation changed the line set and cannot be reconciled safely', 422);
+        }
+
+        $summary = $this->summarizeLines($lineRows);
+        $this->assertSummaryMatchesPayload($summary, $payload, true);
+        $this->assertOrderTotalsMatchPayload($orderRow, $payload);
+    }
+
+    private function deliverAndPost($orderId)
+    {
+        $deliveryResult = levering($orderId, 'on', '', true);
+        if ($deliveryResult !== 'OK') {
+            throw new ApiException('Delivery failed: ' . $deliveryResult, 422);
+        }
+
+        $postingResult = bogfor($orderId, 'on', false, true);
+        if ($postingResult !== 'OK') {
+            throw new ApiException('Posting failed: ' . $postingResult, 422);
+        }
+
+        $orderRow = $this->fetchRequiredOrder($orderId);
+        if ((int) $orderRow['status'] === 3) {
+            $finalPostingResult = bogfor_nu($orderId, 'webservice');
+            if ($finalPostingResult !== 'OK') {
+                throw new ApiException('Final posting failed: ' . $finalPostingResult, 422);
+            }
+        }
+    }
+
+    private function buildPostedResponse($orderId, $payload, $cardClearingAccount = null, $idempotent = false)
+    {
+        $orderRow = $this->fetchRequiredOrder($orderId);
+        $lineRows = $this->fetchOrderLines($orderId);
+        $summary = $this->summarizeLines($lineRows);
+
+        $this->assertSummaryMatchesPayload($summary, $payload, false);
+        $this->assertOrderTotalsMatchPayload($orderRow, $payload);
+
+        if ((int) $orderRow['status'] !== 4) {
+            throw new ApiException('Imported invoice did not finish as status 4', 500);
+        }
+        if (trim((string) $orderRow['betalt']) !== 'on') {
+            throw new ApiException('Imported invoice is no longer marked paid', 500);
+        }
+        if (trim((string) $orderRow['betalingsbet']) !== self::CARD_PAYMENT_TERM) {
+            throw new ApiException('Imported invoice no longer uses credit-card settlement', 500);
+        }
+        if (strtoupper(trim((string) $orderRow['valuta'])) !== 'DKK') {
+            throw new ApiException('Imported invoice currency drifted away from DKK', 500);
+        }
+
+        $openPostRow = $this->fetchRow("SELECT id FROM openpost WHERE refnr = '$orderId' LIMIT 1");
+        if ($openPostRow) {
+            throw new ApiException('Imported invoice created an open post instead of settling through card clearing', 500);
+        }
+
+        $posRow = $this->fetchRow("SELECT id FROM pos_betalinger WHERE ordre_id = '$orderId' LIMIT 1");
+        if ($posRow) {
+            throw new ApiException('Imported invoice was misclassified as POS payment', 500);
+        }
+
+        if ($cardClearingAccount !== null) {
+            $cardRow = $this->fetchRow("SELECT id FROM transaktioner WHERE ordre_id = '$orderId' AND kontonr = '$cardClearingAccount' LIMIT 1");
+            if (!$cardRow) {
+                throw new ApiException('Imported invoice did not create a card-clearing transaction', 500);
+            }
+        }
+
+        return array(
+            'idempotent' => $idempotent,
+            'orderId' => (int) $orderRow['id'],
+            'invoiceId' => (int) $orderRow['id'],
+            'invoiceNumber' => (int) $orderRow['fakturanr'],
+            'externalInvoiceId' => $payload['externalInvoiceId'],
+            'payloadHash' => $payload['payloadHash'],
+            'status' => (int) $orderRow['status'],
+            'paid' => true,
+            'settled' => true,
+            'paidState' => 'settled',
+            'currency' => 'DKK',
+            'netOre' => $summary['netOre'],
+            'vatOre' => $summary['vatOre'],
+            'grossOre' => $summary['grossOre'],
+            'lines' => $summary['lines'],
+        );
+    }
+
+    private function fetchRequiredOrder($orderId)
+    {
+        $marker = $this->escape(self::IMPORT_MARKER);
+        $row = $this->fetchRow("SELECT id, fakturanr, status, valuta, sum, moms, betalt, betalingsbet, kundeordnr, betalings_id, shop_status FROM ordrer WHERE id = '$orderId' AND art = 'DO' AND shop_status = '$marker' LIMIT 1");
+        if (!$row) {
+            throw new ApiException('Imported order could not be read back', 500);
+        }
+
+        return $row;
+    }
+
+    private function fetchOrderLines($orderId)
+    {
+        return $this->fetchAll("SELECT varenr, beskrivelse, antal, pris, rabat, rabatart, procent, momssats, momsfri, posnr FROM ordrelinjer WHERE ordre_id = '$orderId' AND posnr > 0 ORDER BY posnr, id");
+    }
+
+    private function summarizeLines($lineRows)
+    {
+        $summary = array(
+            'netOre' => 0,
+            'vatOre' => 0,
+            'grossOre' => 0,
+            'lines' => array(),
+        );
+
+        for ($index = 0; $index < count($lineRows); $index++) {
+            $row = $lineRows[$index];
+            $netAmount = (float) $row['pris'] * (float) $row['antal'];
+            if ((float) $row['rabat'] != 0.0) {
+                if ((string) $row['rabatart'] === 'amount') {
+                    $netAmount = ((float) $row['pris'] - (float) $row['rabat']) * (float) $row['antal'];
+                } else {
+                    $netAmount = ((float) $row['pris'] - ((float) $row['pris'] * (float) $row['rabat'] / 100)) * (float) $row['antal'];
+                }
+            }
+            if ($row['procent'] !== '' && $row['procent'] !== null) {
+                $netAmount *= ((float) $row['procent'] / 100);
+            }
+
+            $netOre = $this->decimalToOre($netAmount);
+            $vatOre = (trim((string) $row['momsfri']) === 'on' || (float) $row['momssats'] == 0.0)
+                ? 0
+                : $this->decimalToOre(round($netAmount * ((float) $row['momssats'] / 100), 2));
+            $grossOre = $netOre + $vatOre;
+
+            $summary['netOre'] += $netOre;
+            $summary['vatOre'] += $vatOre;
+            $summary['grossOre'] += $grossOre;
+            $summary['lines'][] = array(
+                'sku' => trim((string) $row['varenr']),
+                'description' => trim((string) $row['beskrivelse']),
+                'quantity' => $this->formatQuantity($row['antal']),
+                'netOre' => $netOre,
+                'vatOre' => $vatOre,
+                'grossOre' => $grossOre,
+            );
+        }
+
+        return $summary;
+    }
+
+    private function assertSummaryMatchesPayload($summary, $payload, $enforcePositionEquality)
+    {
+        if ($summary['netOre'] !== $payload['totals']['netOre'] || $summary['vatOre'] !== $payload['totals']['vatOre'] || $summary['grossOre'] !== $payload['totals']['grossOre']) {
+            throw new ApiException('Read-back totals do not match the request payload', 500);
+        }
+
+        if (count($summary['lines']) !== count($payload['lines'])) {
+            throw new ApiException('Read-back line count does not match the request payload', 500);
+        }
+
+        for ($index = 0; $index < count($payload['lines']); $index++) {
+            $expected = $payload['lines'][$index];
+            $actual = $summary['lines'][$index];
+            if ($actual['netOre'] !== $expected['netOre'] || $actual['vatOre'] !== $expected['vatOre'] || $actual['grossOre'] !== $expected['grossOre']) {
+                throw new ApiException('Read-back line totals do not match the request payload', 500);
+            }
+            if ($enforcePositionEquality && $actual['sku'] !== $expected['sku']) {
+                throw new ApiException('Read-back line SKU order does not match the request payload', 500);
+            }
+        }
+    }
+
+    private function assertOrderTotalsMatchPayload($orderRow, $payload)
+    {
+        if ($this->decimalToOre($orderRow['sum']) !== $payload['totals']['netOre']) {
+            throw new ApiException('Read-back order net total does not match the request payload', 500);
+        }
+        if ($this->decimalToOre($orderRow['moms']) !== $payload['totals']['vatOre']) {
+            throw new ApiException('Read-back order VAT total does not match the request payload', 500);
+        }
+    }
+    private function deriveSupportedVatRate($netOre, $vatOre, $fieldName)
+    {
+        if ($vatOre === 0) {
+            return 0;
+        }
+
+        if ($netOre <= 0) {
+            throw new ApiException($fieldName . ' netOre must be positive when VAT is present', 422);
+        }
+
+        $expectedVat = (int) round($netOre * 0.25, 0, PHP_ROUND_HALF_UP);
+        if ($vatOre !== $expectedVat) {
+            throw new ApiException($fieldName . ' VAT must match a supported 25% VAT calculation in whole �re', 422);
+        }
+
+        return 25;
+    }
+
+    private function requireArray($data, $field)
+    {
+        if (!isset($data[$field]) || !is_array($data[$field])) {
+            throw new ApiException($field . ' must be an object', 422);
+        }
+
+        return $data[$field];
+    }
+
+    private function requireString($data, $field)
+    {
+        if (!isset($data[$field])) {
+            throw new ApiException($field . ' is required', 422);
+        }
+
+        $value = trim((string) $data[$field]);
+        if ($value === '') {
+            throw new ApiException($field . ' must not be empty', 422);
+        }
+
+        return $value;
+    }
+
+    private function optionalString($data, $field)
+    {
+        if (!isset($data[$field]) || $data[$field] === null) {
+            return '';
+        }
+
+        return trim((string) $data[$field]);
+    }
+
+    private function requireIntegerField($data, $field, $mustBePositive)
+    {
+        if (!array_key_exists($field, $data)) {
+            throw new ApiException($field . ' is required', 422);
+        }
+
+        $value = $data[$field];
+        if (is_int($value)) {
+            $integer = $value;
+        } elseif (is_string($value) && preg_match('/^-?[0-9]+$/', trim($value))) {
+            $integer = (int) trim($value);
+        } else {
+            throw new ApiException($field . ' must be an integer �re amount', 422);
+        }
+
+        if ($mustBePositive && $integer <= 0) {
+            throw new ApiException($field . ' must be greater than zero', 422);
+        }
+        if (!$mustBePositive && $integer < 0) {
+            throw new ApiException($field . ' must not be negative', 422);
+        }
+
+        return $integer;
+    }
+
+    private function requireDate($data, $field)
+    {
+        $value = $this->requireString($data, $field);
+        $date = DateTime::createFromFormat('Y-m-d', $value);
+        if (!$date || $date->format('Y-m-d') !== $value) {
+            throw new ApiException($field . ' must use YYYY-MM-DD format', 422);
+        }
+
+        return $value;
+    }
+
+    private function fetchRow($query)
+    {
+        $result = db_select($this->prepareQuery($query), __FILE__ . ' linje ' . __LINE__);
+        if (!$result) {
+            return false;
+        }
+
+        return db_fetch_array($result);
+    }
+
+    private function fetchAll($query)
+    {
+        $rows = array();
+        $result = db_select($this->prepareQuery($query), __FILE__ . ' linje ' . __LINE__);
+        if (!$result) {
+            return $rows;
+        }
+
+        while ($row = db_fetch_array($result)) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    private function execute($query)
+    {
+        return db_modify($this->prepareQuery($query), __FILE__ . ' linje ' . __LINE__);
+    }
+
+    private function prepareQuery($query)
+    {
+        if (function_exists('chk4utf8')) {
+            return chk4utf8($query);
+        }
+
+        return $query;
+    }
+
+    private function escape($value)
+    {
+        return db_escape_string((string) $value);
+    }
+
+    private function formatOreAsDecimal($ore)
+    {
+        return number_format(((int) $ore) / 100, 2, '.', '');
+    }
+
+    private function formatDecimal($value, $decimals)
+    {
+        $formatted = number_format((float) $value, $decimals, '.', '');
+        $formatted = rtrim(rtrim($formatted, '0'), '.');
+        if ($formatted === '' || $formatted === '-0') {
+            $formatted = '0';
+        }
+
+        return $formatted;
+    }
+
+    private function decimalToOre($amount)
+    {
+        return (int) round(((float) $amount) * 100, 0, PHP_ROUND_HALF_UP);
+    }
+
+    private function formatQuantity($quantity)
+    {
+        $formatted = rtrim(rtrim(number_format((float) $quantity, 3, '.', ''), '0'), '.');
+        return ($formatted === '') ? '0' : $formatted;
+    }
+}

--- a/restapi/swagger.yaml
+++ b/restapi/swagger.yaml
@@ -860,6 +860,90 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+
+  /debitor/external-paid-invoices/:
+    post:
+      tags:
+        - External Paid Invoices
+      summary: Import one externally paid Stripe invoice as a posted and settled debtor invoice
+      description: |
+        Imports one Stripe-paid invoice atomically and idempotently.
+        The endpoint only accepts DKK invoices, rejects EAN/OIOUBL data, requires exact ore reconciliation,
+        and returns the existing posted result when the same externalInvoiceId and payloadHash are replayed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExternalPaidInvoiceImportRequest'
+            examples:
+              stripe_paid_invoice:
+                summary: Stripe paid invoice import
+                value:
+                  externalInvoiceId: in_1Qwerty123456789
+                  payloadHash: 4f7a1b6a9d8c2e1f
+                  invoiceDate: '2026-07-15'
+                  currency: DKK
+                  totals:
+                    netOre: 100000
+                    vatOre: 25000
+                    grossOre: 125000
+                  customer:
+                    companyName: ACME ApS
+                    contactName: Jane Doe
+                    address1: Main Street 123
+                    address2: Suite 4
+                    postalCode: '2100'
+                    city: Copenhagen
+                    country: Denmark
+                    cvr: '12345678'
+                    email: billing@acme.example
+                    phone: '+4511223344'
+                    groupCode: 1
+                  lines:
+                    - sku: STRIPE-SERVICE
+                      description: Consulting July 2026
+                      quantity: '2'
+                      netOre: 80000
+                      vatOre: 20000
+                      grossOre: 100000
+                    - sku: STRIPE-SUPPORT
+                      description: Support retainer
+                      quantity: '1'
+                      netOre: 20000
+                      vatOre: 5000
+                      grossOre: 25000
+      responses:
+        '200':
+          description: The same externalInvoiceId and payloadHash was already imported; existing posted result returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalPaidInvoiceImportResponse'
+        '201':
+          description: Invoice imported, delivered and posted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalPaidInvoiceImportResponse'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: externalInvoiceId already exists with a different payloadHash or conflicting legacy state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation or accounting prerequisite failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   # Order Lines - Debitor
   /debitor/orderlines/:
     get:
@@ -3500,36 +3584,36 @@ components:
         - `vatRate` (or `momssats`) - VAT rate
         
         **Common fields:**
-        - `accountId` → `konto_id`
-        - `companyName` → `firmanavn`
-        - `phone` → `telefon`
-        - `vatRate` → `momssats`
-        - `orderNumber` → `ordrenr`
-        - `orderDate` → `ordredate`
-        - `invoiceDate` → `fakturadate`
-        - `paid` → `betalt`
-        - `costPrice` → `kostpris`
-        - `vat` → `moms`
-        - `currency` → `valuta`
-        - `currencyRate` → `valutakurs`
-        - `paymentTerms` → `betalingsbet`
-        - `paymentDays` → `betalingsdage`
-        - `accountNumber` → `kontonr`
-        - `reference` → `ref`
-        - `type` → `art`
-        - `address1` → `addr1`
-        - `address2` → `addr2`
-        - `postalCode` → `postnr`
-        - `city` → `bynavn`
-        - `country` → `land`
-        - `deliveryName` → `lev_navn`
-        - `deliveryAddress1` → `lev_addr1`
-        - `deliveryAddress2` → `lev_addr2`
-        - `deliveryPostalCode` → `lev_postnr`
-        - `deliveryCity` → `lev_bynavn`
-        - `deliveryCountry` → `lev_land`
-        - `cvrNo` → `cvrnr`
-        - `customerGroup` → `kundegruppe`
+        - `accountId` Ã¢â€ â€™ `konto_id`
+        - `companyName` Ã¢â€ â€™ `firmanavn`
+        - `phone` Ã¢â€ â€™ `telefon`
+        - `vatRate` Ã¢â€ â€™ `momssats`
+        - `orderNumber` Ã¢â€ â€™ `ordrenr`
+        - `orderDate` Ã¢â€ â€™ `ordredate`
+        - `invoiceDate` Ã¢â€ â€™ `fakturadate`
+        - `paid` Ã¢â€ â€™ `betalt`
+        - `costPrice` Ã¢â€ â€™ `kostpris`
+        - `vat` Ã¢â€ â€™ `moms`
+        - `currency` Ã¢â€ â€™ `valuta`
+        - `currencyRate` Ã¢â€ â€™ `valutakurs`
+        - `paymentTerms` Ã¢â€ â€™ `betalingsbet`
+        - `paymentDays` Ã¢â€ â€™ `betalingsdage`
+        - `accountNumber` Ã¢â€ â€™ `kontonr`
+        - `reference` Ã¢â€ â€™ `ref`
+        - `type` Ã¢â€ â€™ `art`
+        - `address1` Ã¢â€ â€™ `addr1`
+        - `address2` Ã¢â€ â€™ `addr2`
+        - `postalCode` Ã¢â€ â€™ `postnr`
+        - `city` Ã¢â€ â€™ `bynavn`
+        - `country` Ã¢â€ â€™ `land`
+        - `deliveryName` Ã¢â€ â€™ `lev_navn`
+        - `deliveryAddress1` Ã¢â€ â€™ `lev_addr1`
+        - `deliveryAddress2` Ã¢â€ â€™ `lev_addr2`
+        - `deliveryPostalCode` Ã¢â€ â€™ `lev_postnr`
+        - `deliveryCity` Ã¢â€ â€™ `lev_bynavn`
+        - `deliveryCountry` Ã¢â€ â€™ `lev_land`
+        - `cvrNo` Ã¢â€ â€™ `cvrnr`
+        - `customerGroup` Ã¢â€ â€™ `kundegruppe`
       properties:
         # Customer identification (either accountId OR customer details required)
         accountId:
@@ -5845,6 +5929,179 @@ components:
           description: Response data
 
 
+
+    ExternalPaidInvoiceImportRequest:
+      type: object
+      required:
+        - externalInvoiceId
+        - payloadHash
+        - invoiceDate
+        - currency
+        - totals
+        - customer
+        - lines
+      properties:
+        externalInvoiceId:
+          type: string
+          example: in_1Qwerty123456789
+        payloadHash:
+          type: string
+          example: 4f7a1b6a9d8c2e1f
+        invoiceDate:
+          type: string
+          format: date
+        currency:
+          type: string
+          enum: [DKK]
+        totals:
+          $ref: '#/components/schemas/ExternalPaidInvoiceTotals'
+        customer:
+          $ref: '#/components/schemas/ExternalPaidInvoiceCustomer'
+        lines:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ExternalPaidInvoiceRequestLine'
+
+    ExternalPaidInvoiceTotals:
+      type: object
+      required:
+        - netOre
+        - vatOre
+        - grossOre
+      properties:
+        netOre:
+          type: integer
+          example: 100000
+        vatOre:
+          type: integer
+          example: 25000
+        grossOre:
+          type: integer
+          example: 125000
+
+    ExternalPaidInvoiceCustomer:
+      type: object
+      required:
+        - address1
+        - postalCode
+        - city
+        - country
+        - cvr
+        - groupCode
+      properties:
+        companyName:
+          type: string
+        contactName:
+          type: string
+        address1:
+          type: string
+        address2:
+          type: string
+        postalCode:
+          type: string
+        city:
+          type: string
+        country:
+          type: string
+        cvr:
+          type: string
+          example: '12345678'
+        email:
+          type: string
+        phone:
+          type: string
+        groupCode:
+          type: integer
+          example: 1
+
+    ExternalPaidInvoiceRequestLine:
+      type: object
+      required:
+        - sku
+        - quantity
+        - netOre
+        - vatOre
+        - grossOre
+      properties:
+        sku:
+          type: string
+        description:
+          type: string
+        quantity:
+          oneOf:
+            - type: string
+            - type: number
+        netOre:
+          type: integer
+        vatOre:
+          type: integer
+        grossOre:
+          type: integer
+
+    ExternalPaidInvoiceLineSummary:
+      type: object
+      properties:
+        sku:
+          type: string
+        description:
+          type: string
+        quantity:
+          type: string
+        netOre:
+          type: integer
+        vatOre:
+          type: integer
+        grossOre:
+          type: integer
+
+    ExternalPaidInvoiceImportData:
+      type: object
+      properties:
+        idempotent:
+          type: boolean
+        orderId:
+          type: integer
+        invoiceId:
+          type: integer
+        invoiceNumber:
+          type: integer
+        externalInvoiceId:
+          type: string
+        status:
+          type: integer
+          example: 4
+        paid:
+          type: boolean
+          example: true
+        paidState:
+          type: string
+          example: settled
+        currency:
+          type: string
+          example: DKK
+        netOre:
+          type: integer
+        vatOre:
+          type: integer
+        grossOre:
+          type: integer
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExternalPaidInvoiceLineSummary'
+
+    ExternalPaidInvoiceImportResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: External paid invoice imported successfully
+        data:
+          $ref: '#/components/schemas/ExternalPaidInvoiceImportData'
 tags:
   - name: Authentication
     description: Obtain and refresh JWT access tokens
@@ -5872,3 +6129,5 @@ tags:
     description: Operations for fiscal year information
   - name: Attachments
     description: Operations for file attachment management (upload, download, delete)
+  - name: External Paid Invoices
+    description: Import externally paid Stripe invoices as posted debtor invoices

--- a/tests/test_external_paid_invoice_import_service.php
+++ b/tests/test_external_paid_invoice_import_service.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Run: php tests/test_external_paid_invoice_import_service.php
+ */
+
+$passed = 0;
+$failed = 0;
+$transactionCalls = array();
+$dbModifyCalls = array();
+$mockDb = null;
+
+class MockResult
+{
+    public $rows;
+    public $index = 0;
+
+    public function __construct($rows)
+    {
+        $this->rows = $rows;
+    }
+}
+
+class MockDbHandler
+{
+    private $responses = array();
+    public $queries = array();
+
+    public function addResponse($needle, $rows, $consume = false)
+    {
+        $this->responses[] = array('needle' => $needle, 'rows' => $rows, 'consume' => $consume);
+    }
+
+    public function select($query)
+    {
+        $this->queries[] = $query;
+        for ($i = count($this->responses) - 1; $i >= 0; $i--) {
+            if (strpos($query, $this->responses[$i]['needle']) !== false) {
+                $response = $this->responses[$i];
+                if ($response['consume']) {
+                    array_splice($this->responses, $i, 1);
+                }
+                return new MockResult($response['rows']);
+            }
+        }
+
+        return new MockResult(array());
+    }
+}
+
+function db_select($query, $source)
+{
+    global $mockDb;
+    return $mockDb->select($query);
+}
+
+function db_fetch_array($result)
+{
+    if (!($result instanceof MockResult)) {
+        return false;
+    }
+    if ($result->index >= count($result->rows)) {
+        return false;
+    }
+
+    $row = $result->rows[$result->index];
+    $result->index++;
+    return $row;
+}
+
+function db_modify($query, $source)
+{
+    global $dbModifyCalls;
+    $dbModifyCalls[] = $query;
+    return "0\tOK";
+}
+
+function db_escape_string($value)
+{
+    return str_replace(array('\\', "'"), array('\\\\', "\\'"), (string) $value);
+}
+
+function chk4utf8($query)
+{
+    return $query;
+}
+
+function transaktion($action)
+{
+    global $transactionCalls;
+    $transactionCalls[] = $action;
+    return true;
+}
+
+require_once __DIR__ . '/../restapi/core/ApiException.php';
+require_once __DIR__ . '/../restapi/services/ExternalPaidInvoiceImportService.php';
+
+function check($condition, $message)
+{
+    global $passed, $failed;
+    if ($condition) {
+        $passed++;
+        echo "PASS  $message\n";
+    } else {
+        $failed++;
+        echo "FAIL  $message\n";
+    }
+}
+
+function fail($message)
+{
+    check(false, $message);
+}
+
+function resetMocks()
+{
+    global $transactionCalls, $dbModifyCalls, $mockDb;
+    $transactionCalls = array();
+    $dbModifyCalls = array();
+    $mockDb = new MockDbHandler();
+}
+
+function configureImportPrerequisites()
+{
+    global $mockDb;
+    $mockDb->addResponse("SELECT kodenr FROM grupper WHERE art='RA'", array(
+        array('kodenr' => '2026'),
+    ));
+    $mockDb->addResponse("SELECT var_value FROM settings WHERE var_name = 'baseCurrency'", array(
+        array('var_value' => 'DKK'),
+    ));
+    $mockDb->addResponse("SELECT box10 FROM grupper WHERE art = 'DIV' AND kodenr = '3'", array(
+        array('box10' => '5820'),
+    ));
+    $mockDb->addResponse("FROM kontoplan WHERE kontonr = '5820'", array(
+        array('kontonr' => '5820'),
+    ));
+    $mockDb->addResponse("FROM grupper WHERE art = 'DG'", array(
+        array('kodenr' => '1', 'box1' => 'S1'),
+    ));
+    $mockDb->addResponse("FROM varer WHERE UPPER(varenr)", array(
+        array(
+            'id' => '10', 'varenr' => 'STRIPE-SERVICE', 'varenr_alias' => '',
+            'beskrivelse' => 'Stripe service', 'gruppe' => '1', 'samlevare' => '',
+            'm_antal' => '', 'm_rabat' => '',
+        ),
+    ));
+    $mockDb->addResponse("FROM grupper WHERE art = 'VG'", array(
+        array('box4' => '1000'),
+    ));
+    $mockDb->addResponse("FROM kontoplan WHERE kontonr = '1000'", array(
+        array('moms' => 'S1'),
+    ));
+    $mockDb->addResponse("FROM grupper WHERE art = 'SM'", array(
+        array('box2' => '25'),
+    ));
+}
+
+function basePayload()
+{
+    return array(
+        'externalInvoiceId' => 'in_1Qwerty123456789',
+        'payloadHash' => '4f7a1b6a9d8c2e1f',
+        'invoiceDate' => '2026-07-15',
+        'currency' => 'DKK',
+        'totals' => array(
+            'netOre' => 100000,
+            'vatOre' => 25000,
+            'grossOre' => 125000,
+        ),
+        'customer' => array(
+            'companyName' => 'ACME ApS',
+            'contactName' => 'Jane Doe',
+            'address1' => 'Main Street 123',
+            'address2' => 'Suite 4',
+            'postalCode' => '2100',
+            'city' => 'Copenhagen',
+            'country' => 'Denmark',
+            'cvr' => '12345678',
+            'email' => 'billing@acme.example',
+            'phone' => '+4511223344',
+            'groupCode' => 1,
+        ),
+        'lines' => array(
+            array(
+                'sku' => 'STRIPE-SERVICE',
+                'description' => 'Consulting July 2026',
+                'quantity' => '1',
+                'netOre' => 100000,
+                'vatOre' => 25000,
+                'grossOre' => 125000,
+            ),
+        ),
+    );
+}
+
+function expectApiException($callable, $statusCode, $messagePart)
+{
+    try {
+        $callable();
+        fail('Expected ApiException with status ' . $statusCode);
+    } catch (ApiException $exception) {
+        check(
+            $exception->getStatusCode() === $statusCode && strpos($exception->getMessage(), $messagePart) !== false,
+            'Throws ApiException ' . $statusCode . ' containing "' . $messagePart . '"'
+        );
+    }
+}
+
+$service = new ExternalPaidInvoiceImportService();
+
+$normalized = $service->validatePayload(basePayload());
+check($normalized['currency'] === 'DKK', 'validatePayload accepts a valid DKK payload');
+check($normalized['lines'][0]['quantity'] === '1', 'validatePayload keeps normalized quantity strings');
+
+$badCurrency = basePayload();
+$badCurrency['currency'] = 'EUR';
+expectApiException(function () use ($service, $badCurrency) {
+    $service->validatePayload($badCurrency);
+}, 422, 'Only DKK invoices are supported');
+
+$forbidden = basePayload();
+$forbidden['customer']['ean'] = '5790000000000';
+expectApiException(function () use ($service, $forbidden) {
+    $service->validatePayload($forbidden);
+}, 422, 'EAN and OIOUBL');
+
+resetMocks();
+configureImportPrerequisites();
+$mockDb->addResponse("SELECT id, betalings_id, status, valuta FROM ordrer WHERE art = 'DO' AND shop_status = 'stripe_paid_bridge'", array(
+    array('id' => 55, 'betalings_id' => '4f7a1b6a9d8c2e1f', 'status' => '4', 'valuta' => 'DKK'),
+));
+$mockDb->addResponse("SELECT id, fakturanr, status, valuta, sum, moms, betalt, betalingsbet, kundeordnr, betalings_id, shop_status FROM ordrer WHERE id = '55'", array(
+    array(
+        'id' => 55,
+        'fakturanr' => '9001',
+        'status' => '4',
+        'valuta' => 'DKK',
+        'sum' => '1000.00',
+        'moms' => '250.00',
+        'betalt' => 'on',
+        'betalingsbet' => 'Kreditkort',
+        'kundeordnr' => 'in_1Qwerty123456789',
+        'betalings_id' => '4f7a1b6a9d8c2e1f',
+        'shop_status' => 'stripe_paid_bridge',
+    ),
+));
+$mockDb->addResponse("FROM ordrelinjer WHERE ordre_id = '55'", array(
+    array(
+        'varenr' => 'STRIPE-SERVICE',
+        'beskrivelse' => 'Consulting July 2026',
+        'antal' => '1',
+        'pris' => '1000.00',
+        'rabat' => '0',
+        'rabatart' => '',
+        'procent' => '100',
+        'momssats' => '25',
+        'momsfri' => '',
+        'posnr' => '1',
+    ),
+));
+$mockDb->addResponse("SELECT id FROM pos_betalinger WHERE ordre_id = '55'", array());
+$mockDb->addResponse("SELECT id FROM openpost WHERE refnr = '55'", array());
+$mockDb->addResponse("SELECT id FROM transaktioner WHERE ordre_id = '55' AND kontonr = '5820'", array(
+    array('id' => 800),
+));
+$result = $service->import(basePayload(), 'bridge-user');
+check($result['idempotent'] === true && $result['invoiceNumber'] === 9001, 'same externalInvoiceId and payloadHash returns the existing posted result');
+check($transactionCalls === array('begin', 'rollback'), 'idempotent replay uses a no-op rollback instead of commit');
+
+resetMocks();
+configureImportPrerequisites();
+$mockDb->addResponse("SELECT id, betalings_id, status, valuta FROM ordrer WHERE art = 'DO' AND shop_status = 'stripe_paid_bridge'", array(
+    array('id' => 55, 'betalings_id' => 'different-hash', 'status' => '4', 'valuta' => 'DKK'),
+));
+expectApiException(function () use ($service) {
+    $service->import(basePayload(), 'bridge-user');
+}, 409, 'different payloadHash');
+check($transactionCalls === array('begin', 'rollback'), 'conflicting idempotency key rolls the transaction back');
+
+resetMocks();
+$mockDb->addResponse("SELECT kodenr FROM grupper WHERE art='RA'", array(
+    array('kodenr' => '2026'),
+));
+$mockDb->addResponse("SELECT var_value FROM settings WHERE var_name = 'baseCurrency'", array(
+    array('var_value' => 'DKK'),
+));
+$mockDb->addResponse("SELECT box10 FROM grupper WHERE art = 'DIV' AND kodenr = '3'", array(
+    array('box10' => ''),
+));
+expectApiException(function () use ($service) {
+    $service->import(basePayload(), 'bridge-user');
+}, 422, 'Card clearing account is not configured');
+check($transactionCalls === array(), 'missing card-clearing configuration fails before opening a transaction');
+
+echo "\nResults: $passed passed, $failed failed\n";
+exit($failed ? 1 : 0);


### PR DESCRIPTION
## Summary
- add a JWT-authenticated endpoint for atomic external paid invoice imports
- enforce Stripe invoice idempotency and exact DKK/VAT reconciliation
- post and settle through Saldi's existing credit-card accounting flow
- support caller-owned numbering transactions and add a unique import key
- document and test replay, conflict, validation, and rollback behavior

## Tests
- PHP lint for all changed PHP files
- `php tests/test_external_paid_invoice_import_service.php` (10 passed)
- Swagger YAML parse
- staged diff check

## Manual verification before production
- deploy to the Saldi demo tenant and run the database update
- confirm the dedicated STRIPE product, debtor group, VAT, and card-clearing account
- import one DKK 12.50 paid sandbox invoice and inspect status 4 postings
- replay the same invoice and verify no duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated API endpoint for importing externally paid Stripe invoices.
  - Supports DKK invoices with customer details, line items, VAT, and payment information.
  - Added idempotent processing to safely replay previously imported invoices.
  - Added validation for invoice data, currency, totals, and payment prerequisites.
  - Documented the endpoint and request/response schemas in the API specification.

- **Bug Fixes**
  - Improved invoice and order numbering during atomic imports.
  - Prevented duplicate imported orders through database-level uniqueness checks.

- **Tests**
  - Added coverage for payload validation, idempotent imports, conflicts, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->