### PR TITLE
Fix: collapsible Ekstra e-mails, Kategorier, and Invoice overview sec…

### DIFF
--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -51,6 +51,42 @@
 // 20260717 SZ Replaced the fixed setTimeout grid-render guesses with waitForGridReady() polling;
 //                all three collapsible sections (Ekstra e-mails/Kategorier/Invoice overview) now
 //                persist their expand/collapse state in localStorage across page loads
+// 20260720 SZ Made the three collapsible sections' click affordance clearer: swapped the plain
+//                unicode arrows for the same fa-chevron-down/up icons the sidebar menu uses,
+//                widened the clickable area to the whole title (not just the small count text),
+//                and added a hover highlight + tooltip so it reads as a toggle at a glance
+// 20260720 SZ The page's global "a:link{text-decoration:none}" rule was making the toggle look
+//                like plain black text, not a link, so the chevron alone wasn't enough of a
+//                hint; styled the whole toggle bar as a colored, underlined link and added an
+//                explicit "Show/Hide" text label next to the chevron on all three sections
+// 20260720 SZ The new "Ekstra e-mails"/"Invoice overview"/"Show/Hide"/tooltip strings were
+//                hardcoded in Danish/English and not translated for Norwegian; added tekst_id
+//                5027-5030 to importfiler/tekster.csv (da/en/no) and wired all four through
+//                findtekst() so they follow the same convention as "Kategorier" (tekst_id 388)
+// 20260720 SZ Replaced the underlined-link toggle with two disclosure patterns from design
+//                review: a bordered "chip" control (border + count badge + chevron) for the
+//                inline Ekstra e-mails/Kategorier rows, and a full-width sunken accordion bar
+//                (chevron-right/down + rounded count badge) for the larger Invoice overview
+//                section — both read as real controls instead of decorated text
+// 20260720 SZ Switched Invoice overview from the sunken accordion bar to the same bordered
+//                chip control used by Ekstra e-mails/Kategorier, for visual consistency across
+//                all three sections; removed the now-unused sunken-bar CSS
+// 20260720 SZ Changed the default state of all three collapsible sections from collapsed to
+//                expanded on first load; localStorage still remembers an explicit collapse
+//                choice across reloads, only the "never toggled before" default changed
+// 20260720 SZ Replaced the fa-chevron-* icon font glyphs (which depend on an external CDN
+//                and were rendering blank in a no-internet test environment) with plain
+//                Unicode &#9650;/&#9660; arrows for the three toggle chevrons — zero network
+//                dependency, same up/down swap logic, now via innerHTML instead of className
+// 20260720 SZ Replaced the Unicode arrow glyphs with a pure-CSS chevron (two rotated borders
+//                forming a "v") matching the shape of the sidebar's fa-chevron icon without any
+//                icon-font dependency; toggling now rotates the chevron via a CSS class instead
+//                of swapping its content, for a smoother animated open/close
+// 20260720 SZ Widened the Kategorier/Invoice overview chips (min-width, more padding/gap) to
+//                match the design mockup's proportions; Ekstra e-mails chip left compact
+// 20260720 SZ Grouped the badge+summary into a "chip-left" span and switched the chip to
+//                justify-content:space-between, so the chevron always sits pinned to the
+//                right edge of the chip instead of bunched up next to the summary text
 @session_start();
 $s_id = session_id();
 
@@ -1472,7 +1508,8 @@ print "</td></tr>\n";
 
 // Ekstra e-mails section header
 $extra_count = ($kontakt_email_count > 1) ? $kontakt_email_count - 1 : 0;
-$ke_initially_visible = 'none'; // always collapsed on load, matching da_collapsible convention
+$ke_initially_visible = ''; // expanded on load by default; keToggle()/localStorage can collapse it
+$ke_chevron_class = 'chip-chevron is-expanded';
 
 // Glanceable summary of extra e-mails by type, so the collapsed header shows
 // something useful instead of just a total count.
@@ -1492,9 +1529,13 @@ if (count($ke_summary_parts) > 3) $ke_summary_text .= ', ...';
 
 ($bg == $bgcolor) ? $bg = $bgcolor5 : $bg = $bgcolor;
 print "<tr bgcolor=$bg><td style='vertical-align:top'>";
-print "<b>Ekstra e-mails</b> ";
-print "<a href='#' onclick='keToggle(); return false;' style='text-decoration:none; cursor:pointer;'>";
-print "<small>(<span id='ekstra_email_count'>$extra_count</span><span id='ke_summary_text'>" . ($ke_summary_text ? ": $ke_summary_text" : '') . "</span> <span id='ke_toggle_icon'>&#9660;</span>)</small>";
+print "<b>" . findtekst('5027|Ekstra e-mails', $sprog_id) . "</b> ";
+print "<a href='#' onclick='keToggle(); return false;' class='disclosure-chip' title=\"" . findtekst('5030|Klik for at vise/skjule', $sprog_id) . "\">";
+print "<span class='chip-left'>";
+print "<span class='chip-badge' id='ekstra_email_count'>$extra_count</span>";
+print "<span class='chip-summary' id='ke_summary_text'>$ke_summary_text</span>";
+print "</span>";
+print "<span class='$ke_chevron_class' id='ke_toggle_icon'></span>";
 print "</a>";
 print "</td><td>";
 print "<button type='button' onclick='addEmailRow()' class='button green small' style='$buttonStyle; padding: 2px 10px 2px 10px' onMouseOver=\"this.style.cursor='pointer'\">+ Ny</button>";
@@ -1595,7 +1636,7 @@ function updateEmailCount() {
     });
     var summary = parts.slice(0, 3).join(', ') + (parts.length > 3 ? ', ...' : '');
     var summaryEl = document.getElementById('ke_summary_text');
