### PR TITLE
Fix/kreditor autocomplete supplier price

### DIFF
--- a/debitor/itemSearch.php
+++ b/debitor/itemSearch.php
@@ -20,6 +20,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
 $konto_id = isset($_GET['konto_id']) ? intval($_GET['konto_id']) : 0;
+$kreditor_order = isset($_GET['kreditor_order']) ? intval($_GET['kreditor_order']) : 0;
 $search_field = isset($_GET['search_field']) ? $_GET['search_field'] : 'varenr';
 $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
 $limit = 50;
@@ -90,9 +91,18 @@ if ($search !== '') {
     }
 }
 
+// 20260728 MJ Fix: kreditor autocomplete returnerede varer.kostpris i stedet for leverandoerspecifik vl.kostpris
 $leverandorJoin = '';
+$levKostprisSelect = 'varer.kostpris';
+$levDetailsSelect = '';
 if ($konto_id > 0) {
-    $leverandorJoin = "INNER JOIN vare_lev vl ON vl.vare_id = varer.id AND vl.lev_id = $konto_id";
+    if ($kreditor_order) {
+        $leverandorJoin = "INNER JOIN vare_lev vl ON vl.vare_id = varer.id AND vl.lev_id = $konto_id LEFT JOIN adresser a ON a.id = vl.lev_id";
+        $levKostprisSelect = "COALESCE(vl.kostpris, varer.kostpris)";
+        $levDetailsSelect = ", COALESCE(vl.lev_id, 0) as lev_id, COALESCE(a.kontonr, '') as lev_kontonr, COALESCE(a.firmanavn, '') as lev_firmanavn";
+    } else {
+        $leverandorJoin = "INNER JOIN vare_lev vl ON vl.vare_id = varer.id AND vl.lev_id = $konto_id";
+    }
 } elseif ($search_field === 'lev_varenr') {
     $leverandorJoin = "INNER JOIN vare_lev vl ON vl.vare_id = varer.id";
 }
@@ -107,7 +117,7 @@ if ($countQuery) {
 
 // Include gruppe (product group) in query for VAT-free check
 $levVarenrSelect = $leverandorJoin ? ", COALESCE(vl.lev_varenr, '') as lev_varenr" : ", '' as lev_varenr";
-$qtxt = "SELECT varer.id, varer.varenr, varer.beskrivelse, COALESCE(vv.variant_salgspris, varer.salgspris) AS salgspris, varer.kostpris, varer.enhed, varer.beholdning, varer.gruppe, vv.variant_stregkode AS vv_stregkode, vv.variant_text AS vv_variant_text $levVarenrSelect
+$qtxt = "SELECT varer.id, varer.varenr, varer.beskrivelse, COALESCE(vv.variant_salgspris, varer.salgspris) AS salgspris, $levKostprisSelect AS kostpris, varer.enhed, varer.beholdning, varer.gruppe, vv.variant_stregkode AS vv_stregkode, vv.variant_text AS vv_variant_text $levVarenrSelect $levDetailsSelect
          FROM varer $variantJoin $leverandorJoin
          WHERE $baseWhere
          ORDER BY varer.varenr ASC LIMIT $limit OFFSET $offset";
@@ -137,6 +147,9 @@ if ($query) {
             'beholdning' => floatval($row['beholdning']),
             'vv_stregkode' => $row['vv_stregkode'] ? trim($row['vv_stregkode']) : null,
             'vv_variant_text' => $row['vv_variant_text'] ? trim($row['vv_variant_text']) : null,
+            'lev_id' => isset($row['lev_id']) ? intval($row['lev_id']) : 0,
+            'lev_kontonr' => isset($row['lev_kontonr']) ? trim($row['lev_kontonr']) : '',
+            'lev_firmanavn' => isset($row['lev_firmanavn']) ? trim($row['lev_firmanavn']) : '',
         );
     }
 }

