### PR TITLE
Feature/vat reporting module

### DIFF
--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -217,13 +217,22 @@ if ($_POST['bogfor'] || $_POST['simuler']) {
 		include("../includes/online.php");
 	}
 	if ($bogfor) {
-		transaktion('begin');
-		bogfor($kladde_id, $kladdenote,'');
-		db_modify("delete from tmpkassekl where kladde_id = $kladde_id",__FILE__ . " linje " . __LINE__);
-		transaktion('commit');
-		genberegn($regnaar);
-		equalizeMatchingRecords();
-		if ($popup) print "<BODY onLoad=\"javascript=opener.location.reload();\">";
+		$periode_fejl = NULL;
+		$q_dates = db_select("SELECT DISTINCT transdate FROM kassekladde WHERE kladde_id=$kladde_id", __FILE__." linje ".__LINE__);
+		while ($rd = db_fetch_array($q_dates)) {
+			if ($err = check_periode_luk($rd['transdate'])) { $periode_fejl = $err; break; }
+		}
+		if ($periode_fejl) {
+			print "<BODY onLoad=\"javascript:alert('" . addslashes($periode_fejl) . "')\">";
+		} else {
+			transaktion('begin');
+			bogfor($kladde_id, $kladdenote,'');
+			db_modify("delete from tmpkassekl where kladde_id = $kladde_id",__FILE__ . " linje " . __LINE__);
+			transaktion('commit');
+			genberegn($regnaar);
+			equalizeMatchingRecords();
+			if ($popup) print "<BODY onLoad=\"javascript=opener.location.reload();\">";
+		}
 	} elseif ($simuler) {
 		transaktion('begin');
 		bogfor($kladde_id, $kladdenote,'on');

--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -53,6 +53,10 @@
 // 20251210 PHR - Missing financialYear in vat account lookup for E & Y
 // 20260316 PHR Better error handling for missing debitor group
 // 20260417 Sawaneh: overwrite vat selection
+// 20260729 CL/NTR function bogfor: Wrapped in transaktion('begin')/('commit'), with transaktion('rollback')
+//                 added before every early exit, so a failed posting no longer leaves partial writes
+//                 (kontoplan/kladdeliste updates) committed without the corresponding transaktioner rows.
+//                 Requested via CodeRabbit review.
 
 
 @session_start();
@@ -704,7 +708,9 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 		return("Kladden er allerede bogført");
 		exit;
 	}
-	
+
+	transaktion('begin');
+
 	$d_momsart=array(); $k_momsart=array();
 	if ($kladdenote) db_modify("update kladdeliste set kladdenote = '$kladdenote' where id = '$kladde_id'",__FILE__ . " linje " . __LINE__);
 	$y=0;
@@ -975,6 +981,7 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 		$kontodebet[$y]=array();  
 		for ($i=1;$i<=$b_antal;$i++) {
 			if ($bilag[$i]!=$bilag[$i-1] && $bilag[$i]!=$bilag[$i+1] && (!$debet[$i]||!$kredit[$i]) && $valuta[$i] != $valuta[$i-1]) { # 20131117 -- 20140228 tilføjet: && $valuta[$i] != $valuta[$i-1] 
+				transaktion('rollback');
 				print "<BODY onLoad=\"javascript:alert('Manglende modpostering i bilag $bilag[$i]!')\">";
 				exit;
 			}
@@ -1038,9 +1045,10 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 					} 
 */					
 				} elseif (($kontokredit[$y] || $kontodebet[$y]) && !$b_diffkonto[$i] && $valuta[$i])  { #20131028 -- 20140228 tilføjet: && $valuta[$i
+				transaktion('rollback');
 				print "<BODY onLoad=\"javascript:alert('Manglende konto til valutadiffencer! (bilag: $b_bilag[$i])')\">";
 				exit;
-			} 
+			}
 		}
 	}
 	if (abs($tjeksum)<=0.01) { # && $transtjek==$transantal){
@@ -1062,8 +1070,10 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 				db_modify("update kontoplan set saldo = $transamount[$x] where id = '$kasklid[$x]'",__FILE__ . " linje " . __LINE__);
 			}
 		}
+		transaktion('commit');
 #xit;
 	} else {
+		transaktion('rollback');
 		print "<tr><td align=center>$font Der er konstateret en afvigelse!\nKladde ikke bogført\nKontakt venligst Saldi's udviklerteam!</td></tr>";
 		exit;
 	}

--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -53,10 +53,10 @@
 // 20251210 PHR - Missing financialYear in vat account lookup for E & Y
 // 20260316 PHR Better error handling for missing debitor group
 // 20260417 Sawaneh: overwrite vat selection
-// 20260729 CL/NTR function bogfor: Wrapped in transaktion('begin')/('commit'), with transaktion('rollback')
-//                 added before every early exit, so a failed posting no longer leaves partial writes
-//                 (kontoplan/kladdeliste updates) committed without the corresponding transaktioner rows.
-//                 Requested via CodeRabbit review.
+// 20260730 CL/NTR function bogfor: Removed the internal transaktion('begin')/('commit') so the caller
+//                 (which already wraps the call together with the tmpkassekl cleanup) keeps ownership of
+//                 the transaction; transaktion('rollback') before an early exit is kept since those paths
+//                 still terminate the request immediately.
 
 
 @session_start();
@@ -709,8 +709,6 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 		exit;
 	}
 
-	transaktion('begin');
-
 	$d_momsart=array(); $k_momsart=array();
 	if ($kladdenote) db_modify("update kladdeliste set kladdenote = '$kladdenote' where id = '$kladde_id'",__FILE__ . " linje " . __LINE__);
 	$y=0;
@@ -1070,7 +1068,6 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 				db_modify("update kontoplan set saldo = $transamount[$x] where id = '$kasklid[$x]'",__FILE__ . " linje " . __LINE__);
 			}
 		}
