### PR TITLE
Flyt Momsperioder-link fra Finans-sidebar til regnskabsaar.php

### DIFF
--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -3363,7 +3363,7 @@
 3363	Momsrubrikker	VAT categories	Momsrubrikker
 3364	Momsafstemning	VAT reconciliation	MVA-avstemming
 3365	OSS B2C EU-salg	B2C EU Sales	OSS B2C EU-salg
-3366	Momsperioder    Vat periods    MVA-perioder		
+3366	Momsperioder	Vat periods	MVA-perioder		
 3367			
 3368			
 3369			

--- a/index/main.php
+++ b/index/main.php
@@ -29,6 +29,7 @@
 //                  This possibly has changes across everything, but I have tested it, and it has also fixed rendering prematurely.
 // 20260716 MJ      Tilfoejede Momsperioder-link i Finans-sidebar.
 // 20260730 NTR - Added translation to momsperioder.
+// 20260730 MJ Fjernede Momsperioder-link fra Finans-sidebaren; linket er nu en knap i regnskabsaar.php
 @session_start();
 $s_id = session_id();
 
@@ -201,9 +202,6 @@ function brightenColor($color, $amount = 0.2) {
         }
         if (check_permissions(array(4))) {
           echo '<li><a href="#" id="rapport" onclick=\'update_iframe("/finans/rapport.php")\'>' . findtekst('603|Rapporter', $sprog_id) . '</a></li>';
-        }
-        if (check_permissions(array(2, 3, 4))) {
-          echo '<li><a href="#" id="moms_periode" onclick=\'update_iframe("/finans/moms_periode.php")\'>'.findtekst('3366|Momsperioder', $sprog_id).'</a></li>';
         }
         ?>
       </ul>

--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -122,6 +122,7 @@ if ($menu == 'T') {  # 20150327 start
 	print "<table border=\"1\" cellspacing=\"0\" id=\"dataTable\" class=\"dataTable2\">";
 } else {
 	include("top.php");
+	print "<link rel=\"stylesheet\" type=\"text/css\" href=\"../css/top_menu.css\">";
 	print "<table cellpadding=\"1\" cellspacing=\"1\" border=\"0\" align=\"center\">";
 }  # 20150327 stop
 
@@ -175,23 +176,23 @@ function renderEmptyFiscalYearButton($canDelete, $isEmpty, $kodenr, $sprog_id, $
 	$deleteConfirm = ($sprog_id == 2) ? "Are you sure you want to delete this empty fiscal year?" : "Er du sikker på at du vil slette dette tomme regnskabsår?";
 
 	if ($canDelete) {
-			$deleteTitle = ($sprog_id == 2) ? "Delete empty fiscal year" : "Slet tomt regnskabsår";
-			$deleteConfirm = ($sprog_id == 2) ? "Are you sure you want to delete this empty fiscal year?" : "Er du sikker på at du vil slette dette tomme regnskabsår?";
-			$emptyText = ($sprog_id == 2) ? "(empty)" : "(tom)";
+		$deleteTitle = ($sprog_id == 2) ? "Delete empty fiscal year" : "Slet tomt regnskabsår";
+		$deleteConfirm = ($sprog_id == 2) ? "Are you sure you want to delete this empty fiscal year?" : "Er du sikker på at du vil slette dette tomme regnskabsår?";
+		$emptyText = ($sprog_id == 2) ? "(empty)" : "(tom)";
 
-			return "<td style='border:none; display:flex; justify-content:center; align-items:center;'>
-			 			<span style='color:#999; font-size:10px; margin-right:5px;'> $emptyText </span> 
-						<a href='regnskabsaar.php?deleteEmptyYear=$kodenr' title='$deleteTitle' onclick=\"return confirm('$deleteConfirm')\" style='font-weight:bold; text-decoration:none; cursor: pointer;'> 
-							 $trash_icon
-						</a> 
-				   </td>";
-		} elseif($isEmpty){
-            return "<td style='text-align:center;'>
-						<span style='color:#999; font-size:10px;'>$emptyText</span>
-				    </td>";
-		} else {
-			return "<td></td>";
-		}
+		return "<td style='border:none; display:flex; justify-content:center; align-items:center;'>
+					<span style='color:#999; font-size:10px; margin-right:5px;'> $emptyText </span> 
+					<a href='regnskabsaar.php?deleteEmptyYear=$kodenr' title='$deleteTitle' onclick=\"return confirm('$deleteConfirm')\" style='font-weight:bold; text-decoration:none; cursor: pointer;'> 
+							$trash_icon
+					</a> 
+				</td>";
+	} elseif($isEmpty){
+		return "<td style='text-align:center;'>
+					<span style='color:#999; font-size:10px;'>$emptyText</span>
+				</td>";
+	} else {
+		return "<td></td>";
+	}
 }
 
 // Find newest empty fiscal year
