### PR TITLE
SD-592 follow-up: ignore node_modules/, test-results/, playwright-report/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ email.php
 !tools/php/composer.phar
 .svn/
 tools/php/.phpunit.cache/
+node_modules/
+test-results/
+playwright-report/


### PR DESCRIPTION
Follow-up to #416 (merged before this landed): the SD-603 e2e toolchain (PR #420) brings npm + Playwright, whose local artifacts (node_modules/, test-results/, playwright-report/) were not yet covered by the new ignore rules. Pure .gitignore addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)