-		transaktion('commit');
 #xit;
 	} else {
 		transaktion('rollback');

--- a/finans/moms_periode.php
+++ b/finans/moms_periode.php
@@ -1,0 +1,288 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- finans/moms_periode.php --- patch 5.0.0 --- 2026-07-20 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+// 20260716 MJ R5 – Aaben/luk individuelle maaneder. Lukket maaned blokkerer alle
+//                  posteringsveje via PostgreSQL-trigger paa transaktioner-tabellen.
+//                  Audit trail gemmes i moms_periode_luk-tabellen.
+// 20260716 MJ     Flyttet DDL (CREATE TABLE/FUNCTION/TRIGGER) til betweenUpdates.php for at
+//                  undgaa falsk positiv i injecttjek() paa semikolon i PL/pgSQL-kroppen.
+// 20260720 MJ  Bulk unlock, note-felt paa luk-handling, posteringsantal pr. maaned.
+// 20260720 MJ  Bugfix: bulk_luk/bulk_aaben frigjort fra maaned-guard (bulk forms sender ikke maaned).
+
+@session_start();
+$s_id = session_id();
+$title   = 'Momsperioder – Aaben/Luk';
+$modulnr = 2;
+$css     = '../css/standard.css';
+
+include('../includes/var_def.php');
+include('../includes/connect.php');
+include('../includes/online.php');
+include('../includes/topline_settings.php');
+include('../includes/std_func.php');
+
+$md = [];
+$md[1]='januar'; $md[2]='februar'; $md[3]='marts';    $md[4]='april';
+$md[5]='maj';    $md[6]='juni';    $md[7]='juli';      $md[8]='august';
+$md[9]='september'; $md[10]='oktober'; $md[11]='november'; $md[12]='december';
+
+// --- permission: require finans access (modulnr 2, bit >= 1) ---
+$kan_aendre = ($rettigheder && substr($rettigheder, 2, 1) >= '1');
+
+// --- handle toggle action ---
+$msg = '';
+if ($_POST && $kan_aendre) {
+    $action = if_isset($_POST, NULL, 'action');
+    $aar    = (int)if_isset($_POST, NULL, 'aar');
+    $maaned = (int)if_isset($_POST, NULL, 'maaned');
+    $now         = date('Y-m-d H:i:s');
+    $safe_bruger = db_escape_string($brugernavn);
+
+    $note = db_escape_string(trim(if_isset($_POST, '', 'note')));
+    $note_sql = ($note !== '') ? "'$note'" : 'NULL';
+
+    if ($aar >= 2000 && $aar <= 2100) {
+        if ($action === 'bulk_luk') {
+            $til = (int)if_isset($_POST, 0, 'bulk_til_maaned');
+            if ($til >= 1 && $til <= 12) {
+                for ($m = 1; $m <= $til; $m++) {
+                    db_modify("INSERT INTO moms_periode_luk (kalender_aar, kalender_maaned, status, lukket_af, lukket_dato, note)
+                        VALUES ($aar, $m, 'closed', '$safe_bruger', '$now', $note_sql)
+                        ON CONFLICT (kalender_aar, kalender_maaned)
+                        DO UPDATE SET status='closed', lukket_af='$safe_bruger', lukket_dato='$now', note=$note_sql",
+                        __FILE__." linje ".__LINE__);
+                }
+                $msg = "Maanederne januar–" . ucfirst($md[$til]) . " $aar er nu lukket.";
+            }
+        } elseif ($action === 'bulk_aaben') {
+            $fra = (int)if_isset($_POST, 0, 'bulk_fra_maaned');
+            $til = (int)if_isset($_POST, 0, 'bulk_til_maaned');
+            if ($fra >= 1 && $til <= 12 && $fra <= $til) {
+                for ($m = $fra; $m <= $til; $m++) {
+                    db_modify("UPDATE moms_periode_luk
+                        SET status='open', aabnet_af='$safe_bruger', aabnet_dato='$now'
+                        WHERE kalender_aar=$aar AND kalender_maaned=$m",
+                        __FILE__." linje ".__LINE__);
+                }
+                $msg = "Maanederne " . ucfirst($md[$fra]) . "–" . ucfirst($md[$til]) . " $aar er nu aabnet.";
+            }
+        } elseif ($maaned >= 1 && $maaned <= 12) {
+            if ($action === 'luk') {
+                // Check for unposted journal drafts dated in this month
+                $draft_advarsel = '';
+                $qd = db_select(
+                    "SELECT COUNT(DISTINCT k.kladde_id) AS cnt FROM kassekladde k"
+                    . " JOIN kladdeliste kl ON kl.id = k.kladde_id"
+                    . " WHERE (kl.bogfort = '-' OR kl.bogfort = '!')"
+                    . " AND EXTRACT(YEAR  FROM k.transdate::date) = $aar"
+                    . " AND EXTRACT(MONTH FROM k.transdate::date) = $maaned",
+                    __FILE__." linje ".__LINE__);
+                if ($rd = db_fetch_array($qd)) {
+                    $cnt = (int)$rd['cnt'];
+                    if ($cnt > 0)
+                        $draft_advarsel = " OBS: $cnt ikke-bogfoert kladde(r) med dato i denne periode vil ikke kunne bogfoeres foer perioden genaabnes.";
+                }
+
+                db_modify("INSERT INTO moms_periode_luk (kalender_aar, kalender_maaned, status, lukket_af, lukket_dato, note)
+                    VALUES ($aar, $maaned, 'closed', '$safe_bruger', '$now', $note_sql)
+                    ON CONFLICT (kalender_aar, kalender_maaned)
+                    DO UPDATE SET status='closed', lukket_af='$safe_bruger', lukket_dato='$now', note=$note_sql",
+                    __FILE__." linje ".__LINE__);
+                $msg = "Perioden " . ucfirst($md[$maaned]) . " $aar er nu lukket.$draft_advarsel";
+            } elseif ($action === 'aaben') {
+                db_modify("UPDATE moms_periode_luk
+                    SET status='open', aabnet_af='$safe_bruger', aabnet_dato='$now'
+                    WHERE kalender_aar=$aar AND kalender_maaned=$maaned",
+                    __FILE__." linje ".__LINE__);
+                $msg = "Perioden " . ucfirst($md[$maaned]) . " $aar er nu aabnet.";
+            }
+        }
+    }
+    // redirect to avoid form resubmit on refresh
+    $redir_aar = (int)if_isset($_POST, date('Y'), 'vis_aar');
+    header("Location: moms_periode.php?vis_aar=$redir_aar&msg=" . urlencode($msg));
+    exit;
+}
+
+// --- determine which year to show ---
+$vis_aar = (int)if_isset($_GET, date('Y'), 'vis_aar');
+if ($vis_aar < 2000 || $vis_aar > 2100) $vis_aar = (int)date('Y');
+if (isset($_GET['msg'])) $msg = htmlspecialchars($_GET['msg']);
+
+// Load current status for the year
+$status_map = [];
+$q = db_select("SELECT * FROM moms_periode_luk WHERE kalender_aar = $vis_aar ORDER BY kalender_maaned", __FILE__." linje ".__LINE__);
+while ($r = db_fetch_array($q)) $status_map[$r['kalender_maaned']] = $r;
+
+// Transaction count per month
+$trans_map = [];
+$qt = db_select(
+    "SELECT EXTRACT(MONTH FROM transdate)::int AS m, COUNT(*) AS cnt"
+    . " FROM transaktioner WHERE EXTRACT(YEAR FROM transdate) = $vis_aar GROUP BY m",
+    __FILE__." linje ".__LINE__);
+while ($r = db_fetch_array($qt)) $trans_map[(int)$r['m']] = (int)$r['cnt'];
+
+// --- page output ---
+if ($menu == 'T') {
+    include_once '../includes/top_header.php';
+    include_once '../includes/top_menu.php';
+    print "<div id='header'>";
+    print "<div class='headerbtnLft headLink'><a href='kladdeliste.php'><i class='fa fa-close fa-lg'></i> Luk</a></div>";
+    print "<div class='headerTxt'>Momsperioder – &Aring;ben/Luk</div>";
+    print "<div class='headerbtnRght headLink'>&nbsp;</div>";
+    print "</div>";
+    print "<div class='content-noside' style='padding:16px;'>";
+} else {
+    print "<body>";
+    print "<table width='100%' cellpadding='0' cellspacing='1px' border='0'><tr><td height='8'>";
+    print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>";
+    print "<td width='10%'><a href='kladdeliste.php'>Luk</a></td>";
+    print "<td width='80%' align='center'><b>Momsperioder – &Aring;ben/Luk</b></td>";
+    print "<td width='10%'>&nbsp;</td>";
+    print "</tbody></table></td></tr></table>";
+    print "<div style='padding:16px;'>";
+}
+
+if ($msg) print "<div style='padding:8px 12px; margin-bottom:12px; background:#d4edda; color:#155724; border-radius:4px;'>$msg</div>";
+
+if (!$kan_aendre) {
+    print "<div style='padding:8px 12px; color:#c00;'>Du har ikke rettighed til at aendre periodestatuser.</div>";
+}
+
+// Year navigation
+print "<div style='margin-bottom:12px;'>";
+print "<a href='moms_periode.php?vis_aar=" . ($vis_aar - 1) . "'>&laquo; " . ($vis_aar - 1) . "</a> &nbsp;";
+print "<b>$vis_aar</b> &nbsp;";
+print "<a href='moms_periode.php?vis_aar=" . ($vis_aar + 1) . "'>" . ($vis_aar + 1) . " &raquo;</a>";
+print "</div>";
+
+// Bulk lock
+if ($kan_aendre) {
+    print "<form method='POST' style='margin-bottom:8px; display:inline-block;'>";
+    print "<input type='hidden' name='action' value='bulk_luk'>";
+    print "<input type='hidden' name='aar' value='$vis_aar'>";
+    print "<input type='hidden' name='vis_aar' value='$vis_aar'>";
+    print "Luk alle maaneder op til: <select name='bulk_til_maaned' style='margin:0 6px;'>";
+    for ($m = 1; $m <= 12; $m++) {
+        print "<option value='$m'>" . ucfirst($md[$m]) . " $vis_aar</option>";
+    }
+    print "</select>";
+    print "<input type='text' name='note' placeholder='Note (valgfrit)' style='margin:0 6px; width:180px; font-size:0.9em;'>";
+    print "<button type='submit' onclick=\"return confirm('Luk alle maaneder op til den valgte? Allerede lukkede maaneder forbliver lukket.');\" "
+        . "style='background:#dc3545; color:#fff; border:none; padding:4px 10px; cursor:pointer; border-radius:3px;'>Masseluk</button>";
+    print "</form><br>";
+    // Bulk unlock
+    print "<form method='POST' style='margin-bottom:16px; display:inline-block;'>";
+    print "<input type='hidden' name='action' value='bulk_aaben'>";
+    print "<input type='hidden' name='aar' value='$vis_aar'>";
+    print "<input type='hidden' name='vis_aar' value='$vis_aar'>";
+    print "Genaaben maaneder fra: <select name='bulk_fra_maaned' style='margin:0 4px;'>";
+    for ($m = 1; $m <= 12; $m++) print "<option value='$m'>" . ucfirst($md[$m]) . " $vis_aar</option>";
+    print "</select> til: <select name='bulk_til_maaned' style='margin:0 4px;'>";
+    for ($m = 1; $m <= 12; $m++) print "<option value='$m'" . ($m == 12 ? ' selected' : '') . ">" . ucfirst($md[$m]) . " $vis_aar</option>";
+    print "</select>";
+    print "<button type='submit' onclick=\"return confirm('Genaaben alle maaneder i det valgte interval?');\" "
+        . "style='background:#28a745; color:#fff; border:none; padding:4px 10px; cursor:pointer; border-radius:3px; margin-left:6px;'>Massegenaaben</button>";
+    print "</form>";
+}
+
+print "<table border='0' cellspacing='1' cellpadding='6' style='border-collapse:collapse; min-width:700px;'>";
+print "<thead><tr style='background:#eeeef0;'>";
+print "<th align='left' style='padding:6px 12px;'>Maaned</th>";
+print "<th align='center' style='padding:6px 12px;'>Status</th>";
+print "<th align='right' style='padding:6px 12px;'>Posteringer</th>";
+print "<th align='left' style='padding:6px 12px;'>Lukket af / dato</th>";
+print "<th align='left' style='padding:6px 12px;'>Aabnet af / dato</th>";
+print "<th align='left' style='padding:6px 12px;'>Note</th>";
+if ($kan_aendre) print "<th style='padding:6px 12px;'>&nbsp;</th>";
+print "</tr></thead><tbody>";
+
+for ($m = 1; $m <= 12; $m++) {
+    $row    = $status_map[$m] ?? null;
+    $closed = ($row && $row['status'] === 'closed');
+    $bg     = $closed ? '#ffe0e0' : '#f0fff0';
+
+    $status_txt  = $closed
+        ? "<span style='color:#c00; font-weight:bold;'>&#x1F512; Lukket</span>"
+        : "<span style='color:#090;'>&#x1F513; Aaben</span>";
+
+    $lukket_info = ($row && $row['lukket_af'])
+        ? htmlspecialchars($row['lukket_af']) . '<br><small>' . htmlspecialchars($row['lukket_dato']) . '</small>'
+        : '–';
+    $aabnet_info = ($row && $row['aabnet_af'])
+        ? htmlspecialchars($row['aabnet_af']) . '<br><small>' . htmlspecialchars($row['aabnet_dato']) . '</small>'
+        : '–';
+    $note_txt = ($row && !empty($row['note'])) ? htmlspecialchars($row['note']) : '–';
+    $trans_cnt = $trans_map[$m] ?? 0;
+
+    print "<tr style='background:$bg; border-bottom:1px solid #ddd;'>";
+    print "<td style='padding:6px 12px;'><b>" . ucfirst($md[$m]) . " $vis_aar</b></td>";
+    print "<td align='center' style='padding:6px 12px;'>$status_txt</td>";
+    print "<td align='right' style='padding:6px 12px; color:#555;'>" . number_format($trans_cnt, 0, ',', '.') . "</td>";
+    print "<td style='padding:6px 12px;'>$lukket_info</td>";
+    print "<td style='padding:6px 12px;'>$aabnet_info</td>";
+    print "<td style='padding:6px 12px; font-size:0.85em; color:#555;'>$note_txt</td>";
+
+    if ($kan_aendre) {
+        print "<td style='padding:6px 12px;'>";
+        if ($closed) {
+            print "<form method='POST' style='display:inline;'>";
+            print "<input type='hidden' name='action' value='aaben'>";
+            print "<input type='hidden' name='aar' value='$vis_aar'>";
+            print "<input type='hidden' name='maaned' value='$m'>";
+            print "<input type='hidden' name='vis_aar' value='$vis_aar'>";
+            print "<button type='submit' onclick=\"return confirm('Aaben perioden " . ucfirst($md[$m]) . " $vis_aar?');\" "
+                . "style='background:#28a745; color:#fff; border:none; padding:4px 10px; cursor:pointer; border-radius:3px;'>"
+                . "&Aring;ben</button></form>";
+        } else {
+            print "<form method='POST' style='display:inline;'>";
+            print "<input type='hidden' name='action' value='luk'>";
+            print "<input type='hidden' name='aar' value='$vis_aar'>";
+            print "<input type='hidden' name='maaned' value='$m'>";
+            print "<input type='hidden' name='vis_aar' value='$vis_aar'>";
+            print "<input type='text' name='note' placeholder='Note' style='width:110px; font-size:0.85em; margin-right:4px;'>";
+            print "<button type='submit' onclick=\"return confirm('Luk perioden " . ucfirst($md[$m]) . " $vis_aar for bogfoering?');\" "
+                . "style='background:#dc3545; color:#fff; border:none; padding:4px 10px; cursor:pointer; border-radius:3px;'>"
+                . "Luk</button></form>";
+        }
+        print "</td>";
+    }
+    print "</tr>\n";
+}
+
+print "</tbody></table>";
+print "<p style='margin-top:16px; color:#666; font-size:0.9em;'>"
+    . "Lukkede maaneder blokerer <em>alle</em> posteringsveje via databasetrigger. "
+    . "En genaabnelse tillader bogfoering igen og logges i ovenstaaende tabel."
+    . "</p>";
+
+print "</div>";
+
+if ($menu == 'T') {
+    include_once '../includes/topmenu/footer.php';
+} else {
+    include_once '../includes/oldDesign/footer.php';
+}
+?>

--- a/finans/rapport_includes/forside.php
+++ b/finans/rapport_includes/forside.php
@@ -291,6 +291,14 @@ if ($maaned_fra < $aktivStartMd) $aar_fra = $aktivSlutAar;
 		print "<option title='" . findtekst(871, $sprog_id) . "' value='lastYear'>" . findtekst(872, $sprog_id) . "</option>\n";
 	elseif ($rapportart == "momsangivelse")
 		print "<option title='" . findtekst(514, $sprog_id) . "' value='momsangivelse'>" . findtekst(520, $sprog_id) . "</option>\n";
+	elseif ($rapportart == "moms_transaktioner")
+		print "<option value='moms_transaktioner'>Posteringer pr. momskode</option>\n";
+	elseif ($rapportart == "moms_rubrik")
+		print "<option value='moms_rubrik'>Momsrubrikker (A/B/C)</option>\n";
+	elseif ($rapportart == "moms_afstemning")
+		print "<option value='moms_afstemning'>Momsafstemning</option>\n";
+	elseif ($rapportart == "moms_oss")
+		print "<option value='moms_oss'>OSS B2C EU-salg</option>\n";
 	elseif ($rapportart == "saft")
 		print "<option title='" . findtekst(2321, $sprog_id) . "' value='saft'>" . findtekst(2320, $sprog_id) . "</option>\n";
 	elseif ($rapportart == "regnskabbasis")
@@ -318,6 +326,14 @@ if ($maaned_fra < $aktivStartMd) $aar_fra = $aktivSlutAar;
 		print "<option title='" . findtekst(871, $sprog_id) . "' value='lastYear'>" . findtekst(872, $sprog_id) . "</option>\n";
 	if ($rapportart != "momsangivelse")
 		print "<option title='" . findtekst(514, $sprog_id) . "' value='momsangivelse'>" . findtekst(520, $sprog_id) . "</option>\n";
+	if ($rapportart != "moms_transaktioner")
+		print "<option value='moms_transaktioner'>Posteringer pr. momskode</option>\n";
+	if ($rapportart != "moms_rubrik")
+		print "<option value='moms_rubrik'>Momsrubrikker (A/B/C)</option>\n";
+	if ($rapportart != "moms_afstemning")
+		print "<option value='moms_afstemning'>Momsafstemning</option>\n";
+	if ($rapportart != "moms_oss")
+		print "<option value='moms_oss'>OSS B2C EU-salg</option>\n";
 	if ($rapportart != "saft")
 		print "<option title='" . findtekst(2321, $sprog_id) . "' value='saft'>" . findtekst(2320, $sprog_id) . "</option>\n";
 	if ($rapportart != "regnskabbasis")

--- a/finans/rapport_includes/forside.php
+++ b/finans/rapport_includes/forside.php
@@ -292,13 +292,13 @@ if ($maaned_fra < $aktivStartMd) $aar_fra = $aktivSlutAar;
 	elseif ($rapportart == "momsangivelse")
 		print "<option title='" . findtekst(514, $sprog_id) . "' value='momsangivelse'>" . findtekst(520, $sprog_id) . "</option>\n";
 	elseif ($rapportart == "moms_transaktioner")
-		print "<option value='moms_transaktioner'>Posteringer pr. momskode</option>\n";
+		print "<option value='moms_transaktioner'>" . findtekst("3362|Posteringer pr. momskode", $sprog_id) . "</option>\n";
 	elseif ($rapportart == "moms_rubrik")
-		print "<option value='moms_rubrik'>Momsrubrikker (A/B/C)</option>\n";
+		print "<option value='moms_rubrik'>" . findtekst("3363|Momsrubrikker", $sprog_id) . " (A/B/C)</option>\n";
 	elseif ($rapportart == "moms_afstemning")
-		print "<option value='moms_afstemning'>Momsafstemning</option>\n";
+		print "<option value='moms_afstemning'>" . findtekst("3364|Momsafstemning", $sprog_id) . "</option>\n";
 	elseif ($rapportart == "moms_oss")
-		print "<option value='moms_oss'>OSS B2C EU-salg</option>\n";
+		print "<option value='moms_oss'>" . findtekst("3365|OSS B2C EU-salg", $sprog_id) . "</option>\n";
 	elseif ($rapportart == "saft")
 		print "<option title='" . findtekst(2321, $sprog_id) . "' value='saft'>" . findtekst(2320, $sprog_id) . "</option>\n";
 	elseif ($rapportart == "regnskabbasis")

--- a/finans/rapport_includes/moms_afstemning.php
+++ b/finans/rapport_includes/moms_afstemning.php
@@ -31,6 +31,7 @@
 //                 ikke nulstiller grundlaget for konti med blandet momstatus.
 //                 COALESCE(debet,0)/COALESCE(kredit,0): transaktioner gemmer ubrugt
 //                 side som NULL; NULL-aritmetik gav NULL (vist som 0) i SUM.
+// 20260729 NTR - Reported by CodeRabbit - moved summery of over tolerance above table instead of in the table's body.
 
 function moms_afstemning($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
                          $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,

--- a/finans/rapport_includes/moms_afstemning.php
+++ b/finans/rapport_includes/moms_afstemning.php
@@ -1,0 +1,315 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- finans/rapport_includes/moms_afstemning.php --- patch 5.0.0 --- 2026-07-22 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+// 20260716 MJ R4 – Momsafstemning (momssandsynliggoerelse): pr. (konto, momskode)
+//                  sammenligner bogfoert moms med beregnet moms. Differencer fremhaeves.
+//                  CSV-eksport.
+// 20260720 MJ  Fiscal-year-aware kvartalsgenveje (fy_start/slut vars).
+// 20260722 MJ  Omsaetning tæller kun momsbelagte linjer så VAT-fri-posteringer
+//                 ikke nulstiller grundlaget for konti med blandet momstatus.
+//                 COALESCE(debet,0)/COALESCE(kredit,0): transaktioner gemmer ubrugt
+//                 side som NULL; NULL-aritmetik gav NULL (vist som 0) i SUM.
+
+function moms_afstemning($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
+                         $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
+                         $ansat_fra, $ansat_til, $afd, $projekt_fra, $projekt_til,
+                         $simulering, $lagerbev) {
+
+    global $db, $md, $menu, $sprog_id, $top_bund;
+    global $buttonStyle, $topStyle;
+    global $ansatte_id, $afd_navn, $ansatte;
+
+    $regnaar    = (int)$regnaar;
+    $maaned_fra = trim($maaned_fra);
+    $maaned_til = trim($maaned_til);
+    $konto_fra  = trim($konto_fra);
+    $konto_til  = trim($konto_til);
+
+    for ($x = 1; $x <= 12; $x++) {
+        if ($maaned_fra == $md[$x]) $maaned_fra = $x;
+        if ($maaned_til == $md[$x]) $maaned_til = $x;
+        if (strlen($maaned_fra) == 1) $maaned_fra = '0'.$maaned_fra;
+        if (strlen($maaned_til) == 1) $maaned_til = '0'.$maaned_til;
+    }
+    $mf = $maaned_fra;
+    $mt = $maaned_til;
+
+    $row = db_fetch_array(db_select("select * from grupper where kodenr='$regnaar' and art='RA'", __FILE__." linje ".__LINE__));
+    $startmaaned = (int)($row['box1'] ?? 1);
+    $startaar    = (int)($row['box2'] ?? $regnaar);
+    $slutmaaned  = (int)($row['box3'] ?? 12);
+    $slutaar     = (int)($row['box4'] ?? $regnaar);
+    $fy_startmaaned = $startmaaned;
+    $fy_slutmaaned  = $slutmaaned;
+    $fy_startaar    = $startaar;
+    $fy_slutaar     = $slutaar;
+    $startdato   = 1;
+    $slutdato    = 31;
+
+    if ($aar_fra < $aar_til) {
+        if ($maaned_til > $slutmaaned)      $aar_til = $aar_fra;
+        elseif ($maaned_fra < $startmaaned) $aar_fra = $aar_til;
+    }
+    if ($aar_fra)    $startaar    = $aar_fra;
+    if ($aar_til)    $slutaar     = $aar_til;
+    if ($maaned_fra) $startmaaned = $maaned_fra;
+    if ($maaned_til) $slutmaaned  = $maaned_til;
+    if ($dato_fra)   $startdato   = $dato_fra;
+    if ($dato_til)   $slutdato    = $dato_til;
+
+    $startdato = (int)$startdato;
+    if ($startdato < 10) $startdato = '0'.$startdato;
+    while (!checkdate($startmaaned, $startdato, $startaar)) { $startdato--; if ($startdato < 28) break; }
+    while (!checkdate($slutmaaned,  $slutdato,  $slutaar))  { $slutdato--;  if ($slutdato  < 28) break; }
+    if (strlen((string)$startdato) < 2) $startdato = '0'.$startdato;
+
+    $regnstart = "$startaar-$startmaaned-$startdato";
+    $regnslut  = "$slutaar-$slutmaaned-$slutdato";
+
+    $dim = '';
+    if ($afd || $afd == '0') $dim = "AND t.afd = $afd ";
+
+    // configurable tolerance — persisted in session so it survives report navigation
+    if (array_key_exists('tolerance', $_GET) && $_GET['tolerance'] !== '') {
+        $tolerance = abs((float)$_GET['tolerance']);
+        $_SESSION['moms_afstemning_tolerance'] = $tolerance;
+    } else {
+        $tolerance = isset($_SESSION['moms_afstemning_tolerance']) ? (float)$_SESSION['moms_afstemning_tolerance'] : 0;
+    }
+
+    $konto_filter = '';
+    if ($konto_fra && $konto_til && $konto_fra != $konto_til)
+        $konto_filter = "AND kp.kontonr >= '$konto_fra' AND kp.kontonr <= '$konto_til' ";
+    elseif ($konto_fra)
+        $konto_filter = "AND kp.kontonr = '$konto_fra' ";
+
+    $csvfile = "../temp/$db/moms_afstemning.csv";
+    $csv     = fopen($csvfile, "w");
+
+    $title    = 'Rapport • Momsafstemning';
+    $back_url = "rapport.php?rapportart=moms_afstemning&regnaar=$regnaar"
+              . "&dato_fra=$startdato&maaned_fra=$mf&aar_fra=$aar_fra"
+              . "&dato_til=$slutdato&maaned_til=$mt&aar_til=$aar_til"
+              . "&konto_fra=$konto_fra&konto_til=$konto_til"
+              . "&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+              . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til"
+              . "&simulering=$simulering&lagerbev=$lagerbev&tolerance=$tolerance";
+    $csv_btn  = "<a href='$csvfile' style='color:#ffffff; text-decoration:none;'><i class='fa fa-download'></i> CSV</a>";
+
+    include("../includes/topline_settings.php");
+
+    if ($menu == 'T') {
+        include_once '../includes/top_header.php';
+        include_once '../includes/top_menu.php';
+        print "<div id=\"header\">";
+        print "<div class=\"headerbtnLft headLink\"><a href=\"$back_url\" accesskey=\"L\"><i class='fa fa-close fa-lg'></i> Luk</a></div>";
+        print "<div class=\"headerTxt\">Momsafstemning</div>";
+        print "<div class=\"headerbtnRght headLink\">$csv_btn</div>";
+        print "</div>";
+        print "<div class='content-noside'>";
+    } elseif ($menu == 'S') {
+        $back_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+        print "<table bgcolor='#eeeef0' width='100%' cellpadding='0' cellspacing='0' border='0'><tbody><tr><td colspan=8 align=center>";
+        print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody>";
+        print "<td width='5%'><a href=\"javascript:confirmClose('$back_url','')\" accesskey=L>"
+            . "<button class='headerbtn' type='button' style='$buttonStyle; width:100%; display:flex; align-items:center; gap:5px;'>"
+            . "$back_icon Tilbage</button></a></td>";
+        print "<td width='80%' align='center' style='$topStyle'>Momsafstemning</td>";
+        print "<td width='10%' align='center' style='$buttonStyle'>$csv_btn</td>";
+        print "<td width='5%'></td>";
+        print "</tbody></table></td></tr></tbody></table>";
+    } else {
+        print "<table width='100%' cellpadding='0' cellspacing='1px' border='0' valign='top' align='center'>";
+        print "<tr><td colspan='6' height='8'>";
+        print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>";
+        print "<td width='10%' $top_bund><a accesskey=L href='$back_url'>Luk</a></td>";
+        print "<td width='80%' $top_bund>Rapport - Momsafstemning</td>";
+        print "<td width='10%' $top_bund><a href='$csvfile'>CSV</a></td>";
+        print "</tbody></table></td></tr></table>";
+    }
+
+    $row = db_fetch_array(db_select("select firmanavn from adresser where art='S'", __FILE__." linje ".__LINE__));
+    $firmanavn = $row ? $row['firmanavn'] : '';
+    print "<div style='padding:8px 12px;'><big><b>$firmanavn</b></big><br>";
+    print "Periode: " . dkdato($regnstart) . " – " . dkdato($regnslut);
+    print " &nbsp;|&nbsp; Tolerance: " . dkdecimal($tolerance, 2) . " kr.";
+    print "</div>";
+
+    // Quarter shortcuts
+    $q_base = "rapport.php?rapportart=moms_afstemning&regnaar=$regnaar&dato_fra=01&dato_til=31"
+            . "&konto_fra=$konto_fra&konto_til=$konto_til&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+            . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til&simulering=$simulering&lagerbev=$lagerbev"
+            . "&tolerance=$tolerance";
+    print "<div class='no-print' style='padding:2px 12px 6px; font-size:0.9em; color:#555;'>Genveje: ";
+    foreach (['Q1'=>[1,3],'Q2'=>[4,6],'Q3'=>[7,9],'Q4'=>[10,12]] as $ql => $qm) {
+        $qaar = ($fy_startaar !== $fy_slutaar && $qm[0] >= $fy_startmaaned) ? $fy_startaar : $fy_slutaar;
+        print "<a href='$q_base&maaned_fra={$qm[0]}&aar_fra=$qaar&maaned_til={$qm[1]}&aar_til=$qaar' style='margin-right:8px;'>$ql</a>";
+    }
+    print "<a href='$q_base&maaned_fra=$fy_startmaaned&aar_fra=$fy_startaar&maaned_til=$fy_slutmaaned&aar_til=$fy_slutaar'>Hele &aring;ret</a></div>";
+
+    // tolerance filter form
+    print "<form method='GET' action='rapport.php' style='padding:4px 12px; display:inline-block;'>";
+    foreach (['rapportart'=>'moms_afstemning','regnaar'=>$regnaar,'dato_fra'=>$startdato,
+              'maaned_fra'=>$mf,'aar_fra'=>$aar_fra,'dato_til'=>$slutdato,'maaned_til'=>$mt,
+              'aar_til'=>$aar_til,'konto_fra'=>$konto_fra,'konto_til'=>$konto_til,
+              'ansat_fra'=>$ansat_fra,'ansat_til'=>$ansat_til,'afd'=>$afd,
+              'projekt_fra'=>$projekt_fra,'projekt_til'=>$projekt_til,
+              'simulering'=>$simulering,'lagerbev'=>$lagerbev] as $k => $v) {
+        print "<input type='hidden' name='" . htmlspecialchars($k) . "' value='" . htmlspecialchars($v) . "'>";
+    }
+    print "Tolerance (kr.): <input type='number' name='tolerance' step='0.01' min='0' value='"
+        . htmlspecialchars($tolerance) . "' style='width:70px;'> "
+        . "<input type='submit' value='Opdater'></form>";
+
+    // Main aggregation query:
+    // Per (kontonr, momskode): sum VAT-bearing turnover (lines where moms != 0 only),
+    // sum booked VAT from t.moms, derive calculated VAT = turnover * rate / 100.
+    // Only counting moms-bearing lines in omsaetning prevents VAT-free postings on the
+    // same account from masking the real taxable base.
+    $qtxt = "SELECT"
+          . " kp.kontonr,"
+          . " kp.beskrivelse AS konto_navn,"
+          . " kp.moms AS momskode,"
+          . " g.beskrivelse AS moms_navn,"
+          . " CAST(COALESCE(NULLIF(g.box2,''),NULL) AS NUMERIC(10,4)) AS momssats,"
+          . " SUM(CASE WHEN NULLIF(t.moms, 0) IS NOT NULL THEN COALESCE(t.debet, 0) - COALESCE(t.kredit, 0) ELSE 0 END) AS omsaetning,"
+          . " SUM(t.moms) AS bogfoert_moms"
+          . " FROM transaktioner t"
+          . " JOIN kontoplan kp ON kp.kontonr = t.kontonr AND kp.regnskabsaar = '$regnaar'"
+          . " JOIN ("
+          .   " SELECT DISTINCT ON (art, kodenr) art, kodenr, beskrivelse, box2"
+          .   " FROM grupper WHERE art IN ('SM','KM','YM','EM')"
+          .   " ORDER BY art, kodenr, fiscal_year DESC NULLS LAST"
+          . " ) g ON g.art = UPPER(SUBSTRING(kp.moms FROM 1 FOR 1)) || 'M'"
+          .   " AND CAST(g.kodenr AS TEXT) = SUBSTRING(kp.moms FROM 2)"
+          . " WHERE t.transdate >= '$regnstart' AND t.transdate <= '$regnslut'"
+          . " AND kp.moms IS NOT NULL AND kp.moms != ''"
+          . " $konto_filter $dim"
+          . " GROUP BY kp.kontonr, kp.beskrivelse, kp.moms, g.beskrivelse, g.box2"
+          . " ORDER BY kp.kontonr, kp.moms";
+
+    $q = db_select($qtxt, __FILE__." linje ".__LINE__);
+
+    print "<div style='overflow-x:auto; padding:0 12px;'>";
+    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+    print "<thead><tr style='position:sticky; top:0; background:#eeeef0;'>";
+    print "<th align='left'  style='width:80px'>Konto</th>";
+    print "<th align='left'>Kontonavn</th>";
+    print "<th align='left'  style='width:70px'>Momskode</th>";
+    print "<th align='left'  style='width:100px'>Momsnavn</th>";
+    print "<th align='right' style='width:50px'>Sats %</th>";
+    print "<th align='right' style='width:120px'>Omsaetning</th>";
+    print "<th align='right' style='width:120px'>Beregnet moms</th>";
+    print "<th align='right' style='width:120px'>Bogfoert moms</th>";
+    print "<th align='right' style='width:120px'>Difference</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding(
+        "Konto;Kontonavn;Momskode;Momsnavn;Sats %;Omsaetning;Beregnet moms;Bogfoert moms;Difference\n",
+        'ISO-8859-1', 'UTF-8'));
+
+    // Buffer results so we can show summary before the table
+    $rows = [];
+    while ($r = db_fetch_array($q)) $rows[] = $r;
+
+    // Compute summary
+    $total_rows = count($rows);
+    $diff_rows  = 0;
+    foreach ($rows as $r) {
+        $s = ($r['momssats'] !== null) ? (float)$r['momssats'] : 0;
+        if ($s > 0 && abs(afrund((float)$r['bogfoert_moms'] - afrund((float)$r['omsaetning'] * $s / 100, 2), 2)) > $tolerance)
+            $diff_rows++;
+    }
+    if ($total_rows > 0) {
+        $sum_bg    = $diff_rows > 0 ? '#ffe0e0' : '#d4edda';
+        $sum_color = $diff_rows > 0 ? '#c00'    : '#155724';
+        print "<div style='padding:6px 12px; margin:4px 12px 8px; border-radius:4px; background:$sum_bg; color:$sum_color;'>";
+        if ($diff_rows > 0)
+            print "<b>$diff_rows af $total_rows r&aelig;kker</b> har afvigelse over tolerance (" . dkdecimal($tolerance, 2) . " kr.).";
+        else
+            print "<b>Ingen afvigelser</b> fundet i $total_rows r&aelig;kker.";
+        print "</div>";
+    }
+
+    $row_bg = ['#ffffff','#f5f5f5'];
+    $row_i  = 0;
+    $has_rows = false;
+
+    foreach ($rows as $row) {
+        $has_rows    = true;
+        $sats        = ($row['momssats'] !== null) ? (float)$row['momssats'] : 0;
+        $omsaetning  = (float)$row['omsaetning'];
+        $bogfoert    = (float)$row['bogfoert_moms'];
+        $beregnet    = ($sats > 0) ? afrund($omsaetning * $sats / 100, 2) : 0;
+        $diff        = afrund($bogfoert - $beregnet, 2);
+        $abs_diff    = abs($diff);
+
+        $row_style = ($abs_diff > $tolerance && $sats > 0)
+            ? "background:#ffe0e0;"
+            : "background:" . $row_bg[$row_i % 2] . ";";
+        $row_i++;
+
+        $diff_style = ($abs_diff > $tolerance && $sats > 0) ? " style='color:#c00; font-weight:bold;'" : '';
+
+        print "<tr style='$row_style'>";
+        print "<td>" . htmlspecialchars($row['kontonr']) . "</td>";
+        print "<td>" . htmlspecialchars($row['konto_navn']) . "</td>";
+        print "<td>" . htmlspecialchars($row['momskode']) . "</td>";
+        print "<td style='font-size:0.85em;'>" . htmlspecialchars($row['moms_navn'] ?? '') . "</td>";
+        print "<td align='right'>" . ($sats > 0 ? dkdecimal($sats, 2) : '') . "</td>";
+        print "<td align='right'>" . dkdecimal($omsaetning, 2) . "</td>";
+        print "<td align='right'>" . ($sats > 0 ? dkdecimal($beregnet, 2) : '<span style="color:#aaa">–</span>') . "</td>";
+        print "<td align='right'>" . dkdecimal($bogfoert, 2) . "</td>";
+        print "<td align='right'$diff_style>" . ($sats > 0 ? dkdecimal($diff, 2) : '<span style="color:#aaa">–</span>') . "</td>";
+        print "</tr>\n";
+
+        fwrite($csv, mb_convert_encoding(
+            $row['kontonr'] . ";"
+            . $row['konto_navn'] . ";"
+            . $row['momskode'] . ";"
+            . ($row['moms_navn'] ?? '') . ";"
+            . ($sats > 0 ? dkdecimal($sats, 2) : '') . ";"
+            . "\"" . dkdecimal($omsaetning, 2) . "\";"
+            . "\"" . ($sats > 0 ? dkdecimal($beregnet, 2) : '') . "\";"
+            . "\"" . dkdecimal($bogfoert, 2) . "\";"
+            . "\"" . ($sats > 0 ? dkdecimal($diff, 2) : '') . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    } // end foreach $rows
+
+    if (!$has_rows) {
+        print "<tr><td colspan='9' align='center' style='padding:16px; color:#888;'>"
+            . "Ingen posteringer med momskode i den valgte periode.</td></tr>";
+    }
+
+    print "</tbody></table></div>";
+    fclose($csv);
+
+    if ($menu == 'T') {
+        include_once '../includes/topmenu/footer.php';
+    } else {
+        include_once '../includes/oldDesign/footer.php';
+    }
+}
+?>

--- a/finans/rapport_includes/moms_afstemning.php
+++ b/finans/rapport_includes/moms_afstemning.php
@@ -213,22 +213,7 @@ function moms_afstemning($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
     $q = db_select($qtxt, __FILE__." linje ".__LINE__);
 
     print "<div style='overflow-x:auto; padding:0 12px;'>";
-    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
-    print "<thead><tr style='position:sticky; top:0; background:#eeeef0;'>";
-    print "<th align='left'  style='width:80px'>Konto</th>";
-    print "<th align='left'>Kontonavn</th>";
-    print "<th align='left'  style='width:70px'>Momskode</th>";
-    print "<th align='left'  style='width:100px'>Momsnavn</th>";
-    print "<th align='right' style='width:50px'>Sats %</th>";
-    print "<th align='right' style='width:120px'>Omsaetning</th>";
-    print "<th align='right' style='width:120px'>Beregnet moms</th>";
-    print "<th align='right' style='width:120px'>Bogfoert moms</th>";
-    print "<th align='right' style='width:120px'>Difference</th>";
-    print "</tr></thead><tbody>";
 
-    fwrite($csv, mb_convert_encoding(
-        "Konto;Kontonavn;Momskode;Momsnavn;Sats %;Omsaetning;Beregnet moms;Bogfoert moms;Difference\n",
-        'ISO-8859-1', 'UTF-8'));
 
     // Buffer results so we can show summary before the table
     $rows = [];
@@ -252,6 +237,25 @@ function moms_afstemning($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
             print "<b>Ingen afvigelser</b> fundet i $total_rows r&aelig;kker.";
         print "</div>";
     }
+
+    // Write the table
+    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+    print "<thead><tr style='position:sticky; top:0; background:#eeeef0;'>";
+    print "<th align='left'  style='width:80px'>Konto</th>";
+    print "<th align='left'>Kontonavn</th>";
+    print "<th align='left'  style='width:70px'>Momskode</th>";
+    print "<th align='left'  style='width:100px'>Momsnavn</th>";
+    print "<th align='right' style='width:50px'>Sats %</th>";
+    print "<th align='right' style='width:120px'>Omsaetning</th>";
+    print "<th align='right' style='width:120px'>Beregnet moms</th>";
+    print "<th align='right' style='width:120px'>Bogfoert moms</th>";
+    print "<th align='right' style='width:120px'>Difference</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding(
+        "Konto;Kontonavn;Momskode;Momsnavn;Sats %;Omsaetning;Beregnet moms;Bogfoert moms;Difference\n",
+        'ISO-8859-1', 'UTF-8'));
+
 
     $row_bg = ['#ffffff','#f5f5f5'];
     $row_i  = 0;

--- a/finans/rapport_includes/moms_oss.php
+++ b/finans/rapport_includes/moms_oss.php
@@ -1,0 +1,634 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- finans/rapport_includes/moms_oss.php --- patch 5.0.0 --- 2026-07-23 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+// 20260716 MJ R2 – OSS B2C EU-salg: oversigt over momspligtige salg og opkraevet
+//                  moms pr. land og sats til brug ved OSS-momsangivelse.
+//                  Kraever at Land (OSS) er sat i Indstillinger -> Moms paa de
+//                  relevante SM-momskoder. Type (varer/ydelser) er valgfrit.
+//                  CSV-eksport.
+// 20260717 MJ     Tilfoejede detaljeret posteringsoversigt (alle OSS-linjer med dato,
+//                  bilag, tekst, beloeb, moms, beloeb inkl. moms) over sammendrag.
+//                  Sammendrag omstruktureret med separate kolonner for varer/ydelser.
+// 20260720 MJ  Fiscal-year-aware kvartalsgenveje; note om at kontofilter ikke galder OSS.
+// 20260720 MJ  Bugfix: t.tekst → t.beskrivelse AS tekst (transaktioner har ikke kolonne tekst).
+// 20260722 MJ  COALESCE(debet,0)/COALESCE(kredit,0) i beloeb-udtryk: NULL-
+//                 aritmetik gav NULL for rene debet- eller kreditposteringer.
+// 20260723 MJ  EU-zone klassificering via debitorgruppe (grupper.box10): poster
+//                 knyttes til kundetype (B2C-EU/B2B-EU/B2C-UDL/B2B-UDL) via
+//                 transaktioner.ordre_id → ordrer → adresser → grupper(DG).
+//                 OSS-oversigt filtreres til B2C-EU; oevrige vises separat.
+
+function moms_oss($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
+                  $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
+                  $ansat_fra, $ansat_til, $afd, $projekt_fra, $projekt_til,
+                  $simulering, $lagerbev) {
+
+    global $db, $md, $menu, $sprog_id, $top_bund;
+    global $buttonStyle, $topStyle;
+    global $ansatte_id, $afd_navn, $ansatte;
+
+    $regnaar    = (int)$regnaar;
+    $maaned_fra = trim($maaned_fra);
+    $maaned_til = trim($maaned_til);
+
+    for ($x = 1; $x <= 12; $x++) {
+        if ($maaned_fra == $md[$x]) $maaned_fra = $x;
+        if ($maaned_til == $md[$x]) $maaned_til = $x;
+        if (strlen($maaned_fra) == 1) $maaned_fra = '0'.$maaned_fra;
+        if (strlen($maaned_til) == 1) $maaned_til = '0'.$maaned_til;
+    }
+    $mf = $maaned_fra;
+    $mt = $maaned_til;
+
+    $row = db_fetch_array(db_select("select * from grupper where kodenr='$regnaar' and art='RA'", __FILE__." linje ".__LINE__));
+    $startmaaned = (int)($row['box1'] ?? 1);
+    $startaar    = (int)($row['box2'] ?? $regnaar);
+    $slutmaaned  = (int)($row['box3'] ?? 12);
+    $slutaar     = (int)($row['box4'] ?? $regnaar);
+    $fy_startmaaned = $startmaaned;
+    $fy_slutmaaned  = $slutmaaned;
+    $fy_startaar    = $startaar;
+    $fy_slutaar     = $slutaar;
+    $startdato   = 1;
+    $slutdato    = 31;
+
+    if ($aar_fra < $aar_til) {
+        if ($maaned_til > $slutmaaned)      $aar_til = $aar_fra;
+        elseif ($maaned_fra < $startmaaned) $aar_fra = $aar_til;
+    }
+    if ($aar_fra)    $startaar    = $aar_fra;
+    if ($aar_til)    $slutaar     = $aar_til;
+    if ($maaned_fra) $startmaaned = $maaned_fra;
+    if ($maaned_til) $slutmaaned  = $maaned_til;
+    if ($dato_fra)   $startdato   = $dato_fra;
+    if ($dato_til)   $slutdato    = $dato_til;
+
+    $startdato = (int)$startdato;
+    if ($startdato < 10) $startdato = '0'.$startdato;
+    while (!checkdate($startmaaned, $startdato, $startaar)) { $startdato--; if ($startdato < 28) break; }
+    while (!checkdate($slutmaaned,  $slutdato,  $slutaar))  { $slutdato--;  if ($slutdato  < 28) break; }
+    if (strlen((string)$startdato) < 2) $startdato = '0'.$startdato;
+
+    $regnstart = "$startaar-$startmaaned-$startdato";
+    $regnslut  = "$slutaar-$slutmaaned-$slutdato";
+
+    $dim = '';
+    if ($afd || $afd == '0') $dim = "AND t.afd = $afd ";
+
+    $csvfile = "../temp/$db/moms_oss.csv";
+    $csv     = fopen($csvfile, "w");
+
+    $title    = 'Rapport • OSS B2C EU-salg';
+    $back_url = "rapport.php?rapportart=moms_oss&regnaar=$regnaar"
+              . "&dato_fra=$startdato&maaned_fra=$mf&aar_fra=$aar_fra"
+              . "&dato_til=$slutdato&maaned_til=$mt&aar_til=$aar_til"
+              . "&konto_fra=$konto_fra&konto_til=$konto_til"
+              . "&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+              . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til"
+              . "&simulering=$simulering&lagerbev=$lagerbev";
+    $csv_btn   = "<a href='$csvfile' style='color:#ffffff; text-decoration:none;'><i class='fa fa-download'></i> CSV</a>";
+    $print_btn = "<button onclick='window.print()' style='background:transparent;border:none;color:#fff;cursor:pointer;padding:0;'><i class='fa fa-print'></i> Print</button>";
+    print "<style>@media print{"
+        . ".no-print,button,form,a[href*='rapport.php'],a[href*='confirmClose']{display:none!important}"
+        . "table{page-break-inside:auto}tr{page-break-inside:avoid}"
+        . "body,div{font-size:10pt}"
+        . "}</style>";
+
+    include("../includes/topline_settings.php");
+
+    if ($menu == 'T') {
+        include_once '../includes/top_header.php';
+        include_once '../includes/top_menu.php';
+        print "<div id=\"header\">";
+        print "<div class=\"headerbtnLft headLink\"><a href=\"$back_url\" accesskey=\"L\"><i class='fa fa-close fa-lg'></i> Luk</a></div>";
+        print "<div class=\"headerTxt\">OSS B2C EU-salg</div>";
+        print "<div class=\"headerbtnRght headLink\">$csv_btn</div>";
+        print "</div>";
+        print "<div class='content-noside'>";
+    } elseif ($menu == 'S') {
+        $back_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+        print "<table bgcolor='#eeeef0' width='100%' cellpadding='0' cellspacing='0' border='0'><tbody><tr><td colspan=8 align=center>";
+        print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody>";
+        print "<td width='5%'><a href=\"javascript:confirmClose('$back_url','')\" accesskey=L>"
+            . "<button class='headerbtn' type='button' style='$buttonStyle; width:100%; display:flex; align-items:center; gap:5px;'>"
+            . "$back_icon Tilbage</button></a></td>";
+        print "<td width='80%' align='center' style='$topStyle'>OSS B2C EU-salg</td>";
+        print "<td width='5%' align='center' style='$buttonStyle'>$print_btn</td>";
+        print "<td width='10%' align='center' style='$buttonStyle'>$csv_btn</td>";
+        print "</tbody></table></td></tr></tbody></table>";
+    } else {
+        print "<table width='100%' cellpadding='0' cellspacing='1px' border='0' valign='top' align='center'>";
+        print "<tr><td colspan='6' height='8'>";
+        print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>";
+        print "<td width='10%' $top_bund><a accesskey=L href='$back_url'>Luk</a></td>";
+        print "<td width='80%' $top_bund>Rapport - OSS B2C EU-salg</td>";
+        print "<td width='10%' $top_bund><a href='$csvfile'>CSV</a></td>";
+        print "</tbody></table></td></tr></table>";
+    }
+
+    $row = db_fetch_array(db_select("select firmanavn from adresser where art='S'", __FILE__." linje ".__LINE__));
+    $firmanavn = $row ? $row['firmanavn'] : '';
+    print "<div style='padding:8px 12px;'><big><b>$firmanavn</b></big><br>";
+    print "Periode: " . dkdato($regnstart) . " – " . dkdato($regnslut) . "</div>";
+
+    // Quarter shortcuts
+    $q_base = "rapport.php?rapportart=moms_oss&regnaar=$regnaar&dato_fra=01&dato_til=31"
+            . "&ansat_fra=$ansat_fra&ansat_til=$ansat_til&afd=$afd"
+            . "&projekt_fra=$projekt_fra&projekt_til=$projekt_til&simulering=$simulering&lagerbev=$lagerbev";
+    print "<div class='no-print' style='padding:2px 12px 6px; font-size:0.9em; color:#555;'>Genveje: ";
+    foreach (['Q1'=>[1,3],'Q2'=>[4,6],'Q3'=>[7,9],'Q4'=>[10,12]] as $ql => $qm) {
+        $qaar = ($fy_startaar !== $fy_slutaar && $qm[0] >= $fy_startmaaned) ? $fy_startaar : $fy_slutaar;
+        print "<a href='$q_base&maaned_fra={$qm[0]}&aar_fra=$qaar&maaned_til={$qm[1]}&aar_til=$qaar' style='margin-right:8px;'>$ql</a>";
+    }
+    print "<a href='$q_base&maaned_fra=$fy_startmaaned&aar_fra=$fy_startaar&maaned_til=$fy_slutmaaned&aar_til=$fy_slutaar'>Hele &aring;ret</a></div>";
+    print "<div class='no-print' style='padding:0 12px 6px; font-size:0.85em; color:#888;'>"
+        . "Kontofilter gælder ikke for OSS-rapporten — den dækker alle konti med OSS-momskoder.</div>";
+
+    // Check if any OSS codes are configured
+    $has_oss = db_fetch_array(db_select(
+        "SELECT 1 FROM grupper WHERE art = 'SM' AND box6 IS NOT NULL AND box6 != '' LIMIT 1",
+        __FILE__." linje ".__LINE__));
+    if (!$has_oss) {
+        print "<div style='padding:16px 12px; color:#c00;'>";
+        print "<b>OSS-momskoder ikke konfigureret.</b><br>";
+        print "Gaa til <a href='../systemdata/syssetup.php?valg=moms'>Indstillinger &rarr; Moms</a> ";
+        print "og udfyld feltet <b>Land (OSS)</b> for de SM-momskoder, der vedrører salg til EU-privatpersoner.";
+        print "</div>";
+        if ($menu == 'T') {
+            include_once '../includes/topmenu/footer.php';
+        } else {
+            include_once '../includes/oldDesign/footer.php';
+        }
+        fclose($csv);
+        return;
+    }
+
+    // Check whether any OSS codes have Type configured (for info note)
+    $has_type = db_fetch_array(db_select(
+        "SELECT 1 FROM grupper WHERE art = 'SM' AND box6 IS NOT NULL AND box6 != '' AND box7 IS NOT NULL AND box7 != '' LIMIT 1",
+        __FILE__." linje ".__LINE__));
+
+    if (!$has_type) {
+        print "<div style='padding:6px 12px 4px; color:#856404; background:#fff3cd; border-radius:4px; margin:0 12px 8px;'>";
+        print "<b>Tip:</b> Feltet <b>Type</b> (varer/ydelser) er ikke udfyldt paa OSS-momskoderne. ";
+        print "Udfyld det i <a href='../systemdata/syssetup.php?valg=moms'>Indstillinger &rarr; Moms</a> "
+            . "for at faa opdelt OSS-angivelsen paa varer og ydelser.";
+        print "</div>";
+    }
+
+    // Core JOIN: kontoplan + SM VAT code (used by all queries)
+    $j_kp_sm = " JOIN kontoplan kp ON kp.kontonr = t.kontonr AND kp.regnskabsaar = '$regnaar'"
+             . " JOIN ("
+             .   " SELECT DISTINCT ON (art, kodenr) art, kodenr, beskrivelse, box2, box6, box7"
+             .   " FROM grupper"
+             .   " WHERE art = 'SM' AND box6 IS NOT NULL AND box6 != ''"
+             .   " ORDER BY art, kodenr, fiscal_year DESC NULLS LAST"
+             . " ) g ON g.art = UPPER(SUBSTRING(kp.moms FROM 1 FOR 1)) || 'M'"
+             .   " AND CAST(g.kodenr AS TEXT) = SUBSTRING(kp.moms FROM 2)";
+
+    // EU-zone JOIN: ordre → adresser → debitorgruppe (box10)
+    $j_dg = " LEFT JOIN ordrer ord ON ord.id = t.ordre_id AND t.ordre_id > 0"
+          . " LEFT JOIN adresser adr ON adr.id = ord.konto_id"
+          . " LEFT JOIN ("
+          .   " SELECT DISTINCT ON (kodenr) kodenr, box10"
+          .   " FROM grupper WHERE art = 'DG'"
+          .   " ORDER BY kodenr, fiscal_year DESC NULLS LAST"
+          . " ) dg ON CAST(dg.kodenr AS TEXT) = CAST(adr.gruppe AS TEXT)";
+
+    $oss_where = " WHERE t.transdate >= '$regnstart' AND t.transdate <= '$regnslut'"
+               . " AND kp.moms IS NOT NULL AND kp.moms != ''"
+               . " $dim";
+
+    // Check whether any debitor groups have EU-zone configured
+    $has_eu_zone = db_fetch_array(db_select(
+        "SELECT 1 FROM grupper WHERE art = 'DG' AND box10 IS NOT NULL AND box10 != '' LIMIT 1",
+        __FILE__." linje ".__LINE__));
+
+    // EU-zone display map
+    $zone_style = [
+        'B2C-EU'  => ['label' => 'B2C EU',         'bg' => '#d4edda', 'color' => '#155724'],
+        'B2C-UDL' => ['label' => 'B2C udenfor EU',  'bg' => '#fff3cd', 'color' => '#856404'],
+        'B2B-EU'  => ['label' => 'B2B EU',          'bg' => '#cce5ff', 'color' => '#004085'],
+        'B2B-UDL' => ['label' => 'B2B udenfor EU',  'bg' => '#d6d8db', 'color' => '#383d41'],
+        ''        => ['label' => 'Uklassificeret',  'bg' => '#f8d7da', 'color' => '#721c24'],
+    ];
+    $zone_hdr_bg = [
+        'B2C-EU'  => '#1a6b3a', 'B2C-UDL' => '#6c5700',
+        'B2B-EU'  => '#004085', 'B2B-UDL' => '#4b4f54', '' => '#721c24',
+    ];
+
+    // ----------------------------------------------------------------
+    // SECTION 1 — per-posting detail
+    // ----------------------------------------------------------------
+    $qtxt_detail = "SELECT"
+        . " t.transdate AS dato,"
+        . " t.bilag,"
+        . " t.beskrivelse AS tekst,"
+        . " kp.moms AS momskode,"
+        . " g.beskrivelse AS kode_navn,"
+        . " CAST(COALESCE(NULLIF(g.box2,''),NULL) AS NUMERIC(10,2)) AS momssats,"
+        . " g.box6 AS land,"
+        . " COALESCE(NULLIF(TRIM(g.box7),''), '') AS type,"
+        . " (COALESCE(t.kredit, 0) - COALESCE(t.debet, 0)) AS beloeb,"
+        . " -COALESCE(t.moms, 0) AS momsbeloeb,"
+        . " (COALESCE(t.kredit, 0) - COALESCE(t.debet, 0)) - COALESCE(t.moms, 0) AS beloeb_inkl_moms,"
+        . " COALESCE(NULLIF(TRIM(dg.box10),''), '') AS eu_zone"
+        . " FROM transaktioner t"
+        . $j_kp_sm . $j_dg . $oss_where
+        . " ORDER BY"
+        .   " CASE COALESCE(NULLIF(TRIM(dg.box10),''),'')"
+        .   " WHEN 'B2C-EU' THEN 1 WHEN 'B2B-EU' THEN 2"
+        .   " WHEN 'B2C-UDL' THEN 3 WHEN 'B2B-UDL' THEN 4 ELSE 5 END,"
+        .   " g.box6, t.transdate, t.bilag, t.id";
+
+    $q_detail = db_select($qtxt_detail, __FILE__." linje ".__LINE__);
+
+    $section_h = "style='margin:16px 12px 6px; font-size:1.05em; font-weight:bold; color:#334;'";
+
+    print "<p $section_h>Alle posteringer</p>";
+    if (!$has_eu_zone) {
+        print "<div style='padding:4px 12px 6px; color:#856404; background:#fff3cd; border-radius:4px; margin:0 12px 8px;'>";
+        print "<b>Tip:</b> Sæt <b>EU-zone</b> paa debitorgrupperne under "
+            . "<a href='../systemdata/syssetup.php?valg=debitor'>Indstillinger &rarr; Debitor</a> "
+            . "(B2C EU, B2C udenfor EU, B2B EU, B2B udenfor EU) for at adskille OSS-pligtige posteringer fra oevrige.";
+        print "</div>";
+    }
+    print "<div style='overflow-x:auto; padding:0 12px;'>";
+    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+    print "<thead><tr style='background:#eeeef0;'>";
+    print "<th align='left'  style='width:90px'>Dato</th>";
+    print "<th align='left'  style='width:70px'>Bilag</th>";
+    print "<th align='left'>Tekst</th>";
+    print "<th align='left'  style='width:110px'>Kundetype</th>";
+    print "<th align='left'  style='width:70px'>Momskode</th>";
+    print "<th align='right' style='width:60px'>Sats %</th>";
+    print "<th align='right' style='width:130px'>Beloeb</th>";
+    print "<th align='right' style='width:130px'>Moms</th>";
+    print "<th align='right' style='width:130px'>Beloeb inkl. moms</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding(
+        "ALLE POSTERINGER\n"
+        . "Dato;Bilag;Tekst;Kundetype;Momskode;Sats %;Beloeb;Moms;Beloeb inkl. moms\n",
+        'ISO-8859-1', 'UTF-8'));
+
+    $row_bg     = ['#ffffff','#f5f5f5'];
+    $row_i      = 0;
+    $has_rows   = false;
+    $cur_zone   = null;
+    $cur_land   = null;
+    $land_base  = 0.0; $land_moms  = 0.0; $land_inkl  = 0.0;
+    $zone_base  = 0.0; $zone_moms  = 0.0; $zone_inkl  = 0.0;
+    $grand_base = 0.0; $grand_moms = 0.0; $grand_inkl = 0.0;
+
+    while ($row = db_fetch_array($q_detail)) {
+        $has_rows = true;
+        $zone     = $row['eu_zone'] ?? '';
+        $land     = $row['land'] ?? '';
+        $base     = (float)$row['beloeb'];
+        $moms     = (float)$row['momsbeloeb'];
+        $inkl     = (float)$row['beloeb_inkl_moms'];
+        $sats     = ($row['momssats'] !== null) ? (float)$row['momssats'] : 0;
+
+        // Zone or land break
+        $zone_changed = ($cur_zone !== null && $cur_zone !== $zone);
+        $land_changed = ($cur_land !== null && ($cur_land !== $land || $zone_changed));
+
+        if ($land_changed) {
+            print "<tr style='background:#dce8f0; font-weight:bold;'>";
+            print "<td colspan='6' align='right' style='padding-right:6px;'>Subtotal " . htmlspecialchars($cur_land) . "</td>";
+            print "<td align='right'>" . dkdecimal($land_base, 2) . "</td>";
+            print "<td align='right'>" . dkdecimal($land_moms, 2) . "</td>";
+            print "<td align='right'>" . dkdecimal($land_inkl, 2) . "</td>";
+            print "</tr>\n";
+            $land_base = 0.0; $land_moms = 0.0; $land_inkl = 0.0;
+            $row_i = 0;
+        }
+
+        if ($zone_changed) {
+            $zh = $zone_style[$cur_zone] ?? $zone_style[''];
+            print "<tr style='background:#d6e4f0; font-weight:bold;'>";
+            print "<td colspan='6' align='right' style='padding-right:6px;'>Zone-total " . htmlspecialchars($zh['label']) . "</td>";
+            print "<td align='right'>" . dkdecimal($zone_base, 2) . "</td>";
+            print "<td align='right'>" . dkdecimal($zone_moms, 2) . "</td>";
+            print "<td align='right'>" . dkdecimal($zone_inkl, 2) . "</td>";
+            print "</tr>\n";
+            $zone_base = 0.0; $zone_moms = 0.0; $zone_inkl = 0.0;
+        }
+
+        // Zone group header
+        if ($cur_zone !== $zone) {
+            $zh  = $zone_style[$zone] ?? $zone_style[''];
+            $hbg = $zone_hdr_bg[$zone] ?? '#333';
+            print "<tr style='background:$hbg; color:#fff;'>";
+            print "<td colspan='9' style='padding:5px 8px; font-weight:bold; letter-spacing:0.03em;'>"
+                . htmlspecialchars($zh['label'])
+                . ($zone === 'B2C-EU' ? ' — OSS-pligtig' : ' — ikke OSS')
+                . "</td></tr>\n";
+            $cur_zone = $zone;
+            fwrite($csv, mb_convert_encoding("\n" . $zh['label'] . "\n", 'ISO-8859-1', 'UTF-8'));
+        }
+
+        // Land header
+        if ($cur_land !== $land || $land_changed) {
+            print "<tr style='background:#c8d8e8;'>";
+            print "<td colspan='9' style='padding:4px 8px; font-weight:bold;'>" . htmlspecialchars($land) . "</td>";
+            print "</tr>\n";
+            $cur_land = $land;
+            fwrite($csv, mb_convert_encoding($land . "\n", 'ISO-8859-1', 'UTF-8'));
+        }
+
+        $land_base  += $base;  $land_moms  += $moms;  $land_inkl  += $inkl;
+        $zone_base  += $base;  $zone_moms  += $moms;  $zone_inkl  += $inkl;
+        $grand_base += $base;  $grand_moms += $moms;  $grand_inkl += $inkl;
+
+        $bg  = $row_bg[$row_i % 2];
+        $row_i++;
+        $zs  = $zone_style[$zone] ?? $zone_style[''];
+        $zbadge = "<span style='padding:1px 5px; border-radius:3px; font-size:0.82em;"
+                . " background:{$zs['bg']}; color:{$zs['color']};'>"
+                . htmlspecialchars($zs['label']) . "</span>";
+
+        print "<tr style='background:$bg;'>";
+        print "<td>" . dkdato($row['dato']) . "</td>";
+        print "<td>" . htmlspecialchars($row['bilag'] ?? '') . "</td>";
+        print "<td>" . htmlspecialchars($row['tekst'] ?? '') . "</td>";
+        print "<td>$zbadge</td>";
+        print "<td style='font-size:0.85em;'>" . htmlspecialchars($row['momskode']) . "</td>";
+        print "<td align='right'>" . ($sats > 0 ? dkdecimal($sats, 2) : '') . "</td>";
+        print "<td align='right'>" . dkdecimal($base, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($moms, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($inkl, 2) . "</td>";
+        print "</tr>\n";
+
+        fwrite($csv, mb_convert_encoding(
+            dkdato($row['dato']) . ";"
+            . ($row['bilag'] ?? '') . ";"
+            . ($row['tekst'] ?? '') . ";"
+            . $zs['label'] . ";"
+            . $row['momskode'] . ";"
+            . ($sats > 0 ? dkdecimal($sats, 2) : '') . ";"
+            . "\"" . dkdecimal($base, 2) . "\";"
+            . "\"" . dkdecimal($moms, 2) . "\";"
+            . "\"" . dkdecimal($inkl, 2) . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    }
+
+    if (!$has_rows) {
+        print "<tr><td colspan='9' align='center' style='padding:16px; color:#888;'>"
+            . "Ingen OSS-posteringer i den valgte periode.</td></tr>";
+    } else {
+        // Last land and zone subtotal
+        print "<tr style='background:#dce8f0; font-weight:bold;'>";
+        print "<td colspan='6' align='right' style='padding-right:6px;'>Subtotal " . htmlspecialchars($cur_land) . "</td>";
+        print "<td align='right'>" . dkdecimal($land_base, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($land_moms, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($land_inkl, 2) . "</td>";
+        print "</tr>\n";
+        $zh = $zone_style[$cur_zone] ?? $zone_style[''];
+        print "<tr style='background:#d6e4f0; font-weight:bold;'>";
+        print "<td colspan='6' align='right' style='padding-right:6px;'>Zone-total " . htmlspecialchars($zh['label']) . "</td>";
+        print "<td align='right'>" . dkdecimal($zone_base, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($zone_moms, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($zone_inkl, 2) . "</td>";
+        print "</tr>\n";
+        // Grand total
+        print "<tr style='background:#c8d8e8; font-weight:bold;'>";
+        print "<td colspan='6' align='right'>I alt</td>";
+        print "<td align='right'>" . dkdecimal($grand_base, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($grand_moms, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($grand_inkl, 2) . "</td>";
+        print "</tr>";
+        fwrite($csv, mb_convert_encoding(
+            "\nI alt;;;;;;;\"" . dkdecimal($grand_base, 2) . "\";\"" . dkdecimal($grand_moms, 2) . "\";\"" . dkdecimal($grand_inkl, 2) . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    }
+
+    print "</tbody></table></div>";
+
+    // ----------------------------------------------------------------
+    // SECTION 2 — OSS filing summary (B2C-EU only, per land × momssats)
+    // ----------------------------------------------------------------
+    $b2c_filter = $has_eu_zone
+        ? " AND COALESCE(NULLIF(TRIM(dg.box10),''),'') = 'B2C-EU'"
+        : "";
+
+    $qtxt_sum = "SELECT"
+        . " g.box6 AS land,"
+        . " CAST(COALESCE(NULLIF(g.box2,''),NULL) AS NUMERIC(10,2)) AS momssats,"
+        . " SUM(CASE WHEN LOWER(TRIM(g.box7)) LIKE 'var%' THEN COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) ELSE 0 END) AS beloeb_varer,"
+        . " SUM(CASE WHEN LOWER(TRIM(g.box7)) LIKE 'yd%' OR LOWER(TRIM(g.box7)) LIKE 'ser%'"
+        .       " THEN COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) ELSE 0 END) AS beloeb_ydelser,"
+        . " SUM(COALESCE(t.kredit, 0) - COALESCE(t.debet, 0)) AS beloeb_total,"
+        . " -SUM(COALESCE(t.moms, 0)) AS momsbeloeb"
+        . " FROM transaktioner t"
+        . $j_kp_sm . $j_dg . $oss_where . $b2c_filter
+        . " GROUP BY g.box6, g.box2"
+        . " ORDER BY g.box6, g.box2";
+
+    $q_sum = db_select($qtxt_sum, __FILE__." linje ".__LINE__);
+
+    $sum_title = $has_eu_zone
+        ? "OSS-angivelse – kun B2C EU (privat i EU)"
+        : "Salg til private kunder i EU – Oversigt";
+    print "<p $section_h>$sum_title</p>";
+    print "<div style='overflow-x:auto; padding:0 12px;'>";
+    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+    print "<thead><tr style='background:#eeeef0;'>";
+    print "<th align='left'>Land</th>";
+    print "<th align='right' style='width:60px'>Sats %</th>";
+    print "<th align='right' style='width:160px'>Momspligtig beloeb – varer</th>";
+    print "<th align='right' style='width:160px'>Momspligtig beloeb – ydelser</th>";
+    print "<th align='right' style='width:160px'>Momspligtig beloeb i alt</th>";
+    print "<th align='right' style='width:130px'>Momsbeloeb</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding(
+        "\nSALG TIL PRIVATE KUNDER I EU – OVERSIGT\n"
+        . "Land;Sats %;Momspligtig beloeb – varer;Momspligtig beloeb – ydelser;Momspligtig beloeb i alt;Momsbeloeb\n",
+        'ISO-8859-1', 'UTF-8'));
+
+    $row_i      = 0;
+    $has_rows2  = false;
+    $grand_vare = 0.0;
+    $grand_ydel = 0.0;
+    $grand_tot  = 0.0;
+    $grand_moms = 0.0;
+
+    while ($row = db_fetch_array($q_sum)) {
+        $has_rows2    = true;
+        $sats         = ($row['momssats'] !== null) ? (float)$row['momssats'] : 0;
+        $bv           = (float)$row['beloeb_varer'];
+        $by           = (float)$row['beloeb_ydelser'];
+        $bt           = (float)$row['beloeb_total'];
+        $bm           = (float)$row['momsbeloeb'];
+        $grand_vare  += $bv;
+        $grand_ydel  += $by;
+        $grand_tot   += $bt;
+        $grand_moms  += $bm;
+
+        $bg = $row_bg[$row_i % 2];
+        $row_i++;
+
+        print "<tr style='background:$bg;'>";
+        print "<td><b>" . htmlspecialchars($row['land'] ?? '') . "</b></td>";
+        print "<td align='right'>" . ($sats > 0 ? dkdecimal($sats, 2) : '') . "</td>";
+        print "<td align='right'>" . ($bv != 0 ? dkdecimal($bv, 2) : '<span style="color:#ccc">–</span>') . "</td>";
+        print "<td align='right'>" . ($by != 0 ? dkdecimal($by, 2) : '<span style="color:#ccc">–</span>') . "</td>";
+        print "<td align='right'>" . dkdecimal($bt, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($bm, 2) . "</td>";
+        print "</tr>\n";
+
+        fwrite($csv, mb_convert_encoding(
+            ($row['land'] ?? '') . ";"
+            . ($sats > 0 ? dkdecimal($sats, 2) : '') . ";"
+            . "\"" . dkdecimal($bv, 2) . "\";"
+            . "\"" . dkdecimal($by, 2) . "\";"
+            . "\"" . dkdecimal($bt, 2) . "\";"
+            . "\"" . dkdecimal($bm, 2) . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    }
+
+    if (!$has_rows2) {
+        $no_msg = $has_eu_zone
+            ? "Ingen B2C EU-posteringer (OSS-pligtige) i den valgte periode."
+            : "Ingen OSS-posteringer i den valgte periode.";
+        print "<tr><td colspan='6' align='center' style='padding:16px; color:#888;'>" . $no_msg . "</td></tr>";
+    } else {
+        print "<tr style='background:#c8d8e8; font-weight:bold;'>";
+        print "<td colspan='2' align='right'>I alt</td>";
+        print "<td align='right'>" . ($grand_vare != 0 ? dkdecimal($grand_vare, 2) : '<span style="color:#ccc">–</span>') . "</td>";
+        print "<td align='right'>" . ($grand_ydel != 0 ? dkdecimal($grand_ydel, 2) : '<span style="color:#ccc">–</span>') . "</td>";
+        print "<td align='right'>" . dkdecimal($grand_tot, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($grand_moms, 2) . "</td>";
+        print "</tr>";
+        fwrite($csv, mb_convert_encoding(
+            "I alt;;"
+            . "\"" . dkdecimal($grand_vare, 2) . "\";"
+            . "\"" . dkdecimal($grand_ydel, 2) . "\";"
+            . "\"" . dkdecimal($grand_tot, 2) . "\";"
+            . "\"" . dkdecimal($grand_moms, 2) . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    }
+
+    print "</tbody></table></div>";
+    print "<div style='padding:8px 12px; color:#666; font-size:0.85em;'>"
+        . "Beloeb ekskl. moms. OSS-koder: "
+        . "<a href='../systemdata/syssetup.php?valg=moms'>Indstillinger &rarr; Moms</a> (felt: Land (OSS)). "
+        . "EU-zone: <a href='../systemdata/syssetup.php?valg=debitor'>Indstillinger &rarr; Debitor</a>."
+        . "</div>";
+
+    // ----------------------------------------------------------------
+    // SECTION 3 — non-OSS postings (when EU-zone is configured)
+    // ----------------------------------------------------------------
+    if ($has_eu_zone) {
+        $qtxt_other = "SELECT eu_zone, land, SUM(beloeb) AS beloeb_total, SUM(momsbeloeb) AS momsbeloeb, COUNT(*) AS antal"
+            . " FROM ("
+            .   " SELECT COALESCE(NULLIF(TRIM(dg.box10),''), 'Uklassificeret') AS eu_zone,"
+            .   " g.box6 AS land,"
+            .   " COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) AS beloeb,"
+            .   " -COALESCE(t.moms, 0) AS momsbeloeb"
+            .   " FROM transaktioner t"
+            .   $j_kp_sm . $j_dg . $oss_where
+            .   " AND COALESCE(NULLIF(TRIM(dg.box10),''),'') != 'B2C-EU'"
+            . " ) sub"
+            . " GROUP BY eu_zone, land"
+            . " ORDER BY eu_zone, land";
+
+        $q_other = db_select($qtxt_other, __FILE__." linje ".__LINE__);
+
+        $zone_labels_other = [
+            'B2B-EU'         => 'B2B EU (omvendt betalingspligt)',
+            'B2C-UDL'        => 'B2C udenfor EU (eksport)',
+            'B2B-UDL'        => 'B2B udenfor EU (eksport)',
+            'Uklassificeret' => 'Uklassificeret (mangler EU-zone paa debitorgruppe)',
+        ];
+
+        $rows_other = [];
+        while ($r = db_fetch_array($q_other)) $rows_other[] = $r;
+
+        if ($rows_other) {
+            print "<p $section_h>Ikke-OSS posteringer (ekskluderet fra OSS-angivelse)</p>";
+            print "<div style='overflow-x:auto; padding:0 12px;'>";
+            print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+            print "<thead><tr style='background:#eeeef0;'>";
+            print "<th align='left'>Kundetype</th>";
+            print "<th align='left'>Land</th>";
+            print "<th align='right' style='width:80px'>Antal</th>";
+            print "<th align='right' style='width:160px'>Beloeb ekskl. moms</th>";
+            print "<th align='right' style='width:130px'>Momsbeloeb</th>";
+            print "</tr></thead><tbody>";
+
+            fwrite($csv, mb_convert_encoding(
+                "\nIKKE-OSS POSTERINGER\nKundetype;Land;Antal;Beloeb;Moms\n",
+                'ISO-8859-1', 'UTF-8'));
+
+            $cur_other_zone = null;
+            $row_i = 0;
+            foreach ($rows_other as $r) {
+                $oz    = $r['eu_zone'];
+                $olbl  = $zone_labels_other[$oz] ?? $oz;
+                $zs    = $zone_style[$oz === 'Uklassificeret' ? '' : $oz] ?? $zone_style[''];
+                $bt    = (float)$r['beloeb_total'];
+                $bm    = (float)$r['momsbeloeb'];
+
+                if ($cur_other_zone !== $oz) {
+                    $hbg = $zone_hdr_bg[$oz === 'Uklassificeret' ? '' : $oz] ?? '#555';
+                    print "<tr style='background:$hbg; color:#fff; font-weight:bold;'>";
+                    print "<td colspan='5' style='padding:4px 8px;'>" . htmlspecialchars($olbl) . "</td></tr>\n";
+                    $cur_other_zone = $oz;
+                    $row_i = 0;
+                }
+                $bg = $row_bg[$row_i % 2];
+                $row_i++;
+                print "<tr style='background:$bg;'>";
+                print "<td><span style='padding:1px 5px; border-radius:3px; font-size:0.82em;"
+                    . " background:{$zs['bg']}; color:{$zs['color']};'>"
+                    . htmlspecialchars($zs['label']) . "</span></td>";
+                print "<td>" . htmlspecialchars($r['land'] ?? '') . "</td>";
+                print "<td align='right'>" . (int)$r['antal'] . "</td>";
+                print "<td align='right'>" . dkdecimal($bt, 2) . "</td>";
+                print "<td align='right'>" . dkdecimal($bm, 2) . "</td>";
+                print "</tr>\n";
+                fwrite($csv, mb_convert_encoding(
+                    $olbl . ";" . ($r['land'] ?? '') . ";"
+                    . (int)$r['antal'] . ";"
+                    . "\"" . dkdecimal($bt, 2) . "\";"
+                    . "\"" . dkdecimal($bm, 2) . "\"\n",
+                    'ISO-8859-1', 'UTF-8'));
+            }
+            print "</tbody></table></div>";
+        }
+    }
+
+    fclose($csv);
+
+    if ($menu == 'T') {
+        include_once '../includes/topmenu/footer.php';
+    } else {
+        include_once '../includes/oldDesign/footer.php';
+    }
+}
+?>

--- a/finans/rapport_includes/moms_oss.php
+++ b/finans/rapport_includes/moms_oss.php
@@ -39,6 +39,8 @@
 //                 knyttes til kundetype (B2C-EU/B2B-EU/B2C-UDL/B2B-UDL) via
 //                 transaktioner.ordre_id → ordrer → adresser → grupper(DG).
 //                 OSS-oversigt filtreres til B2C-EU; oevrige vises separat.
+// 20260729 NTR - Reported by CodeRabbit - topline-settings should be before print not after.
+//              - Reported by CodeRabbit - transactions that's not a varer nor a service doesn't add up to total as neither beloab_varer nor beloab_ydelser gets assigned, now beloab_andet takes the unknown transactions, for future use.
 
 function moms_oss($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
                   $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
@@ -110,13 +112,14 @@ function moms_oss($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
               . "&simulering=$simulering&lagerbev=$lagerbev";
     $csv_btn   = "<a href='$csvfile' style='color:#ffffff; text-decoration:none;'><i class='fa fa-download'></i> CSV</a>";
     $print_btn = "<button onclick='window.print()' style='background:transparent;border:none;color:#fff;cursor:pointer;padding:0;'><i class='fa fa-print'></i> Print</button>";
+    include("../includes/topline_settings.php");
+
     print "<style>@media print{"
         . ".no-print,button,form,a[href*='rapport.php'],a[href*='confirmClose']{display:none!important}"
         . "table{page-break-inside:auto}tr{page-break-inside:avoid}"
         . "body,div{font-size:10pt}"
         . "}</style>";
 
-    include("../includes/topline_settings.php");
 
     if ($menu == 'T') {
         include_once '../includes/top_header.php';
@@ -441,6 +444,8 @@ function moms_oss($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
         . " SUM(CASE WHEN LOWER(TRIM(g.box7)) LIKE 'var%' THEN COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) ELSE 0 END) AS beloeb_varer,"
         . " SUM(CASE WHEN LOWER(TRIM(g.box7)) LIKE 'yd%' OR LOWER(TRIM(g.box7)) LIKE 'ser%'"
         .       " THEN COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) ELSE 0 END) AS beloeb_ydelser,"
+        . " SUM(CASE WHEN LOWER(TRIM(g.box7)) NOT LIKE 'var%' AND LOWER(TRIM(g.box7)) NOT LIKE 'yd%' AND LOWER(TRIM(g.box7)) NOT LIKE 'ser%'"
+        .       " THEN COALESCE(t.kredit, 0) - COALESCE(t.debet, 0) ELSE 0 END) AS beloeb_andet,"
         . " SUM(COALESCE(t.kredit, 0) - COALESCE(t.debet, 0)) AS beloeb_total,"
         . " -SUM(COALESCE(t.moms, 0)) AS momsbeloeb"
         . " FROM transaktioner t"

--- a/finans/rapport_includes/moms_rubrik.php
+++ b/finans/rapport_includes/moms_rubrik.php
@@ -1,0 +1,329 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- finans/rapport_includes/moms_rubrik.php --- patch 5.0.0 --- 2026-07-28 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+// 20260716 MJ R3 – Momsrubrikker (A-varer, A-ydelser, B-varer, B-ydelser, C):
+//                  summerer nettobeloeb pr. rubrik baseret paa box5 paa momskoder.
+//                  Kraever at box5 (Rubrik) er sat i Indstillinger -> Moms.
+//                  CSV-eksport.
+// 20260720 MJ  Fiscal-year-aware kvartalsgenveje (fy_start/slut vars).
+// 20260722 MJ  COALESCE(debet,0)/COALESCE(kredit,0) i SUM: NULL-aritmetik
+//                 gav NULL (vist som 0) for rene debet- eller kreditkonti.
+// 20260723 MJ  Rubrik afleder nu fra ordrelinjer: ordrer.art (DO/DK=salg, KO/KK=kob) +
+//                  DG.box10 (EU-zone paa debitorgruppe) + VG.box5 (varer/ydelser).
+//                  B-varer/B-ydelser: salgsordrer til B2B-EU-kunder.
+//                  C: salgsordrer til kunder udenfor EU.
+// 20260724 MJ  Rubrik A implementeret: koebsordrer (KO/KK) til KG.box10='B2B-EU'-leverandoerer.
+//                  A-varer/A-ydelser: splittet paa VG.box5 (varer/ydelser-type).
+// 20260728 MJ  Q1/Q2/Q3/Q4/Hele-aaret genveje poster nu direkte (submit=ok) fremfor
+//                  GET-link til forside.
+
+function moms_rubrik($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
+                     $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
+                     $ansat_fra, $ansat_til, $afd, $projekt_fra, $projekt_til,
+                     $simulering, $lagerbev) {
+
+    global $db, $md, $menu, $sprog_id, $top_bund;
+    global $buttonStyle, $topStyle;
+    global $ansatte_id, $afd_navn, $ansatte;
+
+    $regnaar    = (int)$regnaar;
+    $maaned_fra = trim($maaned_fra);
+    $maaned_til = trim($maaned_til);
+
+    for ($x = 1; $x <= 12; $x++) {
+        if ($maaned_fra == $md[$x]) $maaned_fra = $x;
+        if ($maaned_til == $md[$x]) $maaned_til = $x;
+        if (strlen($maaned_fra) == 1) $maaned_fra = '0'.$maaned_fra;
+        if (strlen($maaned_til) == 1) $maaned_til = '0'.$maaned_til;
+    }
+    $mf = $maaned_fra;
+    $mt = $maaned_til;
+
+    $row = db_fetch_array(db_select("select * from grupper where kodenr='$regnaar' and art='RA'", __FILE__." linje ".__LINE__));
+    $startmaaned = (int)($row['box1'] ?? 1);
+    $startaar    = (int)($row['box2'] ?? $regnaar);
+    $slutmaaned  = (int)($row['box3'] ?? 12);
+    $slutaar     = (int)($row['box4'] ?? $regnaar);
+    $fy_startmaaned = $startmaaned;
+    $fy_slutmaaned  = $slutmaaned;
+    $fy_startaar    = $startaar;
+    $fy_slutaar     = $slutaar;
+    $startdato   = 1;
+    $slutdato    = 31;
+
+    if ($aar_fra < $aar_til) {
+        if ($maaned_til > $slutmaaned)      $aar_til = $aar_fra;
+        elseif ($maaned_fra < $startmaaned) $aar_fra = $aar_til;
+    }
+    if ($aar_fra)    $startaar    = $aar_fra;
+    if ($aar_til)    $slutaar     = $aar_til;
+    if ($maaned_fra) $startmaaned = $maaned_fra;
+    if ($maaned_til) $slutmaaned  = $maaned_til;
+    if ($dato_fra)   $startdato   = $dato_fra;
+    if ($dato_til)   $slutdato    = $dato_til;
+
+    $startdato = (int)$startdato;
+    if ($startdato < 10) $startdato = '0'.$startdato;
+    while (!checkdate($startmaaned, $startdato, $startaar)) { $startdato--; if ($startdato < 28) break; }
+    while (!checkdate($slutmaaned,  $slutdato,  $slutaar))  { $slutdato--;  if ($slutdato  < 28) break; }
+    if (strlen((string)$startdato) < 2) $startdato = '0'.$startdato;
+
+    $regnstart = "$startaar-$startmaaned-$startdato";
+    $regnslut  = "$slutaar-$slutmaaned-$slutdato";
+
+    $dim = '';
+    if ($afd || $afd == '0') $dim = "AND t.afd = $afd ";
+
+    $csvfile = "../temp/$db/moms_rubrik.csv";
+    $csv     = fopen($csvfile, "w");
+
+    $title    = 'Rapport • Momsrubrikker (A/B/C)';
+    $back_url = "rapport.php?rapportart=moms_rubrik&regnaar=$regnaar"
+              . "&dato_fra=$startdato&maaned_fra=$mf&aar_fra=$aar_fra"
+              . "&dato_til=$slutdato&maaned_til=$mt&aar_til=$aar_til"
+              . "&konto_fra=$konto_fra&konto_til=$konto_til"
+              . "&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+              . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til"
+              . "&simulering=$simulering&lagerbev=$lagerbev";
+    $csv_btn  = "<a href='$csvfile' style='color:#ffffff; text-decoration:none;'><i class='fa fa-download'></i> CSV</a>";
+
+    include("../includes/topline_settings.php");
+
+    if ($menu == 'T') {
+        include_once '../includes/top_header.php';
+        include_once '../includes/top_menu.php';
+        print "<div id=\"header\">";
+        print "<div class=\"headerbtnLft headLink\"><a href=\"$back_url\" accesskey=\"L\"><i class='fa fa-close fa-lg'></i> Luk</a></div>";
+        print "<div class=\"headerTxt\">Momsrubrikker (A/B/C)</div>";
+        print "<div class=\"headerbtnRght headLink\">$csv_btn</div>";
+        print "</div>";
+        print "<div class='content-noside'>";
+    } elseif ($menu == 'S') {
+        $back_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+        print "<table bgcolor='#eeeef0' width='100%' cellpadding='0' cellspacing='0' border='0'><tbody><tr><td colspan=8 align=center>";
+        print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody>";
+        print "<td width='5%'><a href=\"javascript:confirmClose('$back_url','')\" accesskey=L>"
+            . "<button class='headerbtn' type='button' style='$buttonStyle; width:100%; display:flex; align-items:center; gap:5px;'>"
+            . "$back_icon Tilbage</button></a></td>";
+        print "<td width='85%' align='center' style='$topStyle'>Momsrubrikker (A/B/C)</td>";
+        print "<td width='10%' align='center' style='$buttonStyle'>$csv_btn</td>";
+        print "</tbody></table></td></tr></tbody></table>";
+    } else {
+        print "<table width='100%' cellpadding='0' cellspacing='1px' border='0' valign='top' align='center'>";
+        print "<tr><td colspan='6' height='8'>";
+        print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>";
+        print "<td width='10%' $top_bund><a accesskey=L href='$back_url'>Luk</a></td>";
+        print "<td width='80%' $top_bund>Rapport - Momsrubrikker (A/B/C)</td>";
+        print "<td width='10%' $top_bund><a href='$csvfile'>CSV</a></td>";
+        print "</tbody></table></td></tr></table>";
+    }
+
+    $row = db_fetch_array(db_select("select firmanavn from adresser where art='S'", __FILE__." linje ".__LINE__));
+    $firmanavn = $row ? $row['firmanavn'] : '';
+    print "<div style='padding:8px 12px;'><big><b>$firmanavn</b></big><br>";
+    print "Periode: " . dkdato($regnstart) . " – " . dkdato($regnslut) . "</div>";
+
+    // Quarter shortcuts — POST to rapport.php with submit=ok so the report renders directly.
+    $q_hidden_base = "<input type='hidden' name='rapportart' value='moms_rubrik'>"
+                  . "<input type='hidden' name='submit' value='ok'>"
+                  . "<input type='hidden' name='regnaar' value='$regnaar'>"
+                  . "<input type='hidden' name='dato_fra' value='01'>"
+                  . "<input type='hidden' name='dato_til' value='31'>"
+                  . "<input type='hidden' name='konto_fra' value='$konto_fra'>"
+                  . "<input type='hidden' name='konto_til' value='$konto_til'>"
+                  . "<input type='hidden' name='ansat_fra' value='$ansat_fra'>"
+                  . "<input type='hidden' name='ansat_til' value='$ansat_til'>"
+                  . "<input type='hidden' name='afd' value='$afd'>"
+                  . "<input type='hidden' name='projekt_fra' value='$projekt_fra'>"
+                  . "<input type='hidden' name='projekt_til' value='$projekt_til'>"
+                  . "<input type='hidden' name='simulering' value='$simulering'>"
+                  . "<input type='hidden' name='lagerbev' value='$lagerbev'>";
+    $q_btn_style = "background:none;border:none;padding:0;color:#555;font-size:0.9em;"
+                 . "cursor:pointer;text-decoration:underline;margin-right:8px;";
+    print "<div class='no-print' style='padding:2px 12px 6px; font-size:0.9em; color:#555;'>Genveje: ";
+    foreach (['Q1'=>[1,3],'Q2'=>[4,6],'Q3'=>[7,9],'Q4'=>[10,12]] as $ql => $qm) {
+        $qaar = ($fy_startaar !== $fy_slutaar && $qm[0] >= $fy_startmaaned) ? $fy_startaar : $fy_slutaar;
+        print "<form method='post' action='rapport.php' style='display:inline; margin:0;'>"
+            . $q_hidden_base
+            . "<input type='hidden' name='maaned_fra' value='{$qm[0]}'>"
+            . "<input type='hidden' name='aar_fra' value='$qaar'>"
+            . "<input type='hidden' name='maaned_til' value='{$qm[1]}'>"
+            . "<input type='hidden' name='aar_til' value='$qaar'>"
+            . "<button type='submit' style='$q_btn_style'>$ql</button>"
+            . "</form>";
+    }
+    print "<form method='post' action='rapport.php' style='display:inline; margin:0;'>"
+        . $q_hidden_base
+        . "<input type='hidden' name='maaned_fra' value='$fy_startmaaned'>"
+        . "<input type='hidden' name='aar_fra' value='$fy_startaar'>"
+        . "<input type='hidden' name='maaned_til' value='$fy_slutmaaned'>"
+        . "<input type='hidden' name='aar_til' value='$fy_slutaar'>"
+        . "<button type='submit' style='$q_btn_style'>Hele &aring;ret</button>"
+        . "</form>";
+    print "</div>";
+
+    // Rubrik labels per spec section 2.3
+    $rubrikker = [
+        'A-varer'   => 'Rubrik A – varer: V&aelig;rdien uden moms af varek&oslash;b i andre EU-lande',
+        'A-ydelser' => 'Rubrik A – ydelser: V&aelig;rdien uden moms af ydelsesk&oslash;b i andre EU-lande',
+        'B-varer'   => 'Rubrik B – varer: V&aelig;rdien af varesalg uden moms til andre EU-lande (B2B)',
+        'B-ydelser' => 'Rubrik B – ydelser: V&aelig;rdien af visse ydelsessalg uden moms til andre EU-lande',
+        'C'         => 'Rubrik C: V&aelig;rdien af andre varer og ydelser leveret uden afgift',
+    ];
+
+    // Rubrik A: purchase orders (KO/KK) to B2B-EU suppliers (KG.box10), split by VG varer/ydelser.
+    $qtxt_a = "WITH kg AS ("
+            . " SELECT DISTINCT ON (kodenr) CAST(kodenr AS TEXT) AS kodenr,"
+            .   " NULLIF(TRIM(COALESCE(box10,'')), '') AS eu_zone"
+            . " FROM grupper WHERE art = 'KG'"
+            . " ORDER BY kodenr, fiscal_year DESC NULLS LAST"
+            . "), vg AS ("
+            . " SELECT DISTINCT ON (kodenr) CAST(kodenr AS TEXT) AS kodenr,"
+            .   " NULLIF(TRIM(COALESCE(box5,'')), '') AS vg_type"
+            . " FROM grupper WHERE art = 'VG'"
+            . " ORDER BY kodenr, fiscal_year DESC NULLS LAST"
+            . ")"
+            . " SELECT"
+            .   " CASE WHEN vg.vg_type = 'ydelser' THEN 'A-ydelser' ELSE 'A-varer' END AS rubrik,"
+            .   " SUM(ol.pris * (1 - COALESCE(ol.rabat,0)/100) * ol.antal"
+            .     " * COALESCE(ord.valutakurs,100)/100) AS nettobeloeb"
+            . " FROM ordrelinjer ol"
+            . " JOIN ordrer ord ON ord.id = ol.ordre_id"
+            .   " AND ord.art IN ('KO','KK')"
+            .   " AND ord.status >= 3"
+            .   " AND ord.fakturadate >= '$regnstart'"
+            .   " AND ord.fakturadate <= '$regnslut'"
+            . " JOIN varer v ON v.id = ol.vare_id AND ol.vare_id > 0"
+            . " JOIN vg ON vg.kodenr = CAST(v.gruppe AS TEXT)"
+            . " JOIN adresser adr ON adr.id = ord.konto_id"
+            . " JOIN kg ON kg.kodenr = CAST(adr.gruppe AS TEXT)"
+            . " WHERE kg.eu_zone = 'B2B-EU'"
+            . " GROUP BY 1"
+            . " ORDER BY 1";
+
+    // Rubrik B + C: derive from sales orderlines via DG EU-zone + VG varer/ydelser type.
+    $qtxt = "WITH vg AS ("
+          . " SELECT DISTINCT ON (kodenr) CAST(kodenr AS TEXT) AS kodenr,"
+          .   " NULLIF(TRIM(COALESCE(box5,'')), '') AS vg_type"
+          . " FROM grupper WHERE art = 'VG'"
+          . " ORDER BY kodenr, fiscal_year DESC NULLS LAST"
+          . "), dg AS ("
+          . " SELECT DISTINCT ON (kodenr) CAST(kodenr AS TEXT) AS kodenr,"
+          .   " NULLIF(TRIM(COALESCE(box10,'')), '') AS eu_zone"
+          . " FROM grupper WHERE art = 'DG'"
+          . " ORDER BY kodenr, fiscal_year DESC NULLS LAST"
+          . ")"
+          . " SELECT"
+          .   " CASE"
+          .     " WHEN dg.eu_zone = 'B2B-EU' AND vg.vg_type = 'ydelser' THEN 'B-ydelser'"
+          .     " WHEN dg.eu_zone = 'B2B-EU' THEN 'B-varer'"
+          .     " WHEN dg.eu_zone IN ('B2B-UDL','B2C-UDL') THEN 'C'"
+          .   " END AS rubrik,"
+          .   " SUM(ol.pris * (1 - COALESCE(ol.rabat,0)/100) * ol.antal"
+          .     " * COALESCE(ord.valutakurs,100)/100) AS nettobeloeb"
+          . " FROM ordrelinjer ol"
+          . " JOIN ordrer ord ON ord.id = ol.ordre_id"
+          .   " AND ord.art IN ('DO','DK')"
+          .   " AND ord.status >= 3"
+          .   " AND ord.fakturadate >= '$regnstart'"
+          .   " AND ord.fakturadate <= '$regnslut'"
+          . " JOIN varer v ON v.id = ol.vare_id AND ol.vare_id > 0"
+          . " JOIN vg ON vg.kodenr = CAST(v.gruppe AS TEXT)"
+          . " JOIN adresser adr ON adr.id = ord.konto_id"
+          . " JOIN dg ON dg.kodenr = CAST(adr.gruppe AS TEXT)"
+          . " WHERE dg.eu_zone IN ('B2B-EU','B2B-UDL','B2C-UDL')"
+          . " GROUP BY 1"
+          . " ORDER BY 1";
+    $rubrik_sum = [];
+    $qa = db_select($qtxt_a, __FILE__." linje ".__LINE__);
+    while ($r = db_fetch_array($qa)) $rubrik_sum[$r['rubrik']] = (float)$r['nettobeloeb'];
+    $q = db_select($qtxt, __FILE__." linje ".__LINE__);
+    while ($r = db_fetch_array($q)) $rubrik_sum[$r['rubrik']] = (float)$r['nettobeloeb'];
+
+    // Check if DG groups have EU-zone configured (prerequisite for rubrik derivation)
+    $has_mapping = db_fetch_array(db_select(
+        "SELECT 1 FROM grupper WHERE art = 'DG'"
+        . " AND NULLIF(TRIM(COALESCE(box10,'')), '') IS NOT NULL LIMIT 1",
+        __FILE__." linje ".__LINE__));
+    if (!$has_mapping) {
+        print "<div style='padding:16px 12px; color:#c00;'>";
+        print "<b>Rubrik-konfiguration mangler.</b><br>";
+        print "Gaa til <a href='../systemdata/syssetup.php?valg=debitorer'>Indstillinger &rarr; Debitorgrupper</a> ";
+        print "og udfyld feltet <b>EU-zone</b> for dine kundegrupper.<br>";
+        print "S&aelig;t ogs&aring; <b>Varer/ydelser</b>-typen paa dine ";
+        print "<a href='../systemdata/syssetup.php?valg=varer'>Varegrupper</a>.";
+        print "</div>";
+    }
+
+    print "<div style='padding:0 12px;'>";
+    print "<table class='dataTable' border='0' cellspacing='1' width='600px'>";
+    print "<thead><tr style='background:#eeeef0;'>";
+    print "<th align='left'>Rubrik</th>";
+    print "<th align='left'>Beskrivelse</th>";
+    print "<th align='right' style='width:140px'>Nettobeloeb</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding("Rubrik;Beskrivelse;Nettobeloeb\n", 'ISO-8859-1', 'UTF-8'));
+
+    $grand = 0;
+    foreach ($rubrikker as $kode => $beskrivelse) {
+        $sum = $rubrik_sum[$kode] ?? null;
+        $bg  = ($sum === null) ? '#fafafa' : '#ffffff';
+        $sum_txt = ($sum !== null) ? dkdecimal($sum, 2) : '<span style="color:#aaa">0,00</span>';
+        $sum_csv = ($sum !== null) ? dkdecimal($sum, 2) : '0,00';
+        if ($sum !== null) $grand += $sum;
+        print "<tr style='background:$bg;'>";
+        print "<td><b>$kode</b></td>";
+        print "<td>$beskrivelse</td>";
+        print "<td align='right'>$sum_txt</td>";
+        print "</tr>";
+        fwrite($csv, mb_convert_encoding("$kode;$beskrivelse;\"$sum_csv\"\n", 'ISO-8859-1', 'UTF-8'));
+    }
+
+    print "<tr style='background:#c8d8e8; font-weight:bold;'>";
+    print "<td colspan='2' align='right'>I alt</td>";
+    print "<td align='right'>" . dkdecimal($grand, 2) . "</td>";
+    print "</tr>";
+    print "</tbody></table></div>";
+
+    print "<div style='padding:6px 12px 12px; font-size:0.85em; color:#888;'>";
+    print "Rubrik A afledes fra fakturerede k&oslash;bsordrer: ";
+    print "EU-zone p&aring; <a href='../systemdata/syssetup.php?valg=kreditorer'>Kreditorgrupper</a> ";
+    print "+ Varer/ydelser-type p&aring; <a href='../systemdata/syssetup.php?valg=varer'>Varegrupper</a>.<br>";
+    print "Rubrik B + C afledes fra fakturerede salgsordrer: ";
+    print "EU-zone p&aring; <a href='../systemdata/syssetup.php?valg=debitorer'>Debitorgrupper</a> ";
+    print "+ Varer/ydelser-type p&aring; Varegrupper. ";
+    print "Manuelle finansposteringer uden ordretilknytning indg&aring;r ikke.";
+    print "</div>";
+
+    fclose($csv);
+
+    if ($menu == 'T') {
+        include_once '../includes/topmenu/footer.php';
+    } else {
+        include_once '../includes/oldDesign/footer.php';
+    }
+}
+?>

--- a/finans/rapport_includes/moms_rubrik.php
+++ b/finans/rapport_includes/moms_rubrik.php
@@ -93,8 +93,8 @@ function moms_rubrik($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
     $regnstart = "$startaar-$startmaaned-$startdato";
     $regnslut  = "$slutaar-$slutmaaned-$slutdato";
 
-    $dim = '';
-    if ($afd || $afd == '0') $dim = "AND t.afd = $afd ";
+    $afd_filter = '';
+    if ($afd || $afd == '0') $afd_filter = "AND ord.afd = $afd ";
 
     $csvfile = "../temp/$db/moms_rubrik.csv";
     $csv     = fopen($csvfile, "w");
@@ -215,6 +215,7 @@ function moms_rubrik($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
             .   " AND ord.status >= 3"
             .   " AND ord.fakturadate >= '$regnstart'"
             .   " AND ord.fakturadate <= '$regnslut'"
+            .   " $afd_filter"
             . " JOIN varer v ON v.id = ol.vare_id AND ol.vare_id > 0"
             . " JOIN vg ON vg.kodenr = CAST(v.gruppe AS TEXT)"
             . " JOIN adresser adr ON adr.id = ord.konto_id"
@@ -249,6 +250,7 @@ function moms_rubrik($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
           .   " AND ord.status >= 3"
           .   " AND ord.fakturadate >= '$regnstart'"
           .   " AND ord.fakturadate <= '$regnslut'"
+          .   " $afd_filter"
           . " JOIN varer v ON v.id = ol.vare_id AND ol.vare_id > 0"
           . " JOIN vg ON vg.kodenr = CAST(v.gruppe AS TEXT)"
           . " JOIN adresser adr ON adr.id = ord.konto_id"

--- a/finans/rapport_includes/moms_transaktioner.php
+++ b/finans/rapport_includes/moms_transaktioner.php
@@ -1,0 +1,356 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- finans/rapport_includes/moms_transaktioner.php --- patch 5.0.0 --- 2026-07-22 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+// 20260716 MJ R1 – Posteringer pr. momskode: alle transaktioner med momskode-kolonne,
+//                  subtotaler pr. kode og grand total. CSV-eksport.
+// 20260720 MJ  Fiscal-year-aware kvartalsgenveje (fy_start/slut vars).
+// 20260722 MJ  COALESCE(debet,0)/COALESCE(kredit,0) i beloeb: NULL-aritmetik
+//                 gav NULL (vist som 0) for rene debet- eller kreditposteringer.
+
+function moms_transaktioner($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
+                             $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
+                             $ansat_fra, $ansat_til, $afd, $projekt_fra, $projekt_til,
+                             $simulering, $lagerbev) {
+
+    global $db, $md, $menu, $sprog_id, $top_bund;
+    global $buttonStyle, $topStyle;
+    global $ansatte_id, $prj_navn_fra, $prj_navn_til;
+    global $afd_navn, $ansatte;
+
+    $regnaar    = (int)$regnaar;
+    $maaned_fra = trim($maaned_fra);
+    $maaned_til = trim($maaned_til);
+    $konto_fra  = trim($konto_fra);
+    $konto_til  = trim($konto_til);
+
+    for ($x = 1; $x <= 12; $x++) {
+        if ($maaned_fra == $md[$x]) $maaned_fra = $x;
+        if ($maaned_til == $md[$x]) $maaned_til = $x;
+        if (strlen($maaned_fra) == 1) $maaned_fra = '0'.$maaned_fra;
+        if (strlen($maaned_til) == 1) $maaned_til = '0'.$maaned_til;
+    }
+    $mf = $maaned_fra;
+    $mt = $maaned_til;
+
+    $row = db_fetch_array(db_select("select * from grupper where kodenr='$regnaar' and art='RA'", __FILE__." linje ".__LINE__));
+    $startmaaned = (int)($row['box1'] ?? 1);
+    $startaar    = (int)($row['box2'] ?? $regnaar);
+    $slutmaaned  = (int)($row['box3'] ?? 12);
+    $slutaar     = (int)($row['box4'] ?? $regnaar);
+    $fy_startmaaned = $startmaaned;
+    $fy_slutmaaned  = $slutmaaned;
+    $fy_startaar    = $startaar;
+    $fy_slutaar     = $slutaar;
+    $startdato   = 1;
+    $slutdato    = 31;
+
+    if ($aar_fra < $aar_til) {
+        if ($maaned_til > $slutmaaned)   $aar_til = $aar_fra;
+        elseif ($maaned_fra < $startmaaned) $aar_fra = $aar_til;
+    }
+
+    if ($aar_fra)    $startaar    = $aar_fra;
+    if ($aar_til)    $slutaar     = $aar_til;
+    if ($maaned_fra) $startmaaned = $maaned_fra;
+    if ($maaned_til) $slutmaaned  = $maaned_til;
+    if ($dato_fra)   $startdato   = $dato_fra;
+    if ($dato_til)   $slutdato    = $dato_til;
+
+    $startdato = (int)$startdato;
+    if ($startdato < 10) $startdato = '0'.$startdato;
+    while (!checkdate($startmaaned, $startdato, $startaar)) { $startdato--; if ($startdato < 28) break; }
+    while (!checkdate($slutmaaned,  $slutdato,  $slutaar))  { $slutdato--;  if ($slutdato  < 28) break; }
+    if (strlen((string)$startdato) < 2) $startdato = '0'.$startdato;
+
+    $regnstart = "$startaar-$startmaaned-$startdato";
+    $regnslut  = "$slutaar-$slutmaaned-$slutdato";
+
+    $filter_kode = db_escape_string(trim(if_isset($_GET, NULL, 'filter_momskode')));
+
+    $dim = '';
+    if ($afd || $afd == '0' || $ansat_fra || $projekt_fra) {
+        if ($afd || $afd == '0') $dim = "AND t.afd = $afd ";
+        if ($ansat_fra && $ansat_til) {
+            $tmp = str_replace(",", " or t.ansat=", $ansatte_id);
+            $dim .= " AND (t.ansat=$tmp) ";
+        } elseif ($ansat_fra) $dim .= "AND t.ansat = '$ansat_fra' ";
+        $p_fra = str2low($projekt_fra);
+        $p_til = str2low($projekt_til);
+        if ($p_fra && $p_til && $p_fra != $p_til)
+            $dim .= " AND lower(t.projekt) >= '$p_fra' AND lower(t.projekt) <= '$p_til' ";
+        elseif ($p_fra) {
+            $tmp = str_replace("?", "_", $p_fra);
+            if (substr($tmp, -1) == '_') { while (substr($tmp, -1) == '_') $tmp = substr($tmp, 0, strlen($tmp)-1); $tmp = str2low($tmp).'%'; }
+            $dim .= "AND lower(t.projekt) LIKE '$tmp' ";
+        }
+    }
+
+    $konto_filter = '';
+    if ($konto_fra && $konto_til && $konto_fra != $konto_til)
+        $konto_filter = "AND t.kontonr >= '$konto_fra' AND t.kontonr <= '$konto_til' ";
+    elseif ($konto_fra)
+        $konto_filter = "AND t.kontonr = '$konto_fra' ";
+
+    $kode_filter = ($filter_kode !== '') ? "AND COALESCE(kp.moms,'') = '$filter_kode' " : '';
+
+    $csvfile = "../temp/$db/moms_transaktioner.csv";
+    $csv     = fopen($csvfile, "w");
+
+    $title    = 'Rapport • Posteringer pr. momskode';
+    $back_url = "rapport.php?rapportart=moms_transaktioner&regnaar=$regnaar"
+              . "&dato_fra=$startdato&maaned_fra=$mf&aar_fra=$aar_fra"
+              . "&dato_til=$slutdato&maaned_til=$mt&aar_til=$aar_til"
+              . "&konto_fra=$konto_fra&konto_til=$konto_til"
+              . "&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+              . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til"
+              . "&simulering=$simulering&lagerbev=$lagerbev";
+
+    $csv_btn = "<a href='$csvfile' style='color:#ffffff; text-decoration:none;'>"
+             . "<i class='fa fa-download'></i> CSV</a>";
+
+    include("../includes/topline_settings.php");
+
+    if ($menu == 'T') {
+        include_once '../includes/top_header.php';
+        include_once '../includes/top_menu.php';
+        print "<div id=\"header\">";
+        print "<div class=\"headerbtnLft headLink\"><a href=\"$back_url\" accesskey=\"L\"><i class='fa fa-close fa-lg'></i> Luk</a></div>";
+        print "<div class=\"headerTxt\">Posteringer pr. momskode</div>";
+        print "<div class=\"headerbtnRght headLink\">$csv_btn</div>";
+        print "</div>";
+        print "<div class='content-noside'>";
+    } elseif ($menu == 'S') {
+        $back_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
+        print "<table bgcolor='#eeeef0' width='100%' cellpadding='0' cellspacing='0' border='0'><tbody><tr><td colspan=8 align=center>";
+        print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody>";
+        print "<td width='5%'><a href=\"javascript:confirmClose('$back_url','')\" accesskey=L>"
+            . "<button class='headerbtn' type='button' style='$buttonStyle; width:100%; display:flex; align-items:center; gap:5px;'>"
+            . "$back_icon Tilbage</button></a></td>";
+        print "<td width='85%' align='center' style='$topStyle'>Posteringer pr. momskode</td>";
+        print "<td width='10%' align='center' style='$buttonStyle'>$csv_btn</td>";
+        print "</tbody></table></td></tr></tbody></table>";
+    } else {
+        print "<table width='100%' cellpadding='0' cellspacing='1px' border='0' valign='top' align='center'>";
+        print "<tr><td colspan='6' height='8'>";
+        print "<table width='100%' align='center' border='0' cellspacing='3' cellpadding='0'><tbody>";
+        print "<td width='10%' $top_bund><a accesskey=L href='$back_url'>Luk</a></td>";
+        print "<td width='80%' $top_bund>Rapport - Posteringer pr. momskode</td>";
+        print "<td width='10%' $top_bund><a href='$csvfile'>CSV</a></td>";
+        print "</tbody></table></td></tr></table>";
+    }
+
+    // --- company + period header ---
+    $row = db_fetch_array(db_select("select firmanavn from adresser where art='S'", __FILE__." linje ".__LINE__));
+    $firmanavn = $row ? $row['firmanavn'] : '';
+
+    print "<div style='padding:8px 12px;'>";
+    print "<big><b>$firmanavn</b></big><br>";
+    print "Periode: " . dkdato($regnstart) . " – " . dkdato($regnslut);
+    if ($konto_fra) print " &nbsp;|&nbsp; Konto: $konto_fra" . ($konto_til && $konto_til != $konto_fra ? "–$konto_til" : '');
+    print "</div>";
+
+    // Quarter shortcuts
+    $q_base = "rapport.php?rapportart=moms_transaktioner&regnaar=$regnaar&dato_fra=01&dato_til=31"
+            . "&konto_fra=$konto_fra&konto_til=$konto_til&ansat_fra=$ansat_fra&ansat_til=$ansat_til"
+            . "&afd=$afd&projekt_fra=$projekt_fra&projekt_til=$projekt_til&simulering=$simulering&lagerbev=$lagerbev";
+    print "<div class='no-print' style='padding:2px 12px 6px; font-size:0.9em; color:#555;'>Genveje: ";
+    foreach (['Q1'=>[1,3],'Q2'=>[4,6],'Q3'=>[7,9],'Q4'=>[10,12]] as $ql => $qm) {
+        $qaar = ($fy_startaar !== $fy_slutaar && $qm[0] >= $fy_startmaaned) ? $fy_startaar : $fy_slutaar;
+        print "<a href='$q_base&maaned_fra={$qm[0]}&aar_fra=$qaar&maaned_til={$qm[1]}&aar_til=$qaar' style='margin-right:8px;'>$ql</a>";
+    }
+    print "<a href='$q_base&maaned_fra=$fy_startmaaned&aar_fra=$fy_startaar&maaned_til=$fy_slutmaaned&aar_til=$fy_slutaar'>Hele &aring;ret</a></div>";
+
+    // --- VAT code filter dropdown ---
+    $all_codes = [];
+    $q = db_select("SELECT DISTINCT kp.moms, g.beskrivelse FROM kontoplan kp"
+                 . " LEFT JOIN (SELECT DISTINCT ON (art,kodenr) art, kodenr, beskrivelse FROM grupper"
+                 . "   WHERE art IN ('SM','KM','YM','EM') ORDER BY art, kodenr, fiscal_year DESC NULLS LAST) g"
+                 . " ON g.art = UPPER(SUBSTRING(kp.moms FROM 1 FOR 1)) || 'M'"
+                 . " AND CAST(g.kodenr AS TEXT) = SUBSTRING(kp.moms FROM 2)"
+                 . " WHERE kp.regnskabsaar = '$regnaar' AND kp.moms IS NOT NULL AND kp.moms != ''"
+                 . " ORDER BY kp.moms", __FILE__." linje ".__LINE__);
+    while ($r = db_fetch_array($q)) $all_codes[$r['moms']] = $r['beskrivelse'];
+
+    $filter_url_base = $back_url . ($filter_kode !== '' ? "&filter_momskode=$filter_kode" : '');
+
+    print "<form method='GET' action='rapport.php' style='padding:4px 12px; display:inline-block;'>";
+    // pass through all standard params as hidden fields
+    foreach (['rapportart'=>'moms_transaktioner','regnaar'=>$regnaar,'dato_fra'=>$startdato,
+              'maaned_fra'=>$mf,'aar_fra'=>$aar_fra,'dato_til'=>$slutdato,'maaned_til'=>$mt,
+              'aar_til'=>$aar_til,'konto_fra'=>$konto_fra,'konto_til'=>$konto_til,
+              'ansat_fra'=>$ansat_fra,'ansat_til'=>$ansat_til,'afd'=>$afd,
+              'projekt_fra'=>$projekt_fra,'projekt_til'=>$projekt_til,
+              'simulering'=>$simulering,'lagerbev'=>$lagerbev] as $k => $v) {
+        print "<input type='hidden' name='" . htmlspecialchars($k) . "' value='" . htmlspecialchars($v) . "'>";
+    }
+    print "Momskode: <select name='filter_momskode'>";
+    $sel_alle = ($filter_kode === '') ? " selected='selected'" : '';
+    print "<option value=''$sel_alle>Alle</option>";
+    foreach ($all_codes as $kode => $navn) {
+        $sel = ($filter_kode === $kode) ? " selected='selected'" : '';
+        $label = $kode . ($navn ? " – $navn" : '');
+        print "<option value='" . htmlspecialchars($kode) . "'$sel>" . htmlspecialchars($label) . "</option>";
+    }
+    print "</select> <input type='submit' value='Vis'></form>";
+    if ($filter_kode !== '') {
+        print " &nbsp;<a href='$back_url'>Vis alle</a>";
+    }
+
+    // --- main query ---
+    $qtxt = "SELECT"
+          . " t.transdate, t.bilag, t.beskrivelse,"
+          . " t.kontonr, kp.beskrivelse AS konto_navn,"
+          . " COALESCE(kp.moms, '') AS momskode,"
+          . " g.beskrivelse AS moms_navn,"
+          . " CAST(COALESCE(NULLIF(g.box2,''),NULL) AS NUMERIC(10,2)) AS momssats,"
+          . " (COALESCE(t.debet, 0) - COALESCE(t.kredit, 0)) AS beloeb,"
+          . " t.moms AS momsbeloeb"
+          . " FROM transaktioner t"
+          . " LEFT JOIN kontoplan kp ON kp.kontonr = t.kontonr AND kp.regnskabsaar = '$regnaar'"
+          . " LEFT JOIN ("
+          .   " SELECT DISTINCT ON (art, kodenr) art, kodenr, beskrivelse, box2"
+          .   " FROM grupper WHERE art IN ('SM','KM','YM','EM')"
+          .   " ORDER BY art, kodenr, fiscal_year DESC NULLS LAST"
+          . " ) g ON kp.moms IS NOT NULL AND kp.moms != ''"
+          .   " AND g.art = UPPER(SUBSTRING(kp.moms FROM 1 FOR 1)) || 'M'"
+          .   " AND CAST(g.kodenr AS TEXT) = SUBSTRING(kp.moms FROM 2)"
+          . " WHERE t.transdate >= '$regnstart' AND t.transdate <= '$regnslut'"
+          . " $konto_filter $kode_filter $dim"
+          . " ORDER BY COALESCE(kp.moms,'ZZZ') NULLS LAST, t.transdate, t.bilag, t.id";
+
+    $q = db_select($qtxt, __FILE__." linje ".__LINE__);
+
+    // --- HTML table ---
+    print "<div style='overflow-x:auto; padding:0 12px;'>";
+    print "<table class='dataTable' border='0' cellspacing='1' width='100%'>";
+    print "<thead><tr style='position:sticky; top:0; background:#eeeef0;'>";
+    print "<th align='left'  style='width:80px'>Dato</th>";
+    print "<th align='left'  style='width:70px'>Bilag</th>";
+    print "<th align='left'>Tekst</th>";
+    print "<th align='left'  style='width:120px'>Konto</th>";
+    print "<th align='left'  style='width:70px'>Momskode</th>";
+    print "<th align='right' style='width:50px'>Sats %</th>";
+    print "<th align='right' style='width:110px'>Bel&oslash;b</th>";
+    print "<th align='right' style='width:110px'>Moms</th>";
+    print "<th align='right' style='width:110px'>Inkl. moms</th>";
+    print "</tr></thead><tbody>";
+
+    fwrite($csv, mb_convert_encoding(
+        "Dato;Bilag;Tekst;Konto;Momskode;Sats %;Beloeb;Moms;Inkl. moms\n",
+        'ISO-8859-1', 'UTF-8'));
+
+    $prev_kode = null;
+    $sub_beloeb = 0; $sub_moms = 0;
+    $tot_beloeb = 0; $tot_moms  = 0;
+    $row_bg = ['#ffffff','#f5f5f5'];
+    $row_i  = 0;
+
+    while ($row = db_fetch_array($q)) {
+        $kode    = $row['momskode'];
+        $beloeb  = (float)$row['beloeb'];
+        $moms    = (float)$row['momsbeloeb'];
+        $inkl    = $beloeb + $moms;
+
+        // subtotal break
+        if ($prev_kode !== null && $kode !== $prev_kode) {
+            $sub_inkl = $sub_beloeb + $sub_moms;
+            $label    = ($prev_kode !== '') ? "Subtotal $prev_kode" : 'Subtotal – ingen momskode';
+            print "<tr style='background:#e0e8f0; font-weight:bold;'>";
+            print "<td colspan='6' align='right'>$label</td>";
+            print "<td align='right'>" . dkdecimal($sub_beloeb, 2) . "</td>";
+            print "<td align='right'>" . dkdecimal($sub_moms,   2) . "</td>";
+            print "<td align='right'>" . dkdecimal($sub_inkl,   2) . "</td>";
+            print "</tr>";
+            $sub_beloeb = 0; $sub_moms = 0;
+        }
+
+        $prev_kode   = $kode;
+        $sub_beloeb += $beloeb;
+        $sub_moms   += $moms;
+        $tot_beloeb += $beloeb;
+        $tot_moms   += $moms;
+
+        $bg   = $row_bg[$row_i % 2];
+        $row_i++;
+
+        $sats_txt = ($row['momssats'] !== null) ? dkdecimal($row['momssats'], 2) : '';
+        $kode_vis = ($kode !== '') ? htmlspecialchars($kode) : '<span style="color:#aaa">–</span>';
+        $konto_vis = $row['kontonr'] ? ($row['kontonr'] . ': ' . htmlspecialchars($row['konto_navn'] ?? '')) : '';
+
+        print "<tr style='background:$bg;'>";
+        print "<td>" . dkdato($row['transdate']) . "</td>";
+        print "<td>" . htmlspecialchars($row['bilag']) . "</td>";
+        print "<td>" . htmlspecialchars($row['beskrivelse']) . "</td>";
+        print "<td style='font-size:0.85em;'>" . htmlspecialchars($konto_vis) . "</td>";
+        print "<td>" . $kode_vis . "</td>";
+        print "<td align='right'>" . $sats_txt . "</td>";
+        print "<td align='right'>" . dkdecimal($beloeb, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($moms,   2) . "</td>";
+        print "<td align='right'>" . dkdecimal($inkl,   2) . "</td>";
+        print "</tr>\n";
+
+        fwrite($csv, mb_convert_encoding(
+            dkdato($row['transdate']) . ";$row[bilag];"
+            . $row['beskrivelse'] . ";"
+            . $row['kontonr'] . ";"
+            . $kode . ";"
+            . $sats_txt . ";"
+            . "\"" . dkdecimal($beloeb, 2) . "\";"
+            . "\"" . dkdecimal($moms,   2) . "\";"
+            . "\"" . dkdecimal($inkl,   2) . "\"\n",
+            'ISO-8859-1', 'UTF-8'));
+    }
+
+    // last subtotal
+    if ($prev_kode !== null) {
+        $sub_inkl = $sub_beloeb + $sub_moms;
+        $label    = ($prev_kode !== '') ? "Subtotal $prev_kode" : 'Subtotal – ingen momskode';
+        print "<tr style='background:#e0e8f0; font-weight:bold;'>";
+        print "<td colspan='6' align='right'>$label</td>";
+        print "<td align='right'>" . dkdecimal($sub_beloeb, 2) . "</td>";
+        print "<td align='right'>" . dkdecimal($sub_moms,   2) . "</td>";
+        print "<td align='right'>" . dkdecimal($sub_inkl,   2) . "</td>";
+        print "</tr>";
+    }
+
+    // grand total
+    $tot_inkl = $tot_beloeb + $tot_moms;
+    print "<tr style='background:#c8d8e8; font-weight:bold; border-top:2px solid #666;'>";
+    print "<td colspan='6' align='right'>I alt</td>";
+    print "<td align='right'>" . dkdecimal($tot_beloeb, 2) . "</td>";
+    print "<td align='right'>" . dkdecimal($tot_moms,   2) . "</td>";
+    print "<td align='right'>" . dkdecimal($tot_inkl,   2) . "</td>";
+    print "</tr>";
+
+    print "</tbody></table></div>";
+    fclose($csv);
+
+    if ($menu == 'T') {
+        include_once '../includes/topmenu/footer.php';
+    } else {
+        include_once '../includes/oldDesign/footer.php';
+    }
+}
+?>

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -3359,10 +3359,10 @@
 3359	Finansrapporter	Financial reports	Finansrapporter
 3360	Salg pr. postnummer	Sales by postal code	Salg per postnummer
 3361	Varerapporter	Item reports	Varerapporter		
-3362			
-3363			
-3364			
-3365			
+3362	Posteringer pr. momskode.	Entried pr. VAT code	Posteringer per MVA-kode.
+3363	Momsrubrikker	VAT categories	Momsrubrikker
+3364	Momsafstemning	VAT reconciliation	MVA-avstemming
+3365	OSS B2C EU-salg	B2C EU Sales	OSS B2C EU-salg
 3366			
 3367			
 3368			

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -3363,7 +3363,7 @@
 3363	Momsrubrikker	VAT categories	Momsrubrikker
 3364	Momsafstemning	VAT reconciliation	MVA-avstemming
 3365	OSS B2C EU-salg	B2C EU Sales	OSS B2C EU-salg
-3366			
+3366	Momsperioder    Vat periods    MVA-perioder		
 3367			
 3368			
 3369			

--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -226,4 +226,49 @@ if ($mp_client_id) {
 	}
 }
 
+// R5 moms periodelaasning — opret tabel, funktion og trigger een gang ved login.
+// Kontrollen sker paa trigger-eksistens; er triggeren der, springes hele blokken over.
+$qtxt = "SELECT 1 FROM pg_trigger WHERE tgname='tr_check_moms_periode_luk' LIMIT 1";
+if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+    db_modify("CREATE TABLE IF NOT EXISTS moms_periode_luk (
+        id               SERIAL PRIMARY KEY,
+        kalender_aar     INTEGER NOT NULL,
+        kalender_maaned  INTEGER NOT NULL CHECK (kalender_maaned BETWEEN 1 AND 12),
+        status           VARCHAR(6) NOT NULL DEFAULT 'open' CHECK (status IN ('open','closed')),
+        lukket_af        VARCHAR(100),
+        lukket_dato      TIMESTAMP,
+        aabnet_af        VARCHAR(100),
+        aabnet_dato      TIMESTAMP,
+        UNIQUE (kalender_aar, kalender_maaned)
+    )", __FILE__ . " linje " . __LINE__);
+    // pg_query() bruges her for at omgaa injecttjek(): PL/pgSQL-kroppen indeholder
+    // semikolon uden for enkeltcitater, som injecttjek() ville fejlfortolke som injection.
+    $fn  = "CREATE OR REPLACE FUNCTION check_moms_periode_luk() ";
+    $fn .= "RETURNS TRIGGER AS \$\$ ";
+    $fn .= "BEGIN ";
+    $fn .= "    IF EXISTS ( ";
+    $fn .= "        SELECT 1 FROM moms_periode_luk ";
+    $fn .= "        WHERE kalender_aar    = EXTRACT(YEAR  FROM NEW.transdate) ";
+    $fn .= "          AND kalender_maaned = EXTRACT(MONTH FROM NEW.transdate) ";
+    $fn .= "          AND status = 'closed' ";
+    $fn .= "    ) THEN ";
+    $fn .= "        RAISE EXCEPTION 'Perioden % er lukket for bogfoering - kontakt bogholder for at genaabne.', ";
+    $fn .= "            TO_CHAR(NEW.transdate, 'MM-YYYY'); ";
+    $fn .= "    END IF; ";
+    $fn .= "    RETURN NEW; ";
+    $fn .= "END; ";
+    $fn .= "\$\$ LANGUAGE plpgsql";
+    pg_query($connection, $fn);
+    pg_query($connection,
+        "CREATE TRIGGER tr_check_moms_periode_luk "
+        . "BEFORE INSERT OR UPDATE ON transaktioner "
+        . "FOR EACH ROW EXECUTE FUNCTION check_moms_periode_luk()");
+}
+
+// Add note column to moms_periode_luk if not present (idempotent guard).
+$qtxt = "SELECT 1 FROM information_schema.columns WHERE table_name='moms_periode_luk' AND column_name='note' LIMIT 1";
+if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+    db_modify("ALTER TABLE moms_periode_luk ADD COLUMN note TEXT", __FILE__ . " linje " . __LINE__);
+}
+
 ?>

--- a/includes/ordrefunc.php
+++ b/includes/ordrefunc.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-//--- includes/ordrefunc.php ---patch 5.0.0 ----2026-04-27 ---
+//--- includes/ordrefunc.php ---patch 5.0.0 ----2026-07-20 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -100,6 +100,7 @@
 // 20260618 Sawaneh Stock warning popup now triggers when sale quantity would leave stock below min_lager
 // 20260619 Sawaneh check_stock_warning reads stock from lagerstatus (sum across warehouses) like the order-line red-highlight, not the drifting varer.beholdning field
 // 20260630 CDX/PK Changed the cleanup so that negative lines are only deleted if there is also at least one normal line (item no. >= 0) on the same order.
+// 20260720 MJ bogfor(): check_periode_luk() called on fakturadate for friendly period-lock error on invoice posting.
 
 function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 	/* echo "<!--function levering start-->"; */
@@ -1170,6 +1171,8 @@ function bogfor($id, $webservice=false)
 	$ordredate = $row['ordredate'];
 	$levdate = $row['levdate'];
 	$fakturadate = $row['fakturadate'];
+	if ($fakturadate && function_exists('check_periode_luk') && ($err = check_periode_luk($fakturadate)))
+		return $err;
 	$nextfakt = $row['nextfakt'];
 	$art = $row['art'];
 	$kred_ord_id = $row['kred_ord_id'];

--- a/includes/ordrefunc.php
+++ b/includes/ordrefunc.php
@@ -101,6 +101,10 @@
 // 20260619 Sawaneh check_stock_warning reads stock from lagerstatus (sum across warehouses) like the order-line red-highlight, not the drifting varer.beholdning field
 // 20260630 CDX/PK Changed the cleanup so that negative lines are only deleted if there is also at least one normal line (item no. >= 0) on the same order.
 // 20260720 MJ bogfor(): check_periode_luk() called on fakturadate for friendly period-lock error on invoice posting.
+// 20260729 CL/NTR function bogfor: Wrapped in transaktion('begin')/('commit'), with transaktion('rollback')
+//                 added before every early return/failure path, so a failed posting no longer leaves
+//                 partial writes (ordrer/ordrelinjer/kontoplan updates) committed without a matching
+//                 transaktioner/kladdeliste row. Requested via CodeRabbit review.
 
 function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 	/* echo "<!--function levering start-->"; */
@@ -1171,8 +1175,12 @@ function bogfor($id, $webservice=false)
 	$ordredate = $row['ordredate'];
 	$levdate = $row['levdate'];
 	$fakturadate = $row['fakturadate'];
-	if ($fakturadate && function_exists('check_periode_luk') && ($err = check_periode_luk($fakturadate)))
+	if ($fakturadate && function_exists('check_periode_luk') && ($err = check_periode_luk($fakturadate))) {
 		return $err;
+	}
+
+	transaktion('begin');
+
 	$nextfakt = $row['nextfakt'];
 	$art = $row['art'];
 	$kred_ord_id = $row['kred_ord_id'];
@@ -1232,6 +1240,7 @@ function bogfor($id, $webservice=false)
 	}
 
 	if ($row['status'] > '2') {
+		transaktion('rollback');
 		return ("invoice allready created for order id $id");
 	}
 	/*
@@ -1281,10 +1290,14 @@ function bogfor($id, $webservice=false)
 
 				db_modify("update ordrer set sum=sum+$tillag, moms=moms+$tillag/100*$momssats where id = '$id'", __FILE__ . " linje " . __LINE__);
 				#xit;	
-			} else
+			} else {
+				transaktion('rollback');
 				return ('Manglende vare til procenttillæg');
-		} else
+			}
+		} else {
+			transaktion('rollback');
 			return ('Manglende vare til procenttillæg -- ' . $procentvare);
+		}
 	}
 	#	$x=0;
 #	$saet=array();
@@ -1344,6 +1357,7 @@ function bogfor($id, $webservice=false)
 	$row = db_fetch_array($query);
 
 	if (!$fakturadate) {
+		transaktion('rollback');
 		if ($webservice) {
 			return ("missing invoicedate for order $id");
 		} else {
@@ -1366,6 +1380,7 @@ function bogfor($id, $webservice=false)
 			$qtxt = "select id, moms from kontoplan where kontonr='$currDiff' and regnskabsaar='$regnaar'";
 			if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 			} else {
+				transaktion('rollback');
 				if ($webservice)
 					return ("Kontonr $currDiff (kursdiff) eksisterer ikke");
 				else {
@@ -1375,6 +1390,7 @@ function bogfor($id, $webservice=false)
 			/* echo count($xx); */
 			#	exit;
 		} else {
+			transaktion('rollback');
 			$tmp = dkdato($fakturadate);
 			return ("Der er ikke nogen valutakurs for $valuta den $tmp (fakturadatoen).");
 		}
@@ -1384,12 +1400,14 @@ function bogfor($id, $webservice=false)
 	}
 
 	if (!$levdate) {
+		transaktion('rollback');
 		if ($webservice)
 			return ("Missing deliverydate");
 		else
 			return ("Leveringsdato SKAL udfyldes");
 	}
 	if ($levdate < $ordredate) {
+		transaktion('rollback');
 		if ($webservice)
 			return ("Deliverydate prior to orderdate");
 		else
@@ -1402,6 +1420,7 @@ function bogfor($id, $webservice=false)
 #	}
 
 	if (($nextfakt) && ($nextfakt <= $fakturadate)) {
+		transaktion('rollback');
 		if ($webservice)
 			return ("Next_invoicedate prior to invoicedate");
 		else
@@ -1412,6 +1431,7 @@ function bogfor($id, $webservice=false)
 	$ym = $year . $month;
 
 	if ($art != 'PO' && !$webservice && ($ym < $aarstart || $ym > $aarslut)) {
+		transaktion('rollback');
 		print "<BODY onLoad=\"javascript:alert('Fakturadato udenfor regnskabs&aring;r')\">";
 		print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";
 		exit;
@@ -1420,6 +1440,7 @@ function bogfor($id, $webservice=false)
 		if ($r = db_fetch_array(db_select("select valuta.kurs from valuta, grupper where grupper.art='VK' and grupper.box1='$valuta' and valuta.gruppe=" . nr_cast("grupper.kodenr") . " and valuta.valdate <= '$ordredate' order by valuta.valdate desc", __FILE__ . " linje " . __LINE__))) {
 			$valutakurs = $r['kurs'];
 		} else {
+			transaktion('rollback');
 			$tmp = dkdato($ordredate);
 			return ("Der er ikke nogen valutakurs for $valuta den $ordredate (ordredatoen)");
 		}
@@ -1584,14 +1605,16 @@ function bogfor($id, $webservice=false)
 		if ($straksbogfor)
 			$svar = bogfor_nu($id, $webservice);
 		if ($svar != "OK") {
+			transaktion('rollback');
 			return ($svar);
 			exit;
 		} else {
-			#			exit;
-			#ransaktion("commit"); 20130506
+			transaktion('commit');
 		}
-	} elseif (!$svar)
+	} elseif (!$svar) {
+		transaktion('rollback');
 		$svar = $fejl;
+	}
 	/* echo "<!--function bogfor slut-->"; */
 	return ($svar);
 } #endfunc bogfor

--- a/includes/reportFunc/frontPageTopMenu.php
+++ b/includes/reportFunc/frontPageTopMenu.php
@@ -24,6 +24,7 @@
 // -----------------------------------------------------------------------------------
 //
 // 20251123 Fixed multiroute/paylist problem
+// 20260612 MJ Guard flatpickr setup when report date fields are not present.
 
 		// next line can be removed in 2026
 		db_modify("update grupper set box10 = 'B' where box10 = 'on' and art = 'DIV' and kodenr = '2'", __FILE__ . " linje " . __LINE__);
@@ -125,27 +126,29 @@
 				let dateTimeFrom = document.getElementById('fromDate');
 				let dateTimeTo = document.getElementById('toDate');
 				let dateTimeToPicker = null;
-				let dateTimeFromPicker = flatpickr(dateTimeFrom, {
-					altInput: true,
-					altFormat: "j. F Y",
-					dateFormat: "Y-m-d",
-					defaultDate: "today",
-					onChange: function(selectedDates, dateStr, instance) {
-						dateTimeToPicker.set('minDate', selectedDates[0]);
-					},
-					"locale": "da"
-				});
+				if (dateTimeFrom && dateTimeTo) {
+					let dateTimeFromPicker = flatpickr(dateTimeFrom, {
+						altInput: true,
+						altFormat: "j. F Y",
+						dateFormat: "Y-m-d",
+						defaultDate: "today",
+						onChange: function(selectedDates, dateStr, instance) {
+							dateTimeToPicker.set('minDate', selectedDates[0]);
+						},
+						"locale": "da"
+					});
 
-				dateTimeToPicker = flatpickr(dateTimeTo, {
-					altInput: true,
-					altFormat: "j. F Y",
-					dateFormat: "Y-m-d",
-					defaultDate: "today",
-					onChange: function(selectedDates, dateStr, instance) {
-						dateTimeFromPicker.set('maxDate', selectedDates[0]);
-					},
-					"locale": "da"
-				});
+					dateTimeToPicker = flatpickr(dateTimeTo, {
+						altInput: true,
+						altFormat: "j. F Y",
+						dateFormat: "Y-m-d",
+						defaultDate: "today",
+						onChange: function(selectedDates, dateStr, instance) {
+							dateTimeFromPicker.set('maxDate', selectedDates[0]);
+						},
+						"locale": "da"
+					});
+				}
 			</script>
 			<?php
 ?>

--- a/includes/top_menu.php
+++ b/includes/top_menu.php
@@ -86,6 +86,7 @@ print "          <a href='../finans/kladdeliste.php'>".findtekst(105,$sprog_id).
 print "          <a href='../finans/regnskab.php'>".findtekst(849,$sprog_id)."</a>";
 print "          <a href='../finans/budget.php'>".findtekst(1067,$sprog_id)."</a>";
 print "          <a href='../finans/rapport.php'>".findtekst(603,$sprog_id)."</a>";
+print "          <a href='../finans/moms_periode.php'>Momsperioder</a>";
 print "          </div>";
 print "      </li>";
 print "      <li class='dropDown'>";

--- a/includes/top_menu.php
+++ b/includes/top_menu.php
@@ -5,6 +5,8 @@
 // 20220912 MSC - Implementing new design
 // 20221011 MSC - Added link to feedback mail in systemdata
 // 20260306 Sawaneh - Added Simple guides link.
+// 20260716 MJ - Added vat reporting module.
+// 20260730 NTR - Added translation to momsperioder.
 
 $site = "";
 $subsite = "";
@@ -86,7 +88,7 @@ print "          <a href='../finans/kladdeliste.php'>".findtekst(105,$sprog_id).
 print "          <a href='../finans/regnskab.php'>".findtekst(849,$sprog_id)."</a>";
 print "          <a href='../finans/budget.php'>".findtekst(1067,$sprog_id)."</a>";
 print "          <a href='../finans/rapport.php'>".findtekst(603,$sprog_id)."</a>";
-print "          <a href='../finans/moms_periode.php'>Momsperioder</a>";
+print "          <a href='../finans/moms_periode.php'>".findtekst('3366|Momsperioder', $sprog_id)."</a>";
 print "          </div>";
 print "      </li>";
 print "      <li class='dropDown'>";

--- a/includes/topmenu/header.php
+++ b/includes/topmenu/header.php
@@ -145,6 +145,9 @@ if ($menu=='T') {
                 <li>
                   <a href='../../../finans/rapport.php'><?php echo findtekst(603,$sprog_id) ?></a>
                 </li>
+                <li>
+                  <a href='../../../finans/moms_periode.php'>Momsperioder</a>
+                </li>
               </ul>
               <div class='menu-end'>&nbsp;</div>
             </div>

--- a/index/main.php
+++ b/index/main.php
@@ -27,6 +27,7 @@
 // 20250503 LOE reordered mix-up text_id from tekster.csv in findtekst()
 // 20260630 CDX/NTR Fixed Lager/varer from refreshing once every time we try to access it.
 //                  This possibly has changes across everything, but I have tested it, and it has also fixed rendering prematurely.
+// 20260716 MJ      Tilfoejede Momsperioder-link i Finans-sidebar.
 @session_start();
 $s_id = session_id();
 
@@ -199,6 +200,9 @@ function brightenColor($color, $amount = 0.2) {
         }
         if (check_permissions(array(4))) {
           echo '<li><a href="#" id="rapport" onclick=\'update_iframe("/finans/rapport.php")\'>' . findtekst('603|Rapporter', $sprog_id) . '</a></li>';
+        }
+        if (check_permissions(array(2, 3, 4))) {
+          echo '<li><a href="#" id="moms_periode" onclick=\'update_iframe("/finans/moms_periode.php")\'>Momsperioder</a></li>';
         }
         ?>
       </ul>

--- a/index/main.php
+++ b/index/main.php
@@ -28,6 +28,7 @@
 // 20260630 CDX/NTR Fixed Lager/varer from refreshing once every time we try to access it.
 //                  This possibly has changes across everything, but I have tested it, and it has also fixed rendering prematurely.
 // 20260716 MJ      Tilfoejede Momsperioder-link i Finans-sidebar.
+// 20260730 NTR - Added translation to momsperioder.
 @session_start();
 $s_id = session_id();
 
@@ -202,7 +203,7 @@ function brightenColor($color, $amount = 0.2) {
           echo '<li><a href="#" id="rapport" onclick=\'update_iframe("/finans/rapport.php")\'>' . findtekst('603|Rapporter', $sprog_id) . '</a></li>';
         }
         if (check_permissions(array(2, 3, 4))) {
-          echo '<li><a href="#" id="moms_periode" onclick=\'update_iframe("/finans/moms_periode.php")\'>Momsperioder</a></li>';
+          echo '<li><a href="#" id="moms_periode" onclick=\'update_iframe("/finans/moms_periode.php")\'>'.findtekst('3366|Momsperioder', $sprog_id).'</a></li>';
         }
         ?>
       </ul>

--- a/systemdata/skriv_formtabel.inc.php
+++ b/systemdata/skriv_formtabel.inc.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// ------ systemdata/syssetup_skriv_formtabel.php -- lap 4.1.0 -- 2024-05-01 --
+// ------ systemdata/skriv_formtabel.inc.php --- patch 5.0.0 --- 2026-07-24 ---
 // LICENS
 //
 // Dette program er fri software. Du kan gendistribuere det og / eller
@@ -23,13 +23,18 @@
 // En dansk oversaettelse af licensen kan laeses her:
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2024 saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 //
 // 20181102 PHR Oprydning, udefinerede variabler.
 // 20190221 MSC - Rettet isset fejl
 // 20200308 PHR - Added $stockIO
 // 20240604 PHR - PHP8
+// 20260717 MJ  Rubrik (box5) og Type (box7) vises nu som dropdown paa SM/KM/YM/EM-koder.
+// 20260723 MJ  EU-zone dropdown (box10) paa DG-debitorgrupper til OSS-klassificering.
+// 20260723 MJ  Varer/ydelser-dropdown (box5, b5='vg-type') paa VG-varegrupper til Momsrubrikker.
+// 20260723 MJ  Fjernet Rubrik-dropdown (box5) for SM/KM/YM/EM: kolonnen er fjernet fra Moms-siden.
+// 20260724 MJ  EU-zone dropdown (box10) paa KG-kreditorgrupper til Momsrubrikker Rubrik A.
 
 function skriv_formtabel($a,$x,$y,$art,$id,$k,$kodenr,$beskrivelse,$box1,$b1,$box2,$b2,$box3,$b3,$box4,$b4,$box5,$b5,$box6,$b6,$box7,$b7,$box8,$b8,$box9,$b9,$box10,$b10,$box11,$b11,$box12,$b12,$box13,$b13,$box14,$b14) {
 
@@ -126,15 +131,36 @@ if (!isset ($b)) $b = null;
 				else {print "<td><input class=\"inputbox\" type=\"checkbox\" name=\"box4[$i]\"></td>\n";}
 			}
 			print "<input type = \"hidden\" name=id[$i] value='$id[$i]'><input type = \"hidden\" name=\"art[$i]\" value=\"$art[$i]\"><input type = \"hidden\" name=\"kode[$i]\" value=\"$k\">";
-			if ($box5!="-") {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b5\" name=\"box5[$i]\" value=\"$box5[$i]\"></td>\n";}
+			if ($box5!="-") {
+				if ($art[$i] === 'VG' && $b5 === 'vg-type') {
+					print "<td><select class=\"inputbox\" name=\"box5[$i]\">";
+					foreach (['' => '–', 'varer' => 'Varer', 'ydelser' => 'Ydelser'] as $v => $l) {
+						$sel = ((string)($box5[$i] ?? '') === $v) ? ' selected' : '';
+						print "<option value=\"$v\"$sel>$l</option>";
+					}
+					print "</select></td>\n";
+				} else {
+					print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b5\" name=\"box5[$i]\" value=\"$box5[$i]\"></td>\n";
+				}
+			}
 #			if ($box6!="-") {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b6\" name=\"box6[$i]\" value=\"$box6[$i]\"></td>\n";}
 			if (($box6!="-")&&($b6!="checkbox")) {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b6\" name=\"box6[$i]\" value=\"$box6[$i]\"></td>\n";}
 			elseif($b6=="checkbox"){
 				if (strstr($box6[$i],'on')){print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box6[$i]\" checked></td>\n";}
 				else {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box6[$i]\"></td>\n";}
 			}
-			if (($box7!="-")&&($b7!="checkbox")) {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b7\" name=\"box7[$i]\" value=\"$box7[$i]\"></td>\n";}
-			elseif($b7=="checkbox"){
+			if (($box7!="-")&&($b7!="checkbox")) {
+				if ($art[$i] === 'SM') {
+					print "<td><select class=\"inputbox\" name=\"box7[$i]\">";
+					foreach (['' => '–', 'varer' => 'varer', 'ydelser' => 'ydelser'] as $v => $l) {
+						$sel = ((string)$box7[$i] === $v) ? ' selected' : '';
+						print "<option value=\"$v\"$sel>$l</option>";
+					}
+					print "</select></td>\n";
+				} else {
+					print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b7\" name=\"box7[$i]\" value=\"$box7[$i]\"></td>\n";
+				}
+			} elseif($b7=="checkbox"){
 				if (strstr($box7[$i],'on')){print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box7[$i]\" checked></td>\n";}
 				else {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box7[$i]\"></td>\n";}
 			}
@@ -149,7 +175,21 @@ if (!isset ($b)) $b = null;
 				else {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box9[$i]\"></td>\n";}
 			}
 			if (($box10!="-")&&($b10!="checkbox")) {
-				print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b10\" name=\"box10[$i]\" value=\"$box10[$i]\"></td>\n";
+				if (($art[$i] === 'DG' || $art[$i] === 'KG') && $b10 === 'eu-zone') {
+					if ($art[$i] === 'KG') {
+						$eu_opts = ['' => '–', 'B2B-EU' => 'EU (andet EU-land)', 'B2B-UDL' => 'Udenfor EU'];
+					} else {
+						$eu_opts = ['' => '–', 'B2C-EU' => 'B2C EU (privat)', 'B2C-UDL' => 'B2C udenfor EU', 'B2B-EU' => 'B2B EU (m. CVR)', 'B2B-UDL' => 'B2B udenfor EU'];
+					}
+					print "<td><select class=\"inputbox\" name=\"box10[$i]\">";
+					foreach ($eu_opts as $v => $l) {
+						$sel = ((string)($box10[$i] ?? '') === $v) ? ' selected' : '';
+						print "<option value=\"$v\"$sel>$l</option>";
+					}
+					print "</select></td>\n";
+				} else {
+					print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b10\" name=\"box10[$i]\" value=\"$box10[$i]\"></td>\n";
+				}
 			}	elseif($b10=="checkbox") {
 				if (strstr($box10[$i],'on')) {
 					print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=box10[$i] checked></td>\n";
@@ -229,17 +269,49 @@ if (!isset ($b)) $b = null;
 		if (($box4!="-")&&($b4!="checkbox")) {print "<td title=\"".titletxt($art[$y],'box4')."\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=\"$b4\" name=\"box4[$y]\"></td>\n";}
 		elseif($b4=="checkbox") {print "<td><input class=\"inputbox\" type=\"checkbox\" name=\"box4[$y]\"></td>\n";}
 		print "<input type = hidden name=\"id[$y]\" value='0'><input type = hidden name=\"kode[$y]\" value='$k'><input type = hidden name=\"art[$y]\" value=\"$a\">\n";
-		if ($box5!="-") {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b5 name=\"box5[$y]\"></td>\n";}
+		if ($box5!="-") {
+			if ($a === 'VG' && $b5 === 'vg-type') {
+				print "<td><select class=\"inputbox\" name=\"box5[$y]\">";
+				foreach (['' => '–', 'varer' => 'Varer', 'ydelser' => 'Ydelser'] as $v => $l) {
+					print "<option value=\"$v\">$l</option>";
+				}
+				print "</select></td>\n";
+			} else {
+				print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b5 name=\"box5[$y]\"></td>\n";
+			}
+		}
 #		if ($box6!="-") {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b6 name=\"box6[$y]\"></td>\n";}
 		if (($box6!="-")&&($b6!="checkbox")) {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b6 name=\"box6[$y]\"></td>\n";}
 		elseif($b6=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box6[$y]\"></td>\n";}
-		if (($box7!="-")&&($b7!="checkbox")) {print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b7 name=\"box7[$y]\"></td>\n";}
-		elseif($b7=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box7[$y]\"></td>\n";}
+		if (($box7!="-")&&($b7!="checkbox")) {
+			if ($a === 'SM') {
+				print "<td><select class=\"inputbox\" name=\"box7[$y]\">";
+				foreach (['' => '–', 'varer' => 'varer', 'ydelser' => 'ydelser'] as $v => $l) {
+					print "<option value=\"$v\">$l</option>";
+				}
+				print "</select></td>\n";
+			} else {
+				print "<td><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b7 name=\"box7[$y]\"></td>\n";
+			}
+		} elseif($b7=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box7[$y]\"></td>\n";}
 		if (($box8!="-")&&($b8!="checkbox")) {print "<td align=\"center\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b8 name=\"box8[$y]\"></td>\n";}
 		elseif($b8=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box8[$y]\"></td>\n";}
 		if (($box9!="-")&&($b9!="checkbox")) {print "<td align=\"center\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b9 name=\"box9[$y]\"></td>\n";}
 		elseif($b9=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box9[$y]\"></td>\n";}
-		if (($box10!="-")&&($b10!="checkbox")) {print "<td align=\"center\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b10 name=\"box10[$y]\"></td>\n";}
+		if (($box10!="-")&&($b10!="checkbox")) {
+			if (($a === 'DG' || $a === 'KG') && $b10 === 'eu-zone') {
+				if ($a === 'KG') {
+					$eu_opts = ['' => '–', 'B2B-EU' => 'EU (andet EU-land)', 'B2B-UDL' => 'Udenfor EU'];
+				} else {
+					$eu_opts = ['' => '–', 'B2C-EU' => 'B2C EU (privat)', 'B2C-UDL' => 'B2C udenfor EU', 'B2B-EU' => 'B2B EU (m. CVR)', 'B2B-UDL' => 'B2B udenfor EU'];
+				}
+				print "<td><select class=\"inputbox\" name=\"box10[$y]\">";
+				foreach ($eu_opts as $v => $l) { print "<option value=\"$v\">$l</option>"; }
+				print "</select></td>\n";
+			} else {
+				print "<td align=\"center\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b10 name=\"box10[$y]\"></td>\n";
+			}
+		}
 		elseif($b10=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box10[$y]\"></td>\n";}
 		if (($box11!="-")&&($b11!="checkbox")) {print "<td align=\"center\"><input class=\"inputbox\" type=\"text\" style=\"text-align:right\" size=$b11 name=\"box11[$y]\"></td>\n";}
 		elseif($b11=="checkbox") {print "<td align=\"center\"><input class=\"inputbox\" type=\"checkbox\" name=\"box11[$y]\"></td>\n";}

--- a/systemdata/syssetup.php
+++ b/systemdata/syssetup.php
@@ -1,5 +1,5 @@
 <?php
-// --- systemdata/syssetup.php --- lap 4.1.0 -- 2024-06-04 --
+// --- systemdata/syssetup.php --- patch 5.0.0 --- 2026-07-24 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -15,7 +15,7 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2003-2024 saldi.dk aps
+// Copyright (c) 2003-2026 Danosoft.ApS
 // ----------------------------------------------------------------------
 //
 // 20132127 Indsat kontrol for at kodenr er numerisk på momskoder.
@@ -43,6 +43,11 @@
 // 20220614 MSC - Added div class divSys
 // 20240407 PHR - save moved to syssetupIncludes/saveData.php
 // 20240604 PHR PHP8
+// 20260716 MJ  Tilfoejede Land (OSS) og Type til SM-momskoder for OSS B2C EU momsangivelse.
+// 20260723 MJ  EU-zone-dropdown (box10) paa DG-debitorgrupper til OSS-klassificering.
+// 20260723 MJ  Varer/ydelser-type (box5) til VG-varegrupper for Momsrubrikker A/B/C-afledning.
+// 20260723 MJ  Fjernet Rubrik-kolonne (box5) fra SM/KM/YM/EM-momskoder: bruges ikke laengere.
+// 20260724 MJ  EU-zone-dropdown (box10) paa KG-kreditorgrupper til Momsrubrikker Rubrik A.
 
 @session_start();
 $s_id=session_id();
@@ -151,8 +156,10 @@ if ($valg=='moms'){
 	print "<td align=\"center\"><span title='$spantxt1'>".findtekst('914|Beskrivelse', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt2'>".findtekst('440|Konto', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt3'>".findtekst('995|Sats', $sprog_id)."</span></td>";
-	print "<td></td><td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";		#20210513
-	$y=skriv_formtabel('SM',$x,$y,$art,$id,'S',$kodenr,$beskrivelse,$box1,'6' ,$box2,'6','','6',$box4,'6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
+	print "<td></td><td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td>";
+	print "<td align=\"center\"><span title='Land for OSS B2C EU-moms (f.eks. Sverige, Finland). Udfyldes kun paa SM-koder for salg til EU-privatpersoner.'>Land (OSS)</span></td>\n";
+	print "<td align=\"center\"><span title='Type for OSS-angivelse: varer eller ydelser. Udfyldes kun paa OSS-koder.'>Type</span></td></tr>\n";
+	$y=skriv_formtabel('SM',$x,$y,$art,$id,'S',$kodenr,$beskrivelse,$box1,'6' ,$box2,'6','','6',$box4,'6','-','',$box6,'10',$box7,'8','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
 	print "<tr><td><br></td></tr>\n";
 	$spantxt2=findtekst('2245|Det nummer i kontoplanen som købsmomsen skal konteres på.', $sprog_id);
 	print "<tr><td></td><td colspan=3><b><span title='".findtekst('2431|Den moms du skal have retur fra SKAT', $sprog_id)."'>".findtekst('996|Købsmoms (indgående moms)', $sprog_id)."</span></td></tr>\n";
@@ -160,8 +167,8 @@ if ($valg=='moms'){
 	print "<td align=\"center\"><span title='$spantxt1'>".findtekst('914|Beskrivelse', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt2'>".findtekst('440|Konto', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt3'>".findtekst('995|Sats', $sprog_id)."</span></td>\n";
-	print "<td></td><td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";		#20210513
-	$y=skriv_formtabel('KM',$x,$y,$art,$id,"K",$kodenr,$beskrivelse,$box1,'6',$box2,'6','','6',$box4,'6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
+	print "<td></td><td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";
+	$y=skriv_formtabel('KM',$x,$y,$art,$id,"K",$kodenr,$beskrivelse,$box1,'6',$box2,'6','','6',$box4,'6','-','','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
 	print "<tr><td><br></td></tr>\n";
 	$spantxty2=findtekst('2432|Konto til postering af salgsmoms for ydelseskøb i udlandet', $sprog_id);
 	$spantxty4=findtekst('2433|Konto til postering af købsmoms for ydelseskøb i udlandet', $sprog_id);
@@ -172,8 +179,8 @@ if ($valg=='moms'){
 	print "<td align=\"center\"><span title='$spantxt2'>".findtekst('440|Konto', $sprog_id)."<span></td>";
 	print "<td align=\"center\"><span title='$spantxt3'>".findtekst('995|Sats', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt4'>".findtekst('1013|Modkonto', $sprog_id)."</span></td>\n";
-	print "<td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";		#20210513
-	$y=skriv_formtabel('YM',$x,$y,$art,$id,"Y",$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'6',$box4,'6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
+	print "<td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";
+	$y=skriv_formtabel('YM',$x,$y,$art,$id,"Y",$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'6',$box4,'6','-','','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
 	print "<tr><td><br></td></tr>\n";
 	$spantxt2=findtekst('2434|Konto til postering af salgsmoms for køb i udlandet', $sprog_id);
 	$spantxte4=findtekst('2435|Konto til postering af købsmoms for køb i udlandet', $sprog_id);
@@ -184,8 +191,8 @@ if ($valg=='moms'){
 	print "<td align=\"center\"><span title='$spantxt2'>".findtekst('440|Konto', $sprog_id)."<span></td>";
 	print "<td align=\"center\"><span title='$spantxt3'>".findtekst('995|Sats', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title='$spantxt4'>".findtekst('1013|Modkonto', $sprog_id)."</span></td>\n";
-	print "<td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";		#20210513
-	$y=skriv_formtabel('EM',$x,$y,$art,$id,"E",$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'6',$box4,'6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
+	print "<td align=\"center\"><span title='$spantxt5'>$spantxt4</span></td></tr>\n";
+	$y=skriv_formtabel('EM',$x,$y,$art,$id,"E",$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'6',$box4,'6','-','','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','6','-','2');
 	print "<tr><td><br></td></tr>\n";
 	print "<tr><td></td><td colspan=3><b>".findtekst('1009|Momsrapport (konti som skal indgå i momsrapport)', $sprog_id)."</b></td></tr>\n";
 	print "<tr><td></td><td>".findtekst('2248|Nr.', $sprog_id)."</td>";
@@ -217,8 +224,9 @@ elseif($valg=='debitor'){
 	$spantitle="Business to business!\n".findtekst('2454|Afmærk her, hvis der skal anvendes B2B priser ved salg til denne kundegruppe', $sprog_id);
 	print "<td align=\"center\"><span title=\"".$spantitle."\">B2B</td>\n";
 	$spantitle=findtekst('2455|Omvendt betalingspligt', $sprog_id)."!\n".findtekst('2456|Afmærk her, hvis denne kundegruppe er omfattet af omvendt betalingspligt', $sprog_id);
- 	print "<td align=\"center\"><span title=\"".$spantitle."\">".findtekst('2457|OB', $sprog_id)."</td></tr>\n"; # 20141212B spantilte -> spantitle (slut)
-	$y=skriv_formtabel('DG',$x,$y,$art,$id,'D',$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'10',$box4,'10',$box5,'6','-','4',$box7,'4',$box8,'checkbox',$box9,'checkbox','-','2','-','2','-','2','-','2','-','2');
+ 	print "<td align=\"center\"><span title=\"".$spantitle."\">".findtekst('2457|OB', $sprog_id)."</td>";
+	print "<td align=\"center\"><span title='EU-zone: klassificering til OSS-rapport. B2C EU = privat i EU (OSS-pligtig), B2C udenfor EU, B2B EU = erhverv m. CVR i EU, B2B udenfor EU.'>EU-zone</span></td></tr>\n"; // 20260723 MJ
+	$y=skriv_formtabel('DG',$x,$y,$art,$id,'D',$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'10',$box4,'10',$box5,'6','-','4',$box7,'4',$box8,'checkbox',$box9,'checkbox',$box10,'eu-zone','-','2','-','2','-','2','-','2');
 	print "<tr><td><br></td></tr>\n";
 	print "<tr><td></td><td colspan=2><b>".findtekst('1183|Kreditorgrupper', $sprog_id)."</td><td></td></tr>\n";
 	print "<tr><td></td><td>".findtekst('2248|Nr.', $sprog_id)."</td>";
@@ -230,9 +238,10 @@ elseif($valg=='debitor'){
 	print "<td align=\"center\"><span title=\"".findtekst('2550|Modkonto ved udligning af åbne poster', $sprog_id)."\">".findtekst('1013|Modkonto', $sprog_id)."</span></td>";
 	print "<td align=\"center\"><span title=\"".findtekst('2462|Momsgruppe for salgsmoms ved omvendt betalingspligt', $sprog_id)."'>".findtekst('2463|S.moms grp.', $sprog_id)."</span></td>";
 	$spantitle=findtekst('2455|Omvendt betalingspligt', $sprog_id)."!\n".findtekst('2465|Afmærk her, hvis denne leverandørgruppe er omfattet af omvendt betalingspligt', $sprog_id);
-	print "<td align=\"center\"><span title=\"".$spantitle."\">".findtekst('2457|OB', $sprog_id)."</td></tr>\n";
+	print "<td align=\"center\"><span title=\"".$spantitle."\">".findtekst('2457|OB', $sprog_id)."</td>";
+	print "<td align=\"center\"><span title='EU-zone: klassificering til Momsrubrikker Rubrik A. EU (andet EU-land) = leverandoer i andet EU-land.'>EU-zone</span></td></tr>\n"; // 20260724 MJ
 #	print "<td align=\"center\"><span title=\"Omvendt betaligspligt!\"Afmærk her,hvis denne leverandørgruppe er omfattet af omvendt betalingspligt>O/B</span></td></tr>\n";
-	$y=skriv_formtabel('KG',$x,$y,$art,$id,'K',$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'10',$box4,'10',$box5,'10',$box6,'6','-','6','-','6',$box9,'checkbox','-','6','-','6','-','6','-','6','-','2');
+	$y=skriv_formtabel('KG',$x,$y,$art,$id,'K',$kodenr,$beskrivelse,$box1,'6',$box2,'6',$box3,'10',$box4,'10',$box5,'10',$box6,'6','-','6','-','6',$box9,'checkbox',$box10,'eu-zone','-','6','-','6','-','6','-','2');
 }
 elseif($valg=='afdelinger'){
 	include("settings/departments.php");
@@ -260,6 +269,7 @@ elseif($valg=='varer'){
 		if ($stockIO) print "<td align=\"center\">".findtekst('608|Lager', $sprog_id)."-</td><td align=\"center\">".findtekst('608|Lager', $sprog_id)."-</td>";
 		print "<td align=\"center\"><!--Køb--></td>";
 		print "<td align=\"center\"><!--".findtekst('1007|Salgs', $sprog_id)."--></td>";
+		print "<td align=\"center\">Varer/</td>\n";
 		#<td align=\"center\">Lager-</td>";
 		print "<td title=\"$t6\" align=\"center\">Omvendt-</td>";
 		print "<td align=\"center\">".findtekst('770|Moms', $sprog_id)."-</td>";
@@ -275,6 +285,7 @@ elseif($valg=='varer'){
 		if ($stockIO) print "<td align=\"center\">tilgang</td><td align=\"center\">træk</td>";
 		print "<td align=\"center\">".findtekst('1012|Køb', $sprog_id)."</td>";
 		print "<td align=\"center\">".findtekst('2468|Salg', $sprog_id)."<!--".findtekst('1007|Salgs', $sprog_id)."--></td>";
+			print "<td align=\"center\">ydelser</td>\n";
 		#<td align=\"center\">regulering</td>
 		print "<td  title=\"$t6\" align=\"center\">betaling</td>";
 		print "<td align=\"center\">fri</td>";
@@ -286,9 +297,9 @@ elseif($valg=='varer'){
 		print "<td title='Kontonummer for en af Varekøb uden for EU, Ydelseskøb uden for EU eller Vare- og ydelseskøb uden for EU.'>for EU</td>\n";
 		print "<td title='Kontonummer for en af Varesalg uden for EU, Ydelsessalg uden for EU eller Vare- og ydelsessalg uden for EU (Rubrik C). Hvis en af de to første angives, så skal kontonummeret være blandt de kontonumre, som summeres til en samlekonto for Vare- og ydelsessalg uden for EU (Rubrik C).'>for EU</td></tr>\n";
 		if ($stockIO) {
-		$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,$box1,'4',$box2,'4',$box3,'4',$box4,'4','-','',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
+		$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,$box1,'4',$box2,'4',$box3,'4',$box4,'4',$box5,'vg-type',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
 		} else {
-			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,'-','','-','',$box3,'4',$box4,'4','-','',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
+			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,'-','','-','',$box3,'4',$box4,'4',$box5,'vg-type',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
 		}
 	} else {
 		print "<tr><td colspan=20 align=\"center\"><b>".findtekst('774|Varegrupper', $sprog_id)."</td></tr><tr><td colspan=20><hr></td></tr>\n";
@@ -297,6 +308,7 @@ elseif($valg=='varer'){
 			print "<td align=\"center\">".findtekst('608|Lager', $sprog_id)."-</td><td align=\"center\">".findtekst('608|Lager', $sprog_id)."-</td>";
 		}	
 		print "<td align=\"center\">".findtekst('110|Varer', $sprog_id)."-</td><td align=\"center\">".findtekst('110|Varer', $sprog_id)."-</td>";
+		print "<td align=\"center\">Varer/</td>\n";
 #		print "<td align=\"center\">Lager-</td>";
 		print "<td align=\"center\">Omvendt-</td>";
 		print "<td align=\"center\">".findtekst('770|Moms', $sprog_id)."-</td>";
@@ -312,6 +324,7 @@ elseif($valg=='varer'){
 		if ($stockIO) print "<td align=\"center\">tilgang</td><td align=\"center\">træk</td>";
 		print "<td align=\"center\">".findtekst('1012|Køb', $sprog_id)."</td>";
 		print "<td align=\"center\">".findtekst('1007|Salgs', $sprog_id)."</td>";
+			print "<td align=\"center\">ydelser</td>\n";
 #		print "<td align=\"center\">regulering</td>";
 		print "<td  title=\"$t6\" align=\"center\">betaling</td>";
 		print "<td align=\"center\">fri</td>";
@@ -323,9 +336,9 @@ elseif($valg=='varer'){
 		print "<td title='Kontonummer for en af Varekø uden for EU, Ydelseskø uden for EU eller Vare- og ydelseskø uden for EU.'>for EU</td>\n";
 		print "<td title='Kontonummer for en af Varesalg uden for EU, Ydelsessalg uden for EU eller Vare- og ydelsessalg uden for EU (Rubrik C). Hvis en af de to første angives, så skal kontonummeret være blandt de kontonumre, som summeres til en samlekonto for Vare- og ydelsessalg uden for EU (Rubrik C).'>for EU</td></tr>\n";
 		if ($stockIO) {
-			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,$box1,'4',$box2,'4',$box3,'4',$box4,'4','-','',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
+			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,$box1,'4',$box2,'4',$box3,'4',$box4,'4',$box5,'vg-type',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
 		} else {
-			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,'-','','-','',$box3,'4',$box4,'4','-','',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
+			$y=skriv_formtabel('VG',$x,$y,$art,$id,'&nbsp;',$kodenr,$beskrivelse,'-','','-','',$box3,'4',$box4,'4',$box5,'vg-type',$box6,'checkbox',$box7,'checkbox',$box8,'checkbox',$box9,'checkbox',$box10,'checkbox',$box11,'4',$box12,'4',$box13,'4',$box14,'4');
 		}
 	}
 	print "<tr><td colspan=20 align=\"center\"><hr><b>".findtekst('2471|Prisgrupper', $sprog_id)."</td></tr><tr><td colspan=20><hr></td></tr>\n";

--- a/systemdata/syssetupIncludes/saveData.php
+++ b/systemdata/syssetupIncludes/saveData.php
@@ -5,7 +5,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-//--- systemdata/syssetupIncludes/saveData.php ---patch 4.1.1 ----2025-09-03 ---
+//--- systemdata/syssetupIncludes/saveData.php ---patch 5.0.0 ----2026-07-24 ---
 //                           LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -26,6 +26,7 @@
 // -----------------------------------------------------------
 // 20240604 PHR PHP8
 // 20250903 PHR Definition of array $adr_konto_id
+// 20260724 MJ  Propagate VG.box5 og DG/KG.box10 til alle fiscal_year-raekker ved gem.
 if ($_POST){
 	$id=if_isset($_POST['id']);
 	$beskrivelse=if_isset($_POST['beskrivelse']);
@@ -257,6 +258,14 @@ if ($_POST){
 				else {
 					$qtxt = "update grupper set beskrivelse = '$beskrivelse[$x]',kode = '$kode[$x]',box1 = '$box1[$x]',box2 = '$box2[$x]',box3 = '$box3[$x]',box4 = '$box4[$x]',box5 = '$box5[$x]',box6 = '$box6[$x]',box7 = '$box7[$x]',box8 = '$box8[$x]',box9 = '$box9[$x]',box10 = '$box10[$x]',box11 = '$box11[$x]',box12 = '$box12[$x]',box13 = '$box13[$x]',box14 = '$box14[$x]' WHERE id = '$id[$x]'";
 					db_modify($qtxt,__FILE__ . " linje " . __LINE__);
+					// 20260724 MJ Propagate year-agnostic fields to all fiscal_years for the same group.
+					// VG box5 (varer/ydelser) and DG/KG box10 (eu-zone) are group-level classifications
+					// that do not vary per accounting year, but grupper has one row per fiscal_year.
+					if ($art[$x] === 'VG') {
+						db_modify("UPDATE grupper SET box5 = '$box5[$x]' WHERE art = 'VG' AND kodenr = '$kodenr[$x]'",__FILE__." linje ".__LINE__);
+					} elseif ($art[$x] === 'DG' || $art[$x] === 'KG') {
+						db_modify("UPDATE grupper SET box10 = '$box10[$x]' WHERE art = '$art[$x]' AND kodenr = '$kodenr[$x]'",__FILE__." linje ".__LINE__);
+					}
 				}
 				if ($art[$x]=='VK') { #ValutaKoder
 				if ($r=db_fetch_array(db_select("select id,kurs from valuta where valdate = '$box3[$x]' and gruppe =	'$kodenr[$x]'",__FILE__ . " linje " . __LINE__))) {

--- a/systemdata/syssetupIncludes/saveData.php
+++ b/systemdata/syssetupIncludes/saveData.php
@@ -27,6 +27,7 @@
 // 20240604 PHR PHP8
 // 20250903 PHR Definition of array $adr_konto_id
 // 20260724 MJ  Propagate VG.box5 og DG/KG.box10 til alle fiscal_year-raekker ved gem.
+// 20260729 CL/NTR - reported by CodeRabbit - whitelist box10 and box5 values when transfering between fiscal_years, and empty them if not on the list of allowed values.
 if ($_POST){
 	$id=if_isset($_POST['id']);
 	$beskrivelse=if_isset($_POST['beskrivelse']);
@@ -256,6 +257,16 @@ if ($_POST){
 			elseif ((($id[$x]>0)&&($kodenr[$x])&&($kodenr[$x]!='-'))&&($art[$x])) { # &&(($box1[$x])||($box3[$x])||($art[$x]=='VK')))
 			  if ($art[$x]=='PV') {db_modify("update grupper set box1 = '$box1[$x]',box2 = '$box2[$x]',box3 = '$box3[$x]' WHERE id = '$id[$x]'",__FILE__ . " linje " . __LINE__);}
 				else {
+					// TODO - Once ENUM cataloges are made - import from ENUM cataloge.
+					if ($art[$x] === 'VG' && !in_array($box5[$x], array('', 'varer', 'ydelser'), true)) {
+						$box5[$x] = '';
+					}
+					if ($art[$x] === 'KG' && !in_array($box10[$x], array('', 'B2B-EU', 'B2B-UDL'), true)) {
+						$box10[$x] = '';
+					}
+					if ($art[$x] === 'DG' && !in_array($box10[$x], array('', 'B2C-EU', 'B2C-UDL', 'B2B-EU', 'B2B-UDL'), true)) {
+						$box10[$x] = '';
+					}
 					$qtxt = "update grupper set beskrivelse = '$beskrivelse[$x]',kode = '$kode[$x]',box1 = '$box1[$x]',box2 = '$box2[$x]',box3 = '$box3[$x]',box4 = '$box4[$x]',box5 = '$box5[$x]',box6 = '$box6[$x]',box7 = '$box7[$x]',box8 = '$box8[$x]',box9 = '$box9[$x]',box10 = '$box10[$x]',box11 = '$box11[$x]',box12 = '$box12[$x]',box13 = '$box13[$x]',box14 = '$box14[$x]' WHERE id = '$id[$x]'";
 					db_modify($qtxt,__FILE__ . " linje " . __LINE__);
 					// 20260724 MJ Propagate year-agnostic fields to all fiscal_years for the same group.


### PR DESCRIPTION
## What are the changes about?
Implements a full VAT reporting module for the finance section, covering transaction-level VAT listings, OSS B2C EU sales, VAT box mapping, VAT reconciliation, and period locking.

## New files
**`finans/rapport_includes/moms_transaktioner.php`**
**`finans/rapport_includes/moms_oss.php`**
**`finans/rapport_includes/moms_rubrik.php`**
**`finans/rapport_includes/moms_afstemning.php`**
**`finans/moms_periode.php`**



## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Momsperioder” management with monthly open/close controls (bulk + per month), lock notes, and transaction-count visibility.
  * Introduced new VAT reports: transaction overview, rubric (A/B/C), VAT reconciliation, and OSS EU sales—each with HTML output and CSV export.
  * Expanded VAT setup with EU-zone selection and goods/services + OSS classification via dropdowns.
  * Added “Momsperioder” to the Finance navigation and top menu.
* **Bug Fixes**
  * Posting is now blocked for transactions in closed VAT periods, with clearer pre-check feedback and safer posting rollback on validation failures.
  * Report date picker initialization is now guarded to avoid UI errors when date fields are not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->