@@ -275,9 +276,9 @@ foreach($fiscalYears as $index => $row){
 			print "<a href='regnskabsaar.php?deleteYear=$row[kodenr]' title='$txt1' onclick=\"return confirm('$txt2')\">";
 			print "<td style='border:none; display:flex; justify-content:center; align-items:center;'>
 						<a href='regnskabsaar.php?deleteEmptyYear=$row[kodenr]' title='$txt1' onclick=\"return confirm('$txt2')\" style='font-weight:bold; text-decoration:none; cursor: pointer;'> 
-							 $trash_icon
+							$trash_icon
 						</a> 
-			   </td></a>";
+			</td></a>";
 		}
 		print "</td>";
 		print renderEmptyFiscalYearButton($canDeleteThisyear, $isEmpty[$x], $row['kodenr'], $sprog_id, $trash_icon);
@@ -295,10 +296,13 @@ foreach($fiscalYears as $index => $row){
 }
 ($bgcolor1 != $bgcolor) ? $bgcolor1 = $bgcolor : $bgcolor1 = $bgcolor5;
 print "<td  bgcolor='$bgcolor1' colspan='9'><br></td>";
-print "<tr><td colspan=\"9\" style=\"text-align:center\"><a href=\"regnskabskort.php\"  title=\"" . findtekst('507|Klik her for at oprette nyt regnskabsår.', $sprog_id) . "\"><button class='button green medium'>" . findtekst('508|Opret nyt regnskabsår', $sprog_id) . "</button></a></td></tr>";
-print "<tr><td colspan=\"9\" style=\"text-align:center\"><a href=\"../finans/moms_periode.php\"><button class='button medium'>" . findtekst('3366|Momsperioder', $sprog_id) . "</button></a></td></tr>";
-if ($x < 1)
+print "<tr><td colspan=\"9\" style=\"text-align:center\"><a class='button green medium' href=\"regnskabskort.php\" title=\"" . findtekst('507|Klik her for at oprette nyt regnskabsår.', $sprog_id) . "\">" . findtekst('508|Opret nyt regnskabsår', $sprog_id) . "</a></td></tr>";
+
+print "<tr><td colspan=\"9\" style=\"text-align:center\"><a class='button gray medium' href=\"../finans/moms_periode.php\">" . findtekst('3366|Momsperioder', $sprog_id) . "</a></td></tr>";
+
+if ($x < 1) {
 	print "<meta http-equiv=refresh content=0;url=regnskabskort.php>";
+}
 ?>
 </tbody>
 </table>

--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -50,6 +50,15 @@ include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
 
+function check_permissions($permarr)
+{
+  global $rettigheder;
+  $filtered = array_filter($permarr, function ($item) use ($rettigheder) {
+    return (substr($rettigheder, $item, 1) == "1");
+  });
+  return !empty($filtered);
+}
+
 $aktiver = if_isset($_GET['aktiver']);
 $deleteYear = if_isset($_GET['deleteYear']);
 $deleteEmptyYear = if_isset($_GET['deleteEmptyYear']);
