### PR TITLE
Restore: terminate other PostgreSQL sessions before DROP DATABASE

### DIFF
--- a/admin/restore.php
+++ b/admin/restore.php
@@ -514,13 +514,23 @@ function restore($filnavn,$backup_encode,$backup_dbtype){
 		db_modify("update regnskab set version = '' where db='$db'",__FILE__ . " linje " . __LINE__);
 		if ($db_type=='postgresql') {
 			// Reconnect to the maintenance database so the active connection is NOT the
-			// database we are about to drop, then terminate any other sessions still on it.
+			// database we are about to drop, then block new connections and terminate any
+			// other sessions still on it before dropping.
 			db_close($connection);
 			$connection = db_connect($sqhost, $squser, $sqpass, "postgres", __FILE__ . " linje " . __LINE__);
+			$quotedDb = pg_escape_identifier($connection, $db);
 			$escapedDb = pg_escape_string($connection, $db);
-			db_select("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$escapedDb' AND pid <> pg_backend_pid()", __FILE__ . " linje " . __LINE__);
+			@pg_query($connection, "ALTER DATABASE $quotedDb CONNECTION LIMIT 0"); // best effort; requires ownership
+			$terminated = pg_query($connection, "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$escapedDb' AND pid <> pg_backend_pid()");
+			if (!$terminated) {
+				print "<BODY ONLOAD=\"javascript:alert('Kunne ikke afbryde aktive forbindelser til regnskabet - genskab afbrudt')\">";
+				print "<meta http-equiv=\"refresh\" content=\"0;URL=backup.php\">";
+				return;
+			}
+			db_modify("DROP DATABASE $quotedDb",__FILE__ . " linje " . __LINE__);
+		} else {
+			db_modify("DROP DATABASE $db",__FILE__ . " linje " . __LINE__);
 		}
-		db_modify("DROP DATABASE $db",__FILE__ . " linje " . __LINE__);
 		db_create($db);
 		print "<!-- Saldi-kommentar for at skjule uddata til siden \n"; # Indsat da svar fra pg_dump kan resultere i besked genereres
 		$mysql = $psql = NULL;

--- a/admin/restore.php
+++ b/admin/restore.php
@@ -37,6 +37,7 @@
 // 20250511 LOE Various changes to ehance user's experience
 // 20260127 LOE Updated migrateMySQLToPostgreSQL for some isolated fixes.
 // 20260129 PHR Added some str_replace  and a call to connect.php before lookup in 'regnskab'
+// 20260702 CX/PHR Close target PostgreSQL connection and terminate active sessions before DROP DATABASE in restore
 @session_start();
 $s_id=session_id();
 ini_set('display_errors',0);
@@ -511,6 +512,14 @@ function restore($filnavn,$backup_encode,$backup_dbtype){
 		// }
 		db_modify("delete from online where db='$db'",__FILE__ . " linje " . __LINE__);
 		db_modify("update regnskab set version = '' where db='$db'",__FILE__ . " linje " . __LINE__);
+		if ($db_type=='postgresql') {
+			// Reconnect to the maintenance database so the active connection is NOT the
+			// database we are about to drop, then terminate any other sessions still on it.
+			db_close($connection);
+			$connection = db_connect($sqhost, $squser, $sqpass, "postgres", __FILE__ . " linje " . __LINE__);
+			$escapedDb = pg_escape_string($connection, $db);
+			db_select("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$escapedDb' AND pid <> pg_backend_pid()", __FILE__ . " linje " . __LINE__);
+		}
 		db_modify("DROP DATABASE $db",__FILE__ . " linje " . __LINE__);
 		db_create($db);
 		print "<!-- Saldi-kommentar for at skjule uddata til siden \n"; # Indsat da svar fra pg_dump kan resultere i besked genereres


### PR DESCRIPTION
## Background

Part of porting verified live-server fixes from ssl3.saldi.dk to master (context in #403).

On PostgreSQL, restoring over an existing accounting database fails when other sessions are connected — `DROP DATABASE` refuses to run with active backends.

## Fix

Before `DROP DATABASE`, when `db_type == 'postgresql'`: repoint the active connection to the `postgres` maintenance database, then terminate other sessions on the target database via `pg_terminate_backend()` (database name escaped with `pg_escape_string`). MySQL installs unaffected.

**Note:** this is deliberately *adapted* from the live-server version. The live fix reconnected to the target database itself before dropping it, which PostgreSQL also refuses ("cannot drop the currently open database"), so it could defeat its own purpose. This port reconnects to the maintenance DB instead.

## Testing

`php -l` clean. **Needs a restore test on a PostgreSQL install before merge** — including confirming the saldi DB user may connect to the `postgres` database (otherwise the maintenance target should be made configurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1aEDQs2HH2LoHCQ4pQpxg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL database restoration by safely closing active connections and terminating other sessions before dropping the target database.
  * Restores now proceed more reliably when other sessions are connected.
  * Added user-facing guidance to clarify required connection handling during the restore process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->