--- a/debitor/itemSearch.php
+++ b/debitor/itemSearch.php
@@ -97,7 +97,8 @@ $levKostprisSelect = 'varer.kostpris';
 $levDetailsSelect = '';
 if ($konto_id > 0) {
     if ($kreditor_order) {
-        $leverandorJoin = "INNER JOIN vare_lev vl ON vl.vare_id = varer.id AND vl.lev_id = $konto_id LEFT JOIN adresser a ON a.id = vl.lev_id";
+        $vareLevJoinType = ($search_field === 'lev_varenr') ? 'INNER JOIN' : 'LEFT JOIN';  
+        $leverandorJoin = $vareLevJoinType . " vare_lev vl ON vl.vare_id = varer.id AND vl.lev_id = $konto_id LEFT JOIN adresser a ON a.id = vl.lev_id";
         $levKostprisSelect = "COALESCE(vl.kostpris, varer.kostpris)";
         $levDetailsSelect = ", COALESCE(vl.lev_id, 0) as lev_id, COALESCE(a.kontonr, '') as lev_kontonr, COALESCE(a.firmanavn, '') as lev_firmanavn";
     } else {

--- a/javascript/kreditorOrdreAutocomplete.js
+++ b/javascript/kreditorOrdreAutocomplete.js
@@ -159,12 +159,18 @@
         const kassePath = '../finans/kassekladde_includes/';
 
         switch (type) {
-            case 'item':
+            case 'item': {
+                const kontoId = (document.querySelector('input[name="konto_id"]') || {}).value || '0';
                 url = basePath + 'itemSearch.php?search=' + encodeURIComponent(value);
+                if (kontoId && kontoId !== '0') url += '&kreditor_order=1&konto_id=' + encodeURIComponent(kontoId);
                 break;
-            case 'lev_item':
+            }
+            case 'lev_item': {
+                const kontoId = (document.querySelector('input[name="konto_id"]') || {}).value || '0';
                 url = basePath + 'itemSearch.php?search=' + encodeURIComponent(value) + '&search_field=lev_varenr';
+                if (kontoId && kontoId !== '0') url += '&kreditor_order=1&konto_id=' + encodeURIComponent(kontoId);
                 break;
+            }
             case 'customer':
                 url = kassePath + 'accountSearch.php?type=kreditor&search=' + encodeURIComponent(value);
                 break;
@@ -212,6 +218,8 @@
             <div class="ordre-autocomplete-results">
         `;
 
+        const hasSupplier = type === 'item' && results && results.some(r => r.lev_id > 0);
+
         if (!results || results.length === 0) {
             html += '<div class="ordre-autocomplete-no-results">Ingen resultater fundet</div>';
         } else {
@@ -220,6 +228,7 @@
             if (type === 'item') {
                 html += '<th style="width: 100px;">Varenr.</th>';
                 html += '<th>Beskrivelse</th>';
+                if (hasSupplier) html += '<th style="width: 140px;">Leverandør</th>';
                 html += '<th style="width: 80px; text-align: right;">Kostpris</th>';
             } else if (type === 'lev_item') {
                 html += '<th style="width: 100px;">Lev. varenr</th>';
@@ -244,6 +253,10 @@
                 if (type === 'item') {
                     html += `<td class="code-cell">${escapeHtml(item.varenr)}</td>`;
                     html += `<td>${escapeHtml(item.beskrivelse)}</td>`;
+                    if (hasSupplier) {
+                        const levLabel = item.lev_id > 0 ? escapeHtml((item.lev_kontonr ? item.lev_kontonr + ':' : '') + item.lev_firmanavn) : '';
+                        html += `<td class="code-cell">${levLabel}</td>`;
+                    }
                     html += `<td style="text-align: right;">${item.kostpris.toFixed(2)}</td>`;
                 } else if (type === 'lev_item') {
                     html += `<td class="code-cell">${escapeHtml(item.lev_varenr)}</td>`;

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -58,10 +58,11 @@
 // 20260217 PHR kundeordrnr
 // 20260219 PHR if ($leveres[$x] < $antal[$x] + $tidl_lev[$x]) changed to if ($leveres[$x] && $leveres[$x] < $antal[$x] + $tidl_lev[$x])
 // 20260223 LOE Fixed SD-350-creditor-order-lookup-does-not-work-on-new-supplier-order
-// 20260728 MJ Fix: kreditorOrdreAutocomplete sendte ikke konto_id til itemSearch; viste varer.kostpris i stedet for leverandoerspecifik vl.kostpris
 // 20260225 PHR Order taken by ---
 // 20260421 LOE Set antal to 1 if empty
 // 20260506 sawaneh Added create_creditor POST handler and redirect to kontoopslag when typed kontonr/firmanavn has no match
+// 20260728 MJ Fix: kreditorOrdreAutocomplete sendte ikke konto_id til itemSearch; viste varer.kostpris i stedet for leverandoerspecifik vl.kostpris
+
 @session_start();
 $s_id=session_id();
 

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- kreditor/ordre.php --- patch 5.0.0 --- 2026-05-06---
+// --- kreditor/ordre.php --- patch 5.0.0 --- 2026-07-28---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -58,6 +58,7 @@
 // 20260217 PHR kundeordrnr
 // 20260219 PHR if ($leveres[$x] < $antal[$x] + $tidl_lev[$x]) changed to if ($leveres[$x] && $leveres[$x] < $antal[$x] + $tidl_lev[$x])
 // 20260223 LOE Fixed SD-350-creditor-order-lookup-does-not-work-on-new-supplier-order
+// 20260728 MJ Fix: kreditorOrdreAutocomplete sendte ikke konto_id til itemSearch; viste varer.kostpris i stedet for leverandoerspecifik vl.kostpris
 // 20260225 PHR Order taken by ---
 // 20260421 LOE Set antal to 1 if empty
 // 20260506 sawaneh Added create_creditor POST handler and redirect to kontoopslag when typed kontonr/firmanavn has no match
@@ -1802,7 +1803,7 @@ if ($menu=='T') {
 
 <?php if (get_settings_value("ordreAutocomplete", "ordre", "on", $bruger_id) === "on") { ?>
 <link rel="stylesheet" type="text/css" href="../css/ordreAutocomplete.css">
-<script src="../javascript/kreditorOrdreAutocomplete.js"></script>
+<script src="../javascript/kreditorOrdreAutocomplete.js?v=<?= filemtime(__DIR__ . '/../javascript/kreditorOrdreAutocomplete.js') ?>"></script>
 <?php } ?>
 
 <style>

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -1803,7 +1803,7 @@ if ($menu=='T') {
 
 <?php if (get_settings_value("ordreAutocomplete", "ordre", "on", $bruger_id) === "on") { ?>
 <link rel="stylesheet" type="text/css" href="../css/ordreAutocomplete.css">
-<script src="../javascript/kreditorOrdreAutocomplete.js?v=<?= filemtime(__DIR__ . '/../javascript/kreditorOrdreAutocomplete.js') ?>"></script>
+<script src="../javascript/kreditorOrdreAutocomplete.js"></script>
 <?php } ?>
 
 <style>


### PR DESCRIPTION
## What are the changes about?
When adding item 112140 to a Sound Wize order, the price was taken from varer.kostpris (Diatec's last-invoice price) instead of Sound Wize's vare_lev.kostpris. 

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supplier-specific item searches now include supplier details, including account number and company name when available.
  * Search results can display a dedicated supplier column for clearer identification.
* **Bug Fixes**
  * Creditor order searches now use the correct supplier-specific cost price when available.
  * Items without supplier-specific pricing continue to display the standard product cost.
* **Documentation**
  * Updated the creditor order changelog with details of the search and pricing fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->