@@ -298,7 +307,9 @@ foreach($fiscalYears as $index => $row){
 print "<td  bgcolor='$bgcolor1' colspan='9'><br></td>";
 print "<tr><td colspan=\"9\" style=\"text-align:center\"><a class='button green medium' href=\"regnskabskort.php\" title=\"" . findtekst('507|Klik her for at oprette nyt regnskabsår.', $sprog_id) . "\">" . findtekst('508|Opret nyt regnskabsår', $sprog_id) . "</a></td></tr>";
 
-print "<tr><td colspan=\"9\" style=\"text-align:center\"><a class='button gray medium' href=\"../finans/moms_periode.php\">" . findtekst('3366|Momsperioder', $sprog_id) . "</a></td></tr>";
+if (check_permissions(array(2, 3, 4))) {
+	print "<tr><td colspan=\"9\" style=\"text-align:center\"><a class='button gray medium' href=\"../finans/moms_periode.php\">" . findtekst('3366|Momsperioder', $sprog_id) . "</a></td></tr>";
+}
 
 if ($x < 1) {
 	print "<meta http-equiv=refresh content=0;url=regnskabskort.php>";

--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -5,7 +5,7 @@
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
 //
-// --- systemdata/regnskabsaar.php --- ver 5.0.0 --- 2026-01-30 --
+// --- systemdata/regnskabsaar.php --- ver 5.0.0 --- 2026-07-30 --
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -35,6 +35,7 @@
 // 20250503 LOE reordered mix-up text_id from tekster.csv in findtekst()
 // 20250903 PHR	Changed 5 year calculation to include months.
 // 20260130 PHR - Improved check for empty fiscal year before deletion and used ICONSVG icons.
+// 20260730 MJ Tilfoejede Momsperioder-knap; fjernede linket fra finans-sidebaren i main.php
 
 @session_start();
 $s_id = session_id();
@@ -295,6 +296,7 @@ foreach($fiscalYears as $index => $row){
 ($bgcolor1 != $bgcolor) ? $bgcolor1 = $bgcolor : $bgcolor1 = $bgcolor5;
 print "<td  bgcolor='$bgcolor1' colspan='9'><br></td>";
 print "<tr><td colspan=\"9\" style=\"text-align:center\"><a href=\"regnskabskort.php\"  title=\"" . findtekst('507|Klik her for at oprette nyt regnskabsår.', $sprog_id) . "\"><button class='button green medium'>" . findtekst('508|Opret nyt regnskabsår', $sprog_id) . "</button></a></td></tr>";
+print "<tr><td colspan=\"9\" style=\"text-align:center\"><a href=\"../finans/moms_periode.php\"><button class='button medium'>" . findtekst('3366|Momsperioder', $sprog_id) . "</button></a></td></tr>";
 if ($x < 1)
 	print "<meta http-equiv=refresh content=0;url=regnskabskort.php>";
 ?>

--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -282,12 +282,9 @@ foreach($fiscalYears as $index => $row){
 			$txt1.= "varer er oprettet i regnskabsåret og ikke har været handlet siden ";
 			$txt1.= "samt kunder og leverandører som er urørte i efterfølgende år";
 			$txt2 = "Vil du slette dette regnskabsår ?";
-			print "<a href='regnskabsaar.php?deleteYear=$row[kodenr]' title='$txt1' onclick=\"return confirm('$txt2')\">";
-			print "<td style='border:none; display:flex; justify-content:center; align-items:center;'>
-						<a href='regnskabsaar.php?deleteEmptyYear=$row[kodenr]' title='$txt1' onclick=\"return confirm('$txt2')\" style='font-weight:bold; text-decoration:none; cursor: pointer;'> 
-							$trash_icon
-						</a> 
-			</td></a>";
+			print "<a href='regnskabsaar.php?deleteYear=$row[kodenr]' title='$txt1' onclick=\"return confirm('$txt2')\" style='font-weight:bold; text-decoration:none; cursor: pointer;'>
+						$trash_icon
+					</a>";
 		}
 		print "</td>";
 		print renderEmptyFiscalYearButton($canDeleteThisyear, $isEmpty[$x], $row['kodenr'], $sprog_id, $trash_icon);


### PR DESCRIPTION
## What are the changes about?
Tilfoejede en Momsperioder-knap under Opret nyt regnskabsaar i systemdata/regnskabsaar.php og fjernede det tilsvarende link fra Finans-sidebaren i index/main.php.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Momsperioder" button to the accounting year page for easier access.

* **Changes**
  * Removed the "Momsperioder" link from the Finance sidebar navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->