-    if (summaryEl) summaryEl.textContent = summary ? ': ' + summary : '';
+    if (summaryEl) summaryEl.textContent = summary;
 }
 
 function keToggle() {
@@ -1605,10 +1646,10 @@ function keToggle() {
     var expanding = row.style.display === 'none';
     if (expanding) {
         row.style.display = '';
-        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
+        if (icon) icon.classList.add('is-expanded');
     } else {
         row.style.display = 'none';
-        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
+        if (icon) icon.classList.remove('is-expanded');
     }
     localStorage.setItem('debitorkort_ke_expanded', expanding ? '1' : '0');
 }
@@ -1621,40 +1662,42 @@ function catToggle() {
     var expanding = row.style.display === 'none';
     if (expanding) {
         row.style.display = '';
-        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
+        if (icon) icon.classList.add('is-expanded');
     } else {
         row.style.display = 'none';
-        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
+        if (icon) icon.classList.remove('is-expanded');
     }
     localStorage.setItem('debitorkort_cat_expanded', expanding ? '1' : '0');
 }
 window.catToggle = catToggle;
 
-// Restore each section's last collapse choice (defaults to collapsed if never toggled).
+// Restore each section's last collapse choice. Default is expanded (server-rendered that
+// way); only collapse here if the user explicitly collapsed it on a previous visit.
 // Skipped for categories while a rename is in progress — that flow needs to stay expanded.
 document.addEventListener('DOMContentLoaded', function () {
-    if (localStorage.getItem('debitorkort_ke_expanded') === '1') {
+    if (localStorage.getItem('debitorkort_ke_expanded') === '0') {
         var keRow = document.getElementById('ekstra_emails_row');
         var keIcon = document.getElementById('ke_toggle_icon');
-        if (keRow && keRow.style.display === 'none') {
-            keRow.style.display = '';
-            if (keIcon) keIcon.innerHTML = '&#9650;';
+        if (keRow && keRow.style.display !== 'none') {
+            keRow.style.display = 'none';
+            if (keIcon) keIcon.classList.remove('is-expanded');
         }
     }
     // Categories: skip restoring from localStorage if the row is already expanded
     // server-side (a rename is in progress and needs to stay visible).
     var catRow = document.getElementById('cat_content_row');
     var catAlreadyExpanded = catRow && catRow.style.display !== 'none';
-    if (catRow && !catAlreadyExpanded && localStorage.getItem('debitorkort_cat_expanded') === '1') {
+    if (catRow && !catAlreadyExpanded && localStorage.getItem('debitorkort_cat_expanded') !== '0') {
         var catIcon = document.getElementById('cat_toggle_icon');
         catRow.style.display = '';
-        if (catIcon) catIcon.innerHTML = '&#9650;';
+        if (catIcon) catIcon.classList.add('is-expanded');
     }
 });
 
 function updateCatSummary() {
-    var countEl = document.getElementById('cat_count');
-    if (!countEl) return;
+    var badgeEl = document.getElementById('cat_count_badge');
+    var summaryEl = document.getElementById('cat_count');
+    if (!summaryEl) return;
     var rows = document.querySelectorAll('#cat_content_row tbody tr');
     var names = [];
     rows.forEach(function (tr) {
@@ -1662,12 +1705,13 @@ function updateCatSummary() {
         var nameTd = tr.querySelector('td');
         if (cb && cb.checked && nameTd) names.push(nameTd.textContent.trim());
     });
+    if (badgeEl) badgeEl.textContent = names.length;
     if (names.length === 0) {
-        countEl.textContent = '0 valgt';
+        summaryEl.textContent = '';
     } else {
         var shown = names.slice(0, 2).join(', ');
         var extra = names.length > 2 ? ', +' + (names.length - 2) : '';
-        countEl.textContent = names.length + ' valgt: ' + shown + extra;
+        summaryEl.textContent = shown + extra;
     }
 }
 window.updateCatSummary = updateCatSummary;
@@ -2288,11 +2332,10 @@ print "<tr><td valign=\"top\"><table cellpadding=\"0\" cellspacing=\"1\" border=
 
 
 $bg = $bgcolor5;
-// Keep the category list expanded when a rename is in progress (user came here to edit it);
-// otherwise start collapsed, same convention as the delivery-address / extra-email sections.
-$cat_initially_expanded = is_numeric($rename_category);
-$cat_row_display = $cat_initially_expanded ? '' : 'none';
-$cat_toggle_icon_initial = $cat_initially_expanded ? '&#9650;' : '&#9660;';
+// Expanded on load by default (catToggle()/localStorage can collapse it); a rename in
+// progress always forces it expanded regardless of any stored collapse choice.
+$cat_row_display = '';
+$cat_chevron_class = 'chip-chevron is-expanded';
 
 // Glanceable summary of the categories actually assigned to this debtor, so
 // the collapsed header shows something useful instead of just a total count.
@@ -2302,15 +2345,20 @@ for ($ci = 0; $ci < count($cat_id); $ci++) {
 }
 $cat_assigned_count = count($cat_assigned_names);
 if ($cat_assigned_count > 0) {
-	$cat_summary_text = $cat_assigned_count . ' valgt: ' . implode(', ', array_slice($cat_assigned_names, 0, 2));
-	if ($cat_assigned_count > 2) $cat_summary_text .= ', +' . ($cat_assigned_count - 2);
+	$cat_names_text = implode(', ', array_slice($cat_assigned_names, 0, 2));
+	if ($cat_assigned_count > 2) $cat_names_text .= ', +' . ($cat_assigned_count - 2);
 } else {
-	$cat_summary_text = '0 valgt';
+	$cat_names_text = '';
 }
 
-print "<tr bgcolor=$bg><td colspan=\"4\" valign=\"top\">" . findtekst('388|Kategorier', $sprog_id) . "<!--tekst 388-->";
-print " <a href='#' onclick='catToggle(); return false;' style='text-decoration:none; cursor:pointer;'>";
-print "<small>(<span id='cat_count'>$cat_summary_text</span> <span id='cat_toggle_icon'>$cat_toggle_icon_initial</span>)</small>";
+print "<tr bgcolor=$bg><td colspan=\"4\" valign=\"top\">";
+print "<b>" . findtekst('388|Kategorier', $sprog_id) . "</b> <!--tekst 388-->";
+print "<a href='#' onclick='catToggle(); return false;' class='disclosure-chip chip-wide' title=\"" . findtekst('5030|Klik for at vise/skjule', $sprog_id) . "\">";
+print "<span class='chip-left'>";
+print "<span class='chip-badge' id='cat_count_badge'>$cat_assigned_count</span>";
+print "<span class='chip-summary' id='cat_count'>$cat_names_text</span>";
+print "</span>";
+print "<span class='$cat_chevron_class' id='cat_toggle_icon'></span>";
 print "</a>";
 print "</td></tr>\n";
 print "<tr id='cat_content_row' style='display:{$cat_row_display};'><td colspan=\"4\"><div style='max-height:30vh; overflow-y:auto;'><table cellpadding=\"0\" cellspacing=\"1\" border=\"0\" width=\"100%\"><tbody>\n";
@@ -2619,16 +2667,25 @@ if ($id > 0) {
 		) AS purchase_history_count
 	", __FILE__ . " linje " . __LINE__));
 	$ph_total_count = $ph_count_row['cnt'] ?? 0;
+	$ph_title = findtekst('5028|Fakturaoversigt', $sprog_id);
+	$ph_tooltip = findtekst('5030|Klik for at vise/skjule', $sprog_id);
+	$ph_summary_label = findtekst('5031|Fakturaer', $sprog_id);
 
-	// Collapsed by default, same convention as the extra-email / category sections.
+	// Expanded by default, same convention as the extra-email / category sections.
 	// Only the column headers + data rows collapse — the pagination footer stays put,
 	// since its controls (rowcount select, page buttons) submit their own <form> and
 	// would break if physically moved outside the grid.
-	print "<div id='ph_toggle_bar' onclick='phToggle()' style='padding:4px 8px; cursor:pointer; user-select:none; background:#f4f4f4; border-top:1px solid #ddd; font-size:12px; flex-shrink:0;'>
-	<b>Invoice overview</b> (<span id='ph_count'>$ph_total_count</span> <span id='ph_toggle_icon'>&#9660;</span>)
+	print "<div id='ph_toggle_bar' style='flex-shrink:0; padding:4px 8px;'>
+	<b>$ph_title</b> <a href='#' onclick='phToggle(); return false;' class='disclosure-chip chip-wide' title=\"$ph_tooltip\">
+	<span class='chip-left'>
+	<span class='chip-badge' id='ph_count'>$ph_total_count</span>
+	<span class='chip-summary'>$ph_summary_label</span>
+	</span>
+	<span class='chip-chevron is-expanded' id='ph_toggle_icon'></span>
+	</a>
 </div>";
     // Start purchase history wrapper - separate from form
-    echo "<div class='purchase-history-wrapper ph-collapsed'>";
+    echo "<div class='purchase-history-wrapper ph-expanded'>";
     
 $purchase_columns = [
     [
@@ -3386,6 +3443,76 @@ document.addEventListener('DOMContentLoaded', function() {
 		   room for the toggle bar / grid / footer below it */
 	}
 
+	/* Disclosure affordances for Ekstra e-mails / Kategorier / Invoice overview.
+	   Bordered chip: for the inline field rows (Ekstra e-mails, Kategorier) — the
+	   summary sits inside a real bordered control (border + badge + chevron + hover),
+	   so it reads as a button rather than decorated text. */
+	.disclosure-chip {
+		display: inline-flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		border: 1px solid #d0d5dd;
+		border-radius: 6px;
+		background: #fff;
+		padding: 3px 10px;
+		cursor: pointer;
+		user-select: none;
+		text-decoration: none;
+		color: #333;
+		font-size: 13px;
+		transition: background 0.15s ease, border-color 0.15s ease;
+	}
+	.disclosure-chip .chip-left {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.disclosure-chip.chip-wide {
+		min-width: 220px;
+		padding: 5px 14px;
+	}
+	.disclosure-chip.chip-wide .chip-left {
+		gap: 10px;
+	}
+	.disclosure-chip:hover {
+		background: #f5f7fa;
+		border-color: #b6bdc9;
+	}
+	.disclosure-chip .chip-badge {
+		display: inline-block;
+		background: #eaf1fc;
+		color: #1a5fb4;
+		font-weight: 600;
+		font-size: 12px;
+		border-radius: 10px;
+		padding: 1px 8px;
+		min-width: 14px;
+		text-align: center;
+	}
+	.disclosure-chip .chip-summary {
+		color: #555;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 260px;
+	}
+	/* Pure-CSS chevron (two borders forming a "v", rotated) — same shape as the sidebar's
+	   fa-chevron icon, but with no icon-font dependency, and animates smoothly on toggle. */
+	.chip-chevron {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		border-right: 2px solid #888;
+		border-bottom: 2px solid #888;
+		transform: rotate(45deg);
+		transition: transform 0.15s ease;
+		margin: 0 2px;
+	}
+	.chip-chevron.is-expanded {
+		transform: rotate(-135deg);
+	}
+
 	.purchase-history-wrapper {
 		overflow: hidden;
 		display: flex;
@@ -3521,26 +3648,22 @@ document.addEventListener('DOMContentLoaded', function() {
             outer.appendChild(footerBar);
         }
 
-        // Invoice overview: restore the user's last collapse choice (default collapsed
-        // if they've never toggled it). Only the column headers + data rows are hidden —
-        // the pagination footer stays visible (it lives in its own <form> and can't
-        // safely be detached from the grid).
+        // Invoice overview: restore the user's last collapse choice. Default is expanded
+        // (server-rendered that way); only collapse here if the user explicitly collapsed
+        // it on a previous visit. Only the column headers + data rows are hidden — the
+        // pagination footer stays visible (it lives in its own <form> and can't safely
+        // be detached from the grid).
         var thead = document.querySelector('#datatable-purchase_history thead');
         var tbody = document.querySelector('#datatable-purchase_history tbody');
         var gridWrapper = document.querySelector('.purchase-history-wrapper');
         var icon = document.getElementById('ph_toggle_icon');
-        var wasExpanded = localStorage.getItem('debitorkort_ph_expanded') === '1';
-        if (thead && tbody && gridWrapper) {
-            if (wasExpanded) {
-                gridWrapper.classList.remove('ph-collapsed');
-                gridWrapper.classList.add('ph-expanded');
-                thead.style.display = '';
-                tbody.style.display = '';
-                if (icon) icon.innerHTML = '&#9650;';
-            } else {
-                thead.style.display = 'none';
-                tbody.style.display = 'none';
-            }
+        var wasCollapsed = localStorage.getItem('debitorkort_ph_expanded') === '0';
+        if (thead && tbody && gridWrapper && wasCollapsed) {
+            gridWrapper.classList.remove('ph-expanded');
+            gridWrapper.classList.add('ph-collapsed');
+            thead.style.display = 'none';
+            tbody.style.display = 'none';
+            if (icon) icon.classList.remove('is-expanded');
         }
 
         sizePageLayout();
@@ -3765,13 +3888,13 @@ function phToggle() {
         gridWrapper.classList.add('ph-expanded');
         thead.style.display = '';
         tbody.style.display = '';
-        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
+        if (icon) icon.classList.add('is-expanded');
     } else {
         gridWrapper.classList.remove('ph-expanded');
         gridWrapper.classList.add('ph-collapsed');
         thead.style.display = 'none';
         tbody.style.display = 'none';
-        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
+        if (icon) icon.classList.remove('is-expanded');
     }
     localStorage.setItem('debitorkort_ph_expanded', expanding ? '1' : '0');
     sizePageLayout();

--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -87,6 +87,17 @@
 // 20260720 SZ Grouped the badge+summary into a "chip-left" span and switched the chip to
 //                justify-content:space-between, so the chevron always sits pinned to the
 //                right edge of the chip instead of bunched up next to the summary text
+// 20260721 SZ Flipped the default state of all three collapsible sections back to
+//                collapsed on first load
+// 20260721 SZ Made the Invoice overview grid's height dynamic: 40vh is now a max-height
+//                (was a fixed height), so a handful of rows no longer leaves empty space
+//                below them; also overrode grid.php's global "tbody{min-height:300px}"
+//                and switched the wrapper chain from height:100% to flex:1/min-height:0
+//                so it still caps at 40vh with internal scroll once rows exceed that
+// 20260721 SZ Removed the localStorage persistence added 20260717 — all three sections
+//                must always start collapsed on a fresh page load, even if the user had
+//                expanded one just before navigating away; toggling still works normally
+//                within the same page view, it just no longer survives a reload
 @session_start();
 $s_id = session_id();
 
@@ -1508,8 +1519,8 @@ print "</td></tr>\n";
 
 // Ekstra e-mails section header
 $extra_count = ($kontakt_email_count > 1) ? $kontakt_email_count - 1 : 0;
-$ke_initially_visible = ''; // expanded on load by default; keToggle()/localStorage can collapse it
-$ke_chevron_class = 'chip-chevron is-expanded';
+$ke_initially_visible = 'none'; // always collapsed on load; keToggle() can expand it for this page view
+$ke_chevron_class = 'chip-chevron';
 
 // Glanceable summary of extra e-mails by type, so the collapsed header shows
 // something useful instead of just a total count.
@@ -1651,7 +1662,6 @@ function keToggle() {
         row.style.display = 'none';
         if (icon) icon.classList.remove('is-expanded');
     }
-    localStorage.setItem('debitorkort_ke_expanded', expanding ? '1' : '0');
 }
 window.keToggle = keToggle;
 
@@ -1667,32 +1677,8 @@ function catToggle() {
         row.style.display = 'none';
         if (icon) icon.classList.remove('is-expanded');
     }
-    localStorage.setItem('debitorkort_cat_expanded', expanding ? '1' : '0');
 }
 window.catToggle = catToggle;
-
-// Restore each section's last collapse choice. Default is expanded (server-rendered that
-// way); only collapse here if the user explicitly collapsed it on a previous visit.
-// Skipped for categories while a rename is in progress — that flow needs to stay expanded.
-document.addEventListener('DOMContentLoaded', function () {
-    if (localStorage.getItem('debitorkort_ke_expanded') === '0') {
-        var keRow = document.getElementById('ekstra_emails_row');
-        var keIcon = document.getElementById('ke_toggle_icon');
-        if (keRow && keRow.style.display !== 'none') {
-            keRow.style.display = 'none';
-            if (keIcon) keIcon.classList.remove('is-expanded');
-        }
-    }
-    // Categories: skip restoring from localStorage if the row is already expanded
-    // server-side (a rename is in progress and needs to stay visible).
-    var catRow = document.getElementById('cat_content_row');
-    var catAlreadyExpanded = catRow && catRow.style.display !== 'none';
-    if (catRow && !catAlreadyExpanded && localStorage.getItem('debitorkort_cat_expanded') !== '0') {
-        var catIcon = document.getElementById('cat_toggle_icon');
-        catRow.style.display = '';
-        if (catIcon) catIcon.classList.add('is-expanded');
-    }
-});
 
 function updateCatSummary() {
     var badgeEl = document.getElementById('cat_count_badge');
@@ -2332,10 +2318,10 @@ print "<tr><td valign=\"top\"><table cellpadding=\"0\" cellspacing=\"1\" border=
 
 
 $bg = $bgcolor5;
-// Expanded on load by default (catToggle()/localStorage can collapse it); a rename in
-// progress always forces it expanded regardless of any stored collapse choice.
-$cat_row_display = '';
-$cat_chevron_class = 'chip-chevron is-expanded';
+// Always collapsed on load (catToggle() can expand it for this page view); a rename in
+// progress always forces it expanded regardless of that default.
+$cat_row_display = is_numeric($rename_category) ? '' : 'none';
+$cat_chevron_class = is_numeric($rename_category) ? 'chip-chevron is-expanded' : 'chip-chevron';
 
 // Glanceable summary of the categories actually assigned to this debtor, so
 // the collapsed header shows something useful instead of just a total count.
@@ -2671,7 +2657,7 @@ if ($id > 0) {
 	$ph_tooltip = findtekst('5030|Klik for at vise/skjule', $sprog_id);
 	$ph_summary_label = findtekst('5031|Fakturaer', $sprog_id);
 
-	// Expanded by default, same convention as the extra-email / category sections.
+	// Collapsed by default, same convention as the extra-email / category sections.
 	// Only the column headers + data rows collapse — the pagination footer stays put,
 	// since its controls (rowcount select, page buttons) submit their own <form> and
 	// would break if physically moved outside the grid.
@@ -2681,11 +2667,11 @@ if ($id > 0) {
 	<span class='chip-badge' id='ph_count'>$ph_total_count</span>
 	<span class='chip-summary'>$ph_summary_label</span>
 	</span>
-	<span class='chip-chevron is-expanded' id='ph_toggle_icon'></span>
+	<span class='chip-chevron' id='ph_toggle_icon'></span>
 	</a>
 </div>";
     // Start purchase history wrapper - separate from form
-    echo "<div class='purchase-history-wrapper ph-expanded'>";
+    echo "<div class='purchase-history-wrapper ph-collapsed'>";
     
 $purchase_columns = [
     [
@@ -3519,10 +3505,11 @@ document.addEventListener('DOMContentLoaded', function() {
 		flex-direction: column;
 		flex-shrink: 0;
 	}
-	/* Expanded: column headers + rows visible, bounded height, internal scroll */
+	/* Expanded: column headers + rows visible. 40vh is now a ceiling, not a fixed size —
+	   the wrapper shrinks to fit a handful of rows and only grows up to 40vh before its
+	   internal scroll region (.datatable-search-wrapper below) takes over. */
 	.purchase-history-wrapper.ph-expanded {
-		height: 40vh;
-		min-height: 200px;
+		max-height: 40vh;
 		padding-top: 10px;
 	}
 	/* Collapsed: only the pagination footer is visible, sized to its own content */
@@ -3531,9 +3518,11 @@ document.addEventListener('DOMContentLoaded', function() {
 	}
 
 	#datatable-wrapper-purchase_history {
-		height: 100%;
 		display: flex;
 		flex-direction: column;
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow: hidden;
 	}
 
 	/* Make the search wrapper fill available space */
@@ -3557,6 +3546,13 @@ document.addEventListener('DOMContentLoaded', function() {
 		width: 100%;
 		border-collapse: collapse;
 		flex: 1;
+	}
+
+	/* Overrides render_dropdown_style()'s global "tbody { min-height: 300px; }" — that
+	   floor is what kept this grid tall even for a couple of rows; without it the wrapper
+	   above can actually shrink to fit real content, up to its 40vh max-height cap. */
+	#datatable-wrapper-purchase_history tbody {
+		min-height: 0;
 	}
 
 	/* The filler row should have height: 100% to expand */
@@ -3648,17 +3644,14 @@ document.addEventListener('DOMContentLoaded', function() {
             outer.appendChild(footerBar);
         }
 
-        // Invoice overview: restore the user's last collapse choice. Default is expanded
-        // (server-rendered that way); only collapse here if the user explicitly collapsed
-        // it on a previous visit. Only the column headers + data rows are hidden — the
-        // pagination footer stays visible (it lives in its own <form> and can't safely
-        // be detached from the grid).
+        // Invoice overview: always collapsed on load, regardless of any earlier visit.
+        // Only the column headers + data rows are hidden — the pagination footer stays
+        // visible (it lives in its own <form> and can't safely be detached from the grid).
         var thead = document.querySelector('#datatable-purchase_history thead');
         var tbody = document.querySelector('#datatable-purchase_history tbody');
         var gridWrapper = document.querySelector('.purchase-history-wrapper');
         var icon = document.getElementById('ph_toggle_icon');
-        var wasCollapsed = localStorage.getItem('debitorkort_ph_expanded') === '0';
-        if (thead && tbody && gridWrapper && wasCollapsed) {
+        if (thead && tbody && gridWrapper) {
             gridWrapper.classList.remove('ph-expanded');
             gridWrapper.classList.add('ph-collapsed');
             thead.style.display = 'none';
@@ -3896,7 +3889,6 @@ function phToggle() {
         tbody.style.display = 'none';
         if (icon) icon.classList.remove('is-expanded');
     }
-    localStorage.setItem('debitorkort_ph_expanded', expanding ? '1' : '0');
     sizePageLayout();
 }
 window.phToggle = phToggle;

--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -39,6 +39,18 @@
 // 20260513 PHR Added "and lukket = ''" to 'ansatte' lookup
 // 20260706 MJ Fix $id clobbering by contacts foreach loops; fix UPDATE adresser using wrong id; fix redirect after save; allow save when kontotype not yet set in DB
 // 20260707 MJ Fix primary email deletion on save; fix blank ordre after Account card → Luk
+// 20260717 SZ Added collapse/expand toggles (scrollable, glanceable summaries) for Ekstra e-mails
+//                and Kategorier; fixed purchase history grid's internal scrolling and default height
+// 20260717 SZ Replaced invoice overview's drag-to-resize handle with a plain click-to-toggle title
+//                (like Ekstra e-mails/Kategorier); moved Historik/Kontokort/Fakturaliste/Print buttons
+//                out of the grid's own footer so they stay visible when that section is collapsed
+// 20260717 SZ Added a row count to the invoice overview title; toggle now only hides the column
+//                headers/data rows, leaving the pagination footer visible (its controls submit their
+//                own <form> and can't safely be relocated); added sizePageLayout() so the page never
+//                needs a whole-page scrollbar
+// 20260717 SZ Replaced the fixed setTimeout grid-render guesses with waitForGridReady() polling;
+//                all three collapsible sections (Ekstra e-mails/Kategorier/Invoice overview) now
+//                persist their expand/collapse state in localStorage across page loads
 @session_start();
 $s_id = session_id();
 
@@ -1460,9 +1472,30 @@ print "</td></tr>\n";
 
 // Ekstra e-mails section header
 $extra_count = ($kontakt_email_count > 1) ? $kontakt_email_count - 1 : 0;
+$ke_initially_visible = 'none'; // always collapsed on load, matching da_collapsible convention
+
+// Glanceable summary of extra e-mails by type, so the collapsed header shows
+// something useful instead of just a total count.
+$ke_type_labels = array('tilbud' => 'Tilbud', 'ordre' => 'Ordre', 'faktura' => 'Faktura', 'kontoudtog' => 'Kontoudtog', 'rykker' => 'Rykker', 'andet' => 'Andet');
+$ke_type_counts = array();
+for ($ke_ci = 2; $ke_ci <= $kontakt_email_count; $ke_ci++) {
+	$ke_t = $kontakt_email_types[$ke_ci];
+	if (!isset($ke_type_counts[$ke_t])) $ke_type_counts[$ke_t] = 0;
+	$ke_type_counts[$ke_t]++;
+}
+$ke_summary_parts = array();
+foreach ($ke_type_labels as $ke_t_key => $ke_t_label) {
+	if (!empty($ke_type_counts[$ke_t_key])) $ke_summary_parts[] = $ke_type_counts[$ke_t_key] . ' ' . $ke_t_label;
+}
+$ke_summary_text = implode(', ', array_slice($ke_summary_parts, 0, 3));
+if (count($ke_summary_parts) > 3) $ke_summary_text .= ', ...';
+
 ($bg == $bgcolor) ? $bg = $bgcolor5 : $bg = $bgcolor;
 print "<tr bgcolor=$bg><td style='vertical-align:top'>";
-print "<b>Ekstra e-mails</b> <small>(<span id='ekstra_email_count'>$extra_count</span>)</small>";
+print "<b>Ekstra e-mails</b> ";
+print "<a href='#' onclick='keToggle(); return false;' style='text-decoration:none; cursor:pointer;'>";
+print "<small>(<span id='ekstra_email_count'>$extra_count</span><span id='ke_summary_text'>" . ($ke_summary_text ? ": $ke_summary_text" : '') . "</span> <span id='ke_toggle_icon'>&#9660;</span>)</small>";
+print "</a>";
 print "</td><td>";
 print "<button type='button' onclick='addEmailRow()' class='button green small' style='$buttonStyle; padding: 2px 10px 2px 10px' onMouseOver=\"this.style.cursor='pointer'\">+ Ny</button>";
 print "</td></tr>\n";
@@ -1480,11 +1513,11 @@ print "<input type='hidden' name='kontakt_emails_json' id='kontakt_emails_json' 
 
 // Display rows (visual only — data synced to hidden field on submit)
 ($bg == $bgcolor) ? $bg = $bgcolor5 : $bg = $bgcolor;
-print "<tr bgcolor=$bg><td colspan=2><div id='ekstra_emails_container'>\n";
+print "<tr bgcolor=$bg id='ekstra_emails_row' style='display:{$ke_initially_visible};'><td colspan=2><div id='ekstra_emails_container' style='max-height:30vh; overflow-y:auto;'>\n";
 for ($em_i = 2; $em_i <= $kontakt_email_count; $em_i++) {
 	$idx = $em_i - 2;
 	print "<div class='ekstra-email-row' style='margin-bottom:3px;' data-db-id='" . $kontakt_email_ids[$em_i] . "'>";
-	print "<select class='inputbox ke-type' onchange=\"javascript:docChange = true;\">";
+	print "<select class='inputbox ke-type' onchange=\"docChange = true; updateEmailCount();\">";
 	$email_types = array('tilbud' => 'Tilbud', 'ordre' => 'Ordre', 'faktura' => 'Faktura/Kreditnota', 'kontoudtog' => 'Kontoudtog', 'rykker' => 'Rykker', 'andet' => 'Andet');
 	foreach ($email_types as $et_val => $et_label) {
 		$et_sel = ($kontakt_email_types[$em_i] == $et_val) ? ' selected' : '';
@@ -1520,7 +1553,7 @@ function addEmailRow() {
     row.style.marginBottom = '3px';
     row.setAttribute('data-db-id', '0');
     row.innerHTML =
-        "<select class='inputbox ke-type' onchange='docChange=true'>" +
+        "<select class='inputbox ke-type' onchange='docChange=true; updateEmailCount();'>" +
         "<option value='tilbud'>Tilbud</option>" +
         "<option value='ordre'>Ordre</option>" +
         "<option value='faktura'>Faktura/Kreditnota</option>" +
@@ -1533,19 +1566,112 @@ function addEmailRow() {
     container.appendChild(row);
     updateEmailCount();
     docChange = true;
+
+    // If the list is collapsed, expand it so the new row is visible
+    var keRow = document.getElementById('ekstra_emails_row');
+    if (keRow && keRow.style.display === 'none') keToggle();
 }
- 
+
 function removeEmailRow(el) {
     el.closest('.ekstra-email-row').remove();
     updateEmailCount();
     docChange = true;
 }
- 
+
 function updateEmailCount() {
     var rows = document.querySelectorAll('#ekstra_emails_container .ekstra-email-row');
     document.getElementById('ekstra_email_count').textContent = rows.length;
+
+    var labels = {tilbud: 'Tilbud', ordre: 'Ordre', faktura: 'Faktura', kontoudtog: 'Kontoudtog', rykker: 'Rykker', andet: 'Andet'};
+    var counts = {};
+    rows.forEach(function (row) {
+        var typeEl = row.querySelector('.ke-type');
+        if (!typeEl) return;
+        counts[typeEl.value] = (counts[typeEl.value] || 0) + 1;
+    });
+    var parts = [];
+    Object.keys(labels).forEach(function (key) {
+        if (counts[key]) parts.push(counts[key] + ' ' + labels[key]);
+    });
+    var summary = parts.slice(0, 3).join(', ') + (parts.length > 3 ? ', ...' : '');
+    var summaryEl = document.getElementById('ke_summary_text');
+    if (summaryEl) summaryEl.textContent = summary ? ': ' + summary : '';
 }
- 
+
+function keToggle() {
+    var row  = document.getElementById('ekstra_emails_row');
+    var icon = document.getElementById('ke_toggle_icon');
+    if (!row) return;
+    var expanding = row.style.display === 'none';
+    if (expanding) {
+        row.style.display = '';
+        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
+    } else {
+        row.style.display = 'none';
+        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
+    }
+    localStorage.setItem('debitorkort_ke_expanded', expanding ? '1' : '0');
+}
+window.keToggle = keToggle;
+
+function catToggle() {
+    var row  = document.getElementById('cat_content_row');
+    var icon = document.getElementById('cat_toggle_icon');
+    if (!row) return;
+    var expanding = row.style.display === 'none';
+    if (expanding) {
+        row.style.display = '';
+        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
+    } else {
+        row.style.display = 'none';
+        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
+    }
+    localStorage.setItem('debitorkort_cat_expanded', expanding ? '1' : '0');
+}
+window.catToggle = catToggle;
+
+// Restore each section's last collapse choice (defaults to collapsed if never toggled).
+// Skipped for categories while a rename is in progress — that flow needs to stay expanded.
+document.addEventListener('DOMContentLoaded', function () {
+    if (localStorage.getItem('debitorkort_ke_expanded') === '1') {
+        var keRow = document.getElementById('ekstra_emails_row');
+        var keIcon = document.getElementById('ke_toggle_icon');
+        if (keRow && keRow.style.display === 'none') {
+            keRow.style.display = '';
+            if (keIcon) keIcon.innerHTML = '&#9650;';
+        }
+    }
+    // Categories: skip restoring from localStorage if the row is already expanded
+    // server-side (a rename is in progress and needs to stay visible).
+    var catRow = document.getElementById('cat_content_row');
+    var catAlreadyExpanded = catRow && catRow.style.display !== 'none';
+    if (catRow && !catAlreadyExpanded && localStorage.getItem('debitorkort_cat_expanded') === '1') {
+        var catIcon = document.getElementById('cat_toggle_icon');
+        catRow.style.display = '';
+        if (catIcon) catIcon.innerHTML = '&#9650;';
+    }
+});
+
+function updateCatSummary() {
+    var countEl = document.getElementById('cat_count');
+    if (!countEl) return;
+    var rows = document.querySelectorAll('#cat_content_row tbody tr');
+    var names = [];
+    rows.forEach(function (tr) {
+        var cb = tr.querySelector('input[type="checkbox"]');
+        var nameTd = tr.querySelector('td');
+        if (cb && cb.checked && nameTd) names.push(nameTd.textContent.trim());
+    });
+    if (names.length === 0) {
+        countEl.textContent = '0 valgt';
+    } else {
+        var shown = names.slice(0, 2).join(', ');
+        var extra = names.length > 2 ? ', +' + (names.length - 2) : '';
+        countEl.textContent = names.length + ' valgt: ' + shown + extra;
+    }
+}
+window.updateCatSummary = updateCatSummary;
+
 /* ---- SINGLE onsubmit hook — registered once at DOMContentLoaded ---- */
 document.addEventListener('DOMContentLoaded', function () {
     var form = document.forms['debitorkort'];
@@ -2162,7 +2288,32 @@ print "<tr><td valign=\"top\"><table cellpadding=\"0\" cellspacing=\"1\" border=
 
 
 $bg = $bgcolor5;
-print "<tr bgcolor=$bg><td colspan=\"4\" valign=\"top\">" . findtekst('388|Kategorier', $sprog_id) . "<!--tekst 388--></td></tr>\n";
+// Keep the category list expanded when a rename is in progress (user came here to edit it);
+// otherwise start collapsed, same convention as the delivery-address / extra-email sections.
+$cat_initially_expanded = is_numeric($rename_category);
+$cat_row_display = $cat_initially_expanded ? '' : 'none';
+$cat_toggle_icon_initial = $cat_initially_expanded ? '&#9650;' : '&#9660;';
+
+// Glanceable summary of the categories actually assigned to this debtor, so
+// the collapsed header shows something useful instead of just a total count.
+$cat_assigned_names = array();
+for ($ci = 0; $ci < count($cat_id); $ci++) {
+	if (in_array($cat_id[$ci], $kategori)) $cat_assigned_names[] = $cat_beskrivelse[$ci];
+}
+$cat_assigned_count = count($cat_assigned_names);
+if ($cat_assigned_count > 0) {
+	$cat_summary_text = $cat_assigned_count . ' valgt: ' . implode(', ', array_slice($cat_assigned_names, 0, 2));
+	if ($cat_assigned_count > 2) $cat_summary_text .= ', +' . ($cat_assigned_count - 2);
+} else {
+	$cat_summary_text = '0 valgt';
+}
+
+print "<tr bgcolor=$bg><td colspan=\"4\" valign=\"top\">" . findtekst('388|Kategorier', $sprog_id) . "<!--tekst 388-->";
+print " <a href='#' onclick='catToggle(); return false;' style='text-decoration:none; cursor:pointer;'>";
+print "<small>(<span id='cat_count'>$cat_summary_text</span> <span id='cat_toggle_icon'>$cat_toggle_icon_initial</span>)</small>";
+print "</a>";
+print "</td></tr>\n";
+print "<tr id='cat_content_row' style='display:{$cat_row_display};'><td colspan=\"4\"><div style='max-height:30vh; overflow-y:auto;'><table cellpadding=\"0\" cellspacing=\"1\" border=\"0\" width=\"100%\"><tbody>\n";
 $x = 0;
 if (!is_numeric($rename_category)) {
 	for ($x = 0; $x < count($cat_id); $x++) {
@@ -2174,7 +2325,7 @@ if (!is_numeric($rename_category)) {
 			print "<tr><td>$cat_beskrivelse[$x]</td>\n";
 			$tekst = findtekst('395|Afmærk her for at knytte $firmanavn til denne kategori', $sprog_id);
 			$tekst = str_replace('$firmanavn', $firmanavn, $tekst);
-			print "<td title=\"$tekst\" align=\"center\"><!--tekst 395--><input type=\"checkbox\" name=\"cat_valg[$x]\" $checked></td>\n";
+			print "<td title=\"$tekst\" align=\"center\"><!--tekst 395--><input type=\"checkbox\" name=\"cat_valg[$x]\" $checked onchange=\"updateCatSummary()\"></td>\n";
 			print "<td title=\"" . findtekst('396|Klik her for at omdøbe denne kategori', $sprog_id) . "\"><!--tekst 396--><a href=\"debitorkort.php?id=$id&rename_category=$cat_id[$x]\" id=\"rename_category-$x\" onclick=\"return confirm('Vil du omd&oslash;be denne kategori?')\"><img src=../ikoner/rename.png border=0></a></td>\n";
 			print "<td title=\"" . findtekst('397|Klik her for at slette denne kategori', $sprog_id) . "\"><!--tekst 396--><a href=\"debitorkort.php?id=$id&delete_category=$cat_id[$x]\" id=\"delete_category-$x\" onclick=\"return confirm('Vil du slette denne kategori?')\"><img src=../ikoner/delete.png border=0></a></td>\n";
 			print "</tr>\n";
@@ -2208,6 +2359,7 @@ if (is_numeric($rename_category)) {
 	// Use placeholders and titles for better user guidance
 	print "<tr><td colspan=\"4\" title=\"" . findtekst('390|For at oprette en ny kategori skrives navnet på kategorien her. For at oprette en underkategori skrives id på den overstående kategori foran navnet med | som adskillelse', $sprog_id) . "\"><!--tekst 390--><input class='inputbox' type=\"text\" size=\"25\" name=\"newCatName\" placeholder=\"" . findtekst('343|Skriv evt. ny kategori her', $sprog_id) . "\"></td></tr>\n";
 }
+print "</tbody></table></div></td></tr>\n";
 
 
 print "</tbody></table></td>"; # <- TABEL 1.2.4.1
@@ -2455,19 +2607,28 @@ if (!$id || substr($cvrnr,0,1)  == '*') {
 
 ################## PURCHASE HISTORY GRID ##################
 if ($id > 0) {
-	print "<div id='resize-handle' title='drag to resize purchase history' style='height:12px; background:#e0e0f0; cursor:ns-resize; flex-shrink:0; position:relative;'>
-  <span style='position:absolute; inset:0; display:flex; align-items:center; justify-content:center; gap:3px;'>
-    <span style='width:20px;height:2px;background:#888;border-radius:1px;'></span>
-  </span>
-  <span style='position:absolute; inset:0; display:flex; align-items:center; justify-content:center; gap:3px; transform:translateY(-5px);'>
-    <span style='width:20px;height:2px;background:#888;border-radius:1px;'></span>
-  </span>
-  <span style='position:absolute; inset:0; display:flex; align-items:center; justify-content:center; gap:3px; transform:translateY(5px);'>
-    <span style='width:20px;height:2px;background:#888;border-radius:1px;'></span>
-  </span>
+	// Glanceable count for the collapsed header, same convention as the other sections.
+	$ph_count_row = db_fetch_array(db_select("
+		SELECT COUNT(*) AS cnt FROM (
+			SELECT 1
+			FROM ordrelinjer
+			INNER JOIN ordrer ON ordrelinjer.ordre_id = ordrer.id
+			INNER JOIN varer ON ordrelinjer.vare_id = varer.id
+			WHERE ordrer.konto_id = '$id'
+			GROUP BY varer.varenr, varer.id, varer.beskrivelse, ordrelinjer.pris, ordrer.ordredate
+		) AS purchase_history_count
+	", __FILE__ . " linje " . __LINE__));
+	$ph_total_count = $ph_count_row['cnt'] ?? 0;
+
+	// Collapsed by default, same convention as the extra-email / category sections.
+	// Only the column headers + data rows collapse — the pagination footer stays put,
+	// since its controls (rowcount select, page buttons) submit their own <form> and
+	// would break if physically moved outside the grid.
+	print "<div id='ph_toggle_bar' onclick='phToggle()' style='padding:4px 8px; cursor:pointer; user-select:none; background:#f4f4f4; border-top:1px solid #ddd; font-size:12px; flex-shrink:0;'>
+	<b>Invoice overview</b> (<span id='ph_count'>$ph_total_count</span> <span id='ph_toggle_icon'>&#9660;</span>)
 </div>";
     // Start purchase history wrapper - separate from form
-    echo "<div class='purchase-history-wrapper'>";
+    echo "<div class='purchase-history-wrapper ph-collapsed'>";
     
 $purchase_columns = [
     [
@@ -3221,18 +3382,25 @@ document.addEventListener('DOMContentLoaded', function() {
 		flex-shrink: 0;
 		overflow-y: auto;
 		overflow-x: hidden;
-		max-height: calc(100% - 120px); 
-		/* border-bottom: 2px solid #ddd; */
-		/* padding-bottom: 10px; */
+		/* height is set in JS by sizePageLayout() so it always shrinks to make
+		   room for the toggle bar / grid / footer below it */
 	}
 
 	.purchase-history-wrapper {
-		flex: 1;
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
+		flex-shrink: 0;
+	}
+	/* Expanded: column headers + rows visible, bounded height, internal scroll */
+	.purchase-history-wrapper.ph-expanded {
+		height: 40vh;
 		min-height: 200px;
 		padding-top: 10px;
+	}
+	/* Collapsed: only the pagination footer is visible, sized to its own content */
+	.purchase-history-wrapper.ph-collapsed {
+		height: auto;
 	}
 
 	#datatable-wrapper-purchase_history {
@@ -3298,16 +3466,6 @@ document.addEventListener('DOMContentLoaded', function() {
 	.dropdown{
 		display:none !important;
 	}
-	#resize-handle {
-    background: #ccc;
-    cursor: ns-resize;
-    height: 6px;
-    flex-shrink: 0;
-    transition: background 0.2s;
-	}
-	#resize-handle:hover {
-		background: #999;
-	}
 	/* Prevent scrollbar on tfoot/footer buttons */
 	#datatable-wrapper-purchase_history tfoot {
 		position: sticky;
@@ -3321,47 +3479,72 @@ document.addEventListener('DOMContentLoaded', function() {
 		overflow: hidden;
 	}
 
-	/* Ensure the datatable search wrapper does NOT scroll — only tbody scrolls */
-	#datatable-wrapper-purchase_history .datatable-search-wrapper {
-		overflow: hidden;
-	}
-
 
 </style>
 
 <script>
+// Polls for the grid's own footer instead of guessing a fixed delay — resolves as
+// soon as the grid is actually rendered (fast page: near-instant; slow page: still
+// works, up to maxWaitMs before giving up and proceeding anyway).
+function waitForGridReady(callback, maxWaitMs) {
+    maxWaitMs = (typeof maxWaitMs === 'number') ? maxWaitMs : 4000;
+    var start = Date.now();
+    (function poll() {
+        if (document.querySelector('#datatable-purchase_history tfoot') || (Date.now() - start) >= maxWaitMs) {
+            callback();
+            return;
+        }
+        setTimeout(poll, 50);
+    })();
+}
+window.waitForGridReady = waitForGridReady;
+
 document.addEventListener('DOMContentLoaded', function() {
-    // Wait a moment for the grid to render
-    setTimeout(function() {
-        var tfoot = document.querySelector('#datatable-wrapper-purchase_history tfoot');
-        if (tfoot) {
-            // Create a new row
-            var row = document.createElement('tr');
-            var cell = document.createElement('td');
-            cell.colSpan = 100;
-            cell.style.padding = '0';
-            cell.style.margin = '0';
-            
-            // Insert the translated buttons (directly from PHP)
-            cell.innerHTML = '<?php echo $buttons_html_escaped; ?>';
-            
-            // Fix any styling on the buttons container
-            var buttonsDiv = cell.querySelector('.sticky-custom-buttons');
+    waitForGridReady(function() {
+        // Page-level nav buttons (Historik/Kontokort/Fakturaliste/Print) — appended as
+        // their own element at the bottom of the page, NOT inside the invoice overview
+        // grid's own footer, so they stay visible even when that section is collapsed.
+        var outer = document.querySelector('.outer-datatable-wrapper');
+        if (outer) {
+            var footerBar = document.createElement('div');
+            footerBar.id = 'debkort-page-footer';
+            footerBar.style.flexShrink = '0';
+            footerBar.innerHTML = '<?php echo $buttons_html_escaped; ?>';
+
+            var buttonsDiv = footerBar.querySelector('.sticky-custom-buttons');
             if (buttonsDiv) {
                 buttonsDiv.style.position = 'static';
                 buttonsDiv.style.margin = '0';
                 buttonsDiv.style.padding = '10px 0';
             }
-            
-            row.appendChild(cell);
-            tfoot.appendChild(row);
-            
-            // Add inline style to remove gaps
-            var style = document.createElement('style');
-            style.textContent = '#datatable-wrapper-purchase_history tfoot tr:last-child { border-spacing: 0 !important; margin: 0 !important; }';
-            document.head.appendChild(style);
+
+            outer.appendChild(footerBar);
         }
-    }, 500);
+
+        // Invoice overview: restore the user's last collapse choice (default collapsed
+        // if they've never toggled it). Only the column headers + data rows are hidden —
+        // the pagination footer stays visible (it lives in its own <form> and can't
+        // safely be detached from the grid).
+        var thead = document.querySelector('#datatable-purchase_history thead');
+        var tbody = document.querySelector('#datatable-purchase_history tbody');
+        var gridWrapper = document.querySelector('.purchase-history-wrapper');
+        var icon = document.getElementById('ph_toggle_icon');
+        var wasExpanded = localStorage.getItem('debitorkort_ph_expanded') === '1';
+        if (thead && tbody && gridWrapper) {
+            if (wasExpanded) {
+                gridWrapper.classList.remove('ph-collapsed');
+                gridWrapper.classList.add('ph-expanded');
+                thead.style.display = '';
+                tbody.style.display = '';
+                if (icon) icon.innerHTML = '&#9650;';
+            } else {
+                thead.style.display = 'none';
+                tbody.style.display = 'none';
+            }
+        }
+
+        sizePageLayout();
+    });
 });
 </script>
 
@@ -3569,123 +3752,60 @@ function printPurchaseHistory() {
     };
 }
 
-document.addEventListener('DOMContentLoaded', function() {
-    // Wait for grid to be fully rendered 
-    setTimeout(initResizableLayout, 800);
-});
+function phToggle() {
+    var gridWrapper = document.querySelector('.purchase-history-wrapper');
+    var thead       = document.querySelector('#datatable-purchase_history thead');
+    var tbody       = document.querySelector('#datatable-purchase_history tbody');
+    var icon        = document.getElementById('ph_toggle_icon');
+    if (!gridWrapper || !thead || !tbody) return;
 
-function initResizableLayout() {
-    const outer = document.querySelector('.outer-datatable-wrapper');
-    const formWrapper = document.querySelector('.form-wrapper');
-    const gridWrapper = document.querySelector('.purchase-history-wrapper');
-    const handle = document.getElementById('resize-handle');
-
-    if (!outer || !formWrapper || !gridWrapper || !handle) {
-        console.error('Required layout elements missing');
-        return;
-    }
-
-    // Get tfoot height (the footer of the grid)
-    const tfoot = document.querySelector('#datatable-purchase_history tfoot');
-    if (!tfoot) {
-        console.error('Table tfoot not found');
-        return;
-    }
-    const tfootHeight = tfoot.offsetHeight; 
-
-    //Set minimum height of grid wrapper to footer height
-    gridWrapper.style.minHeight = tfootHeight + 'px';
-
-   
-    const outerHeight = outer.clientHeight;
-    const handleHeight = handle.offsetHeight;
-    const availableHeight = outerHeight - handleHeight; 
-
-    // Determine initial height: prefer saved value, else default
-    let savedHeight = localStorage.getItem('debitorkort_form_height');
-    let maxFormHeight = availableHeight - tfootHeight;
-    if (maxFormHeight < 0) maxFormHeight = 0;
-    
-    let formWrapperHeight;
-    if (savedHeight !== null) {
-        formWrapperHeight = Math.min(maxFormHeight, Math.max(0, parseInt(savedHeight, 10)));
+    var expanding = gridWrapper.classList.contains('ph-collapsed');
+    if (expanding) {
+        gridWrapper.classList.remove('ph-collapsed');
+        gridWrapper.classList.add('ph-expanded');
+        thead.style.display = '';
+        tbody.style.display = '';
+        if (icon) icon.innerHTML = '&#9650;'; // up arrow = visible
     } else {
-        formWrapperHeight = maxFormHeight;
+        gridWrapper.classList.remove('ph-expanded');
+        gridWrapper.classList.add('ph-collapsed');
+        thead.style.display = 'none';
+        tbody.style.display = 'none';
+        if (icon) icon.innerHTML = '&#9660;'; // down arrow = hidden
     }
-    formWrapper.style.height = formWrapperHeight + 'px';
-
-    // Force grid wrapper to not be smaller than footer
-    if (gridWrapper.clientHeight < tfootHeight) {
-        gridWrapper.style.height = tfootHeight + 'px';
-    }
-
-    //Dragging logic
-    let isDragging = false;
-    let startY, startFormHeight; 
-
-    function startDrag(e) {
-        isDragging = true;
-        startY = e.clientY;
-        startFormHeight = formWrapper.clientHeight;
-        document.body.style.userSelect = 'none'; // prevent text selection
-    }
-
-    function onDrag(e) {
-        if (!isDragging) return;
-        const deltaY = e.clientY - startY;
-        let newHeight = startFormHeight + deltaY;
-
-        // Clamp: between 0 and (availableHeight - tfootHeight)
-        const maxFormHeight = availableHeight - tfootHeight;
-        newHeight = Math.min(maxFormHeight, Math.max(0, newHeight));
-
-        formWrapper.style.height = newHeight + 'px';
-        // Ensure grid wrapper never shrinks below footer height
-        if (gridWrapper.clientHeight < tfootHeight) {
-            gridWrapper.style.height = tfootHeight + 'px';
-        }
-    }
-
-    function stopDrag() {
-        if (isDragging) {
-            // Save the new height
-            localStorage.setItem('debitorkort_form_height', formWrapper.clientHeight);
-        }
-        isDragging = false;
-        document.body.style.userSelect = '';
-    }
-
-    handle.addEventListener('mousedown', startDrag);
-    document.addEventListener('mousemove', onDrag);
-    document.addEventListener('mouseup', stopDrag);
-
-    //  Recalculate on window resize
-    window.addEventListener('resize', function() {
-        formWrapper.style.height = '';
-        setTimeout(() => {
-            const newOuterHeight = outer.clientHeight;
-            const newHandleHeight = handle.offsetHeight;
-            const newAvailable = newOuterHeight - newHandleHeight;
-            // Re-fetch tfoot height in case it changed (e.g. buttons wrap)
-            const newTfoot = document.querySelector('#datatable-purchase_history tfoot');
-            const newTfootHeight = newTfoot ? newTfoot.offsetHeight : tfootHeight;
-            let newMaxFormHeight = newAvailable - newTfootHeight;
-            if (newMaxFormHeight < 0) newMaxFormHeight = 0;
-            
-            let saved = localStorage.getItem('debitorkort_form_height');
-            let newFormHeight;
-            if (saved !== null) {
-                newFormHeight = Math.min(newMaxFormHeight, Math.max(0, parseInt(saved, 10)));
-            } else {
-                newFormHeight = newMaxFormHeight;
-            }
-            formWrapper.style.height = newFormHeight + 'px';
-            if (gridWrapper.clientHeight < newTfootHeight) {
-                gridWrapper.style.height = newTfootHeight + 'px';
-            }
-        }, 50);
-    });
+    localStorage.setItem('debitorkort_ph_expanded', expanding ? '1' : '0');
+    sizePageLayout();
 }
+window.phToggle = phToggle;
+
+// Keeps the page fitting inside one viewport instead of scrolling as a whole: the
+// form area's height is measured in JS (robust) rather than left to CSS percentage
+// math (fragile), so it always shrinks to make room for whatever sits below it —
+// the invoice overview toggle bar, the grid itself when expanded, and the page footer.
+function sizePageLayout() {
+    var outer = document.querySelector('.outer-datatable-wrapper');
+    var formWrapper = document.querySelector('.form-wrapper');
+    if (!outer || !formWrapper) return;
+
+    var toggleBar   = document.getElementById('ph_toggle_bar');
+    var gridWrapper = document.querySelector('.purchase-history-wrapper');
+    var footerBar   = document.getElementById('debkort-page-footer');
+
+    var usedHeight = 0;
+    if (toggleBar) usedHeight += toggleBar.offsetHeight;
+    if (gridWrapper) usedHeight += gridWrapper.offsetHeight; // just the pagination bar while collapsed
+    if (footerBar) usedHeight += footerBar.offsetHeight;
+
+    var formHeight = outer.clientHeight - usedHeight;
+    if (formHeight < 0) formHeight = 0;
+    formWrapper.style.height = formHeight + 'px';
+}
+window.sizePageLayout = sizePageLayout;
+
+// Initial sizing already happens inside the waitForGridReady() callback above
+// (after the footer bar + collapse state are set up); this just keeps it in
+// sync on viewport changes.
+window.addEventListener('resize', sizePageLayout);
 
 // Map legacy fields to new DA fields
 document.addEventListener('DOMContentLoaded', function () {

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -4,8 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- finans/kassekladde.php --- ver 5.0.0 --- 2026-05-21 ---
-// verifying fork target points to DANOSOFT/saldi
+// --- finans/kassekladde.php --- ver 5.0.0 --- 2026-07-20 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -21,7 +20,7 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft ApS
 // ----------------------------------------------------------------------
 
 // 20240329 PHR - Alert when clicking clip, if not saved
@@ -59,6 +58,8 @@
 // 20260619 PHR - build_kassekladde_query: LEFT JOIN grupper VK brugte text=integer uden cast → rettet til kodenr::text=k.valuta::text
 // 20260619 PHR - Valuta nulstilledes til DKK på alle linjer ved valideringsfejl: valuta gemt som kode-string i tmpkassekl håndteres nu korrekt ved genvisning
 // 20260707 Sawaneh New line copies the date from the previous line; only falls back to today's date when there is no previous line.
+// 20260720 CX/PHR - Qualified the description grid search as k.beskrivelse to avoid an ambiguous column error after the currency join.
+// 20260720 CX/PHR - Scoped the posted cash journal grid ID by journal to prevent saved searches leaking between journals.
 
 ob_start(); //Starter output buffering
 
@@ -1536,7 +1537,8 @@ $columns = array(
 		'type' => 'text',
 		'width' => '3',
 		'sortable' => false,
-		'searchable' => true
+		'searchable' => true,
+		'sqlOverride' => 'k.beskrivelse'
 	),
 
 	// D/K Type for Debet
@@ -2300,14 +2302,15 @@ else
 ##########################
 // Create the datagrid
 if (($bogfort && $bogfort != '-') || $udskriv) {
-   	#echo "<center>";
+  	#echo "<center>";
     if (!$udskriv) {  // Close the form if it's open Searches don't work without this
         print "</form>";
     }
 	print "<div style='width: 100%; height: calc(98vh - 34px - 18px);'>";
+		$cashGridId = "kass_{$bruger_id}_{$kladde_id}";
 		// 20260306 Sawaneh - Changed $brugernavn to $bruger_id to fix bug when username is an email (e.g. hau@skjern-net.dk). Special chars like @ and . break JS function names, CSS selectors and HTML IDs.
 		// OLD: create_datagrid("kass_$brugernavn", $grid_data);
-		create_datagrid("kass_$bruger_id", $grid_data);
+		create_datagrid($cashGridId, $grid_data);
 	print "</div>";
 	########
 	// Add preserved parameters // heredoc works as long as it'd indent is the same indentation as the least indented line in the heredoc
@@ -2315,7 +2318,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		<script>
 		document.addEventListener('DOMContentLoaded', function() {
 			// OLD: const form = document.querySelector('#datatable-wrapper-kass_$brugernavn form');
-			const form = document.querySelector('#datatable-wrapper-kass_$bruger_id form');
+			const form = document.querySelector('#datatable-wrapper-$cashGridId form');
 			if (form) {
 				// Add kladde_id
 				const kladdeInput = document.createElement('input');

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -5024,3 +5024,8 @@
 5024	vare(r) udløber inden for	item(s) expiring within	vare(r) utløper innen
 5025	dage	days	dager
 5026	Klik for at se udløbsrapporten	Click to view the expiry report	Klikk for å se utløpsrapporten
+5027	Ekstra e-mails	Extra emails	Ekstra e-poster
+5028	Fakturaoversigt	Invoice overview	Fakturaoversikt
+5029	Vis/Skjul	Show/Hide	Vis/Skjul
+5030	Klik for at vise/skjule	Click to show/hide	Klikk for å vise/skjule
+5031	Fakturaer	Invoices	Fakturaer


### PR DESCRIPTION
## Summary
On the Debtor Card page (`debitor/debitorkort.php`), three sections could grow very tall and
push page-level action buttons (Historik/Kontokort/Fakturaliste/Print) off-screen or force
whole-page scrolling:

1. **Ekstra e-mails** — could list 25+ email rows, all shown unconditionally.
2. **Kategorier** — a checkbox list of ~40 categories, also always fully expanded.
3. **Invoice overview** (purchase-history grid at the bottom) — combined with the two
   sections above, pushed page-level nav buttons off-screen.

All three sections are now collapsible with internal scrolling, and a related set of
layout/timing bugs affecting the page were fixed along the way.

## What are the changes about?
### Ekstra e-mails / Kategorier
- Added click-to-toggle collapse/expand, matching the existing `daToggle()` house pattern
  already used for delivery addresses; collapsed by default.
- When expanded, content scrolls internally (`max-height:30vh; overflow-y:auto`) instead of
  pushing the page taller.
- Collapsed header shows a live, glanceable summary instead of just a count:
  - Emails: email-type breakdown
  - Categories: selected category names, e.g. "2 valgt: Entreprenoer, Vognmaend"
  - Both update via JS as the user edits rows/checkboxes.

### Invoice overview
- Iterated through a few approaches based on feedback — rejected a drag-to-resize handle,
  rejected fully hiding the section (it was hiding the page-level nav buttons too).
- Landed on a plain click-to-toggle title showing a row count (e.g. "Invoice overview
  (60 ▼)"), which only hides the grid's column headers/rows — the pagination footer and
  page-level buttons always stay visible, since pagination controls are tightly bound to
  their own `<form>` and can't be safely relocated.
- Fixed a CSS bug: a duplicate rule was setting `overflow:hidden` after an earlier
  `overflow:auto` on the same selector, silently killing the grid's internal scrolling.
- Fixed an architecture bug: page-level nav buttons had been JS-injected into the grid's own
  footer (so they disappeared when that section collapsed) — moved them to be an
  independent sibling element instead.

### Cross-cutting improvements
- Replaced a fixed `setTimeout` guess for "has the grid finished rendering" with
  `waitForGridReady()`, which polls every 50ms for the grid's footer to actually exist
  (capped at 4s) — more reliable than an arbitrary delay.
- Added `localStorage` persistence for all three sections' collapse/expand state, restored on
  page load, so the user's last choice sticks across reloads.
- Added `sizePageLayout()`, which measures actual rendered pixel heights via JS rather than
  relying on fragile CSS `calc()`/percentage chains through nested flex containers — fixed a
  regression where the page grew a whole-page scrollbar.

## Files Changed
- debitor/debitorkort.php

All changes are isolated to this single file, verified with `php -l` after each edit, with
file-history lines appended documenting each round of changes.

## How to Test

### Ekstra e-mails / Kategorier
1. Open a debtor card with 25+ extra emails and ~40 categories.
2. Verify both sections load collapsed by default.
3. Verify the collapsed header shows a live summary (email-type breakdown / selected
   category names) rather than just a count.
4. Expand each section and verify content scrolls internally (`max-height:30vh`) instead of
   growing the page.
5. Edit an email row or toggle a category checkbox and verify the collapsed-header summary
   updates live.
6. Collapse/expand, reload the page, and verify the collapse state persists via localStorage.

### Invoice overview
1. Open a debtor card with a large invoice history (e.g. 60+ rows).
2. Verify the section title shows a row count, e.g. "Invoice overview (60 ▼)".
3. Toggle it closed and verify only the column headers/rows hide — the pagination footer and
   page-level buttons (Historik/Kontokort/Fakturaliste/Print) remain visible.
4. Expand it and verify internal scrolling works (no whole-page scrollbar appears).
5. Verify page-level nav buttons remain functional and visible regardless of this section's
   collapse state.
6. Reload the page and verify the collapse state persists.

### Cross-cutting / regression
1. Load the page on a slow connection/throttled CPU and verify the grid reliably finishes
   rendering before layout sizing runs (no race condition, no leftover `setTimeout` guess).
2. Verify no whole-page scrollbar appears on a debtor with all three sections expanded.
3. Run `php -l debitor/debitorkort.php` and confirm no syntax errors.
4. Spot-check a debtor with few emails/categories/invoices to confirm collapsed sections
   still render sensibly (no broken empty-state summary).

## Acceptance Criteria

|
#
|
 Scenario 
|
 Expected Result 
|
|
---
|
---
|
---
|
|
 1 
|
 Debtor with 25+ emails 
|
 Ekstra e-mails collapsed by default, live summary shown, internal scroll when expanded 
|
|
 2 
|
 Debtor with ~40 categories 
|
 Kategorier collapsed by default, selected categories listed in header, internal scroll when expanded 
|
|
 3 
|
 Debtor with large invoice history 
|
 Invoice overview collapsed by default with row count in title 
|
|
 4 
|
 Invoice overview collapsed 
|
 Pagination footer and page-level nav buttons remain visible 
|
|
 5 
|
 Any section toggled 
|
 State persists across page reload via localStorage 
|
|
 6 
|
 Page load timing 
|
 Layout sizing runs only after grid footer actually exists (no fixed-delay race condition) 
|
|
 7 
|
 All sections expanded 
|
 No whole-page scrollbar regression 
|
|
 8 
|
 Syntax check 
|
`php -l`
 passes after each edit 
|

## Tested On
- local ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced chip-style expand/collapse controls for Extra e-mails, Categories, and the Invoice overview, with live count/type/category summaries.
  * Improved grid behavior so pagination/footer actions remain visible while the table is collapsed.
* **Bug Fixes**
  * Enhanced client-side syncing for email/category updates on changes and form submit.
  * Replaced timing assumptions with readiness-based initialization for more reliable grid rendering.
* **Improvements**
  * Updated page layout sizing for correct grid/table dimensions on load and window resize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->