### PR TITLE
Fix SST-715: urlencode returside i udskriv-redirect fra formfunk.php

### DIFF
--- a/includes/formfunk.php
+++ b/includes/formfunk.php
@@ -2260,7 +2260,8 @@ if (!function_exists('formularprint')) {
 		} elseif ($nomailantal > 0) {
 			print "<big><b>Vent - Udskrift genereres</b></big><br>";
 			$mappe = str_replace('../temp/', '', $mappe);
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=$returside\">";
+			// 20260807 MJ urlencode returside saa search-parametre ikke laekaer som separate GET-parametre i udskriv.php
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=" . urlencode($returside) . "\">";
 		} elseif ($popup)
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
 		#else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";

--- a/includes/formfunk.php
+++ b/includes/formfunk.php
@@ -2261,7 +2261,8 @@ if (!function_exists('formularprint')) {
 			print "<big><b>Vent - Udskrift genereres</b></big><br>";
 			$mappe = str_replace('../temp/', '', $mappe);
 			// 20260807 MJ urlencode returside saa search-parametre ikke laekaer som separate GET-parametre i udskriv.php
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=" . urlencode($returside) . "\">";
+			// 20260812 MJ Cast til string foer urlencode saa PHP 8.1 ikke rejser null-deprecation naar returside er usat
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=" . urlencode((string)($returside ?? '')) . "\">";
 		} elseif ($popup)
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
 		#else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";

--- a/includes/formfunk.php
+++ b/includes/formfunk.php
@@ -2261,8 +2261,8 @@ if (!function_exists('formularprint')) {
 			print "<big><b>Vent - Udskrift genereres</b></big><br>";
 			$mappe = str_replace('../temp/', '', $mappe);
 			// 20260807 MJ urlencode returside saa search-parametre ikke laekaer som separate GET-parametre i udskriv.php
-			// 20260812 MJ Cast til string foer urlencode saa PHP 8.1 ikke rejser null-deprecation naar returside er usat
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=" . urlencode((string)($returside ?? '')) . "\">";
+			// 20260812 MJ Brug is_string-guard saa array-input ikke giver PHP-advarsel (null/array -> tom streng)
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/udskriv.php?locat=$locat&ps_fil=$mappe/$printfilnavn&amp;id=$id&amp;udskriv_til=$udskriv_til&amp;art=$art&amp;bgr=" . urlencode($background_pdf_path) . "&returside=" . urlencode(is_string($returside ?? null) ? $returside : '') . "\">";
 		} elseif ($popup)
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
 		#else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";

--- a/includes/udskriv.php
+++ b/includes/udskriv.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- includes/udskriv.php --- lap 5.0.0 --- 2026.05.12 ---
+// --- includes/udskriv.php --- lap 5.0.0 --- 2026-08-12 ---
 // LICENS
 //
 // This program is free software. You can redistribute it and / or
@@ -41,6 +41,7 @@
 // 20260320 PHR cleanup (pdftk)
 // 20260428 LOE added more options for 'DO' type and updated faktura navigation for pick list.
 // 20260512 LOE Updated the code to allow printing multiple files no matter the state of 'Use HTML / CSS for form generation-SD-490'
+// 20260812 MJ Valider returside til relative stier; undgaar open-redirect og XSS via JS/href-kontekst
 
 @session_start();
 $s_id=session_id();
@@ -70,6 +71,15 @@ $art           = if_isset($_GET, NULL, 'art');
 $ordreliste    = if_isset($_GET, NULL, 'ordreliste');
 $ordre_antal   = if_isset($_GET, NULL, 'ordre_antal');
 $returside    = if_isset($_GET, NULL, 'returside');
+// 20260812 MJ Begraens til relative stier — afviser protokoller (javascript:, http://) og absolutte URL'er
+$returside = (function($s) {
+    $s = trim((string)$s);
+    if ($s === '' || $s === 'ordreliste.php') return $s; // 'ordreliste.php' normaliseres nedenfor linje 93
+    if (preg_match('/[a-zA-Z][a-zA-Z0-9+\-.]*:/', $s)) return ''; // afvis protokol-URL'er
+    if (substr($s, 0, 2) === '//') return '';                      // afvis protokol-relative URL'er
+    if (substr($s, 0, 3) !== '../') return '';                     // kraev relativ sti
+    return $s;
+})($returside);
 $locat      = if_isset($_GET, NULL, 'locat');
 
 if ($udskriv_til == 'PDF') { // refer ../includes/udskriv.php
@@ -83,7 +93,7 @@ if ($udskriv_til == 'PDF') { // refer ../includes/udskriv.php
         echo "<script>
                 alert('ERROR: pdftk is not installed. Please install pdftk first.');
                 setTimeout(function() {
-                    window.location.href = '$returside';
+                    window.location.href = <?= json_encode($returside) ?>;
                 }, 1000); // 1 second delay
               </script>";
         exit();
@@ -395,7 +405,7 @@ if (file_exists("../temp/$ps_fil.pdf")) {
 				$r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__));
 				$firmanavn=htmlentities($r['firmanavn']);
 				$fakturanr=htmlentities($r['fakturanr']);
-				print "<meta http-equiv=\"refresh\" content=\"0;URL=http://$ip/localprint.php?printfil=$printfil.pdf&url=$url&id=$id&returside=$returside&bruger_id=$bruger_id&firmanavn=$firmanavn&fakturanr=$fakturanr\">\n";
+				print "<meta http-equiv=\"refresh\" content=\"0;URL=http://$ip/localprint.php?printfil=$printfil.pdf&url=$url&id=$id&returside=" . urlencode($returside) . "&bruger_id=$bruger_id&firmanavn=$firmanavn&fakturanr=$fakturanr\">\n";
 				exit;
 			} elseif ($valg=='ip') {
 				print "<!--!";
@@ -420,20 +430,20 @@ if (file_exists("../temp/$ps_fil.pdf")) {
 			if ($menu == 'S') {
 				print "<table width=100% height=100%><tbody>"; 
 				if ($returside) {
-				 if (substr($art,0,1)=='K'){  
-					$href="\"../kreditor/ordre.php?tjek=$id&id=$id&returside=$returside\" accesskey=\"L\"";
+				 if (substr($art,0,1)=='K'){
+					$href="\"../kreditor/ordre.php?tjek=$id&id=$id&returside=" . urlencode($returside) . "\" accesskey=\"L\"";
 				 }elseif ($art == ('DO' || 'PO') && (strpos($returside, "ordreliste.php") !== false) && $locat) {
 					$href = "../debitor/ordreliste.php";
 				 } else {
 					if($art == 'DO'){
 						if($value == 'faktura'){
-							$href = "../debitor/ordre.php?tjek=$id&id=$id&valg=faktura&returside=$returside";
+							$href = "../debitor/ordre.php?tjek=$id&id=$id&valg=faktura&returside=" . urlencode($returside);
 
 						}else{
 							$href = "../debitor/ordreliste.php";
 						}
 					}else{
-					  $href = "../debitor/ordre.php?tjek=$id&id=$id&returside=$returside";
+					  $href = "../debitor/ordre.php?tjek=$id&id=$id&returside=" . urlencode($returside);
 					}
 				 }  
 				} else { 
@@ -452,7 +462,7 @@ if (file_exists("../temp/$ps_fil.pdf")) {
 
 			} else {
 				print "<table width=100% height=100%><tbody>";
-				if ($returside) $href="\"$returside\" accesskey=\"L\"";
+				if ($returside) $href="\"" . htmlspecialchars($returside, ENT_QUOTES, 'UTF-8') . "\" accesskey=\"L\"";
 				else $href="\"udskriv.php?valg=tilbage&id=$id&art=$art\" accesskey=\"L\"";
 				print "<td width=\"10%\" height=\"1%\" $top_bund><a href=$href>$ordre_antal ".findtekst('2172|Luk', $sprog_id)."</a></td>";
 				print "<td width=\"80%\" $top_bund align=\"center\" title=\"".findtekst('2179|Klik her for at åbne filen i nyt vindue, højreklik her for at gemme', $sprog_id).">";

--- a/includes/udskriv.php
+++ b/includes/udskriv.php
@@ -71,14 +71,18 @@ $art           = if_isset($_GET, NULL, 'art');
 $ordreliste    = if_isset($_GET, NULL, 'ordreliste');
 $ordre_antal   = if_isset($_GET, NULL, 'ordre_antal');
 $returside    = if_isset($_GET, NULL, 'returside');
-// 20260812 MJ Begraens til relative stier — afviser protokoller (javascript:, http://) og absolutte URL'er
+// 20260812 MJ Begraens til same-origin stier — afviser protokoller (javascript:, http://) og cross-origin URL'er
 $returside = (function($s) {
     $s = trim((string)$s);
     if ($s === '' || $s === 'ordreliste.php') return $s; // 'ordreliste.php' normaliseres nedenfor linje 93
-    if (preg_match('/[a-zA-Z][a-zA-Z0-9+\-.]*:/', $s)) return ''; // afvis protokol-URL'er
-    if (substr($s, 0, 2) === '//') return '';                      // afvis protokol-relative URL'er
-    if (substr($s, 0, 3) !== '../') return '';                     // kraev relativ sti
-    return $s;
+    if (!mb_check_encoding($s, 'UTF-8')) return '';       // afvis ugyldig UTF-8 (json_encode returnerer false)
+    if (preg_match('/[a-zA-Z][a-zA-Z0-9+\-.]*:/', $s)) return ''; // afvis protokol-URL'er (javascript:, http://)
+    if (substr($s, 0, 2) === '//') return '';             // afvis protokol-relative URL'er (//evil.com)
+    // Godkend relative stier (../x) og rod-relative stier (/x) — begge er same-origin
+    // nav_back_url() gemmer $_SERVER['REQUEST_URI'] som /debitor/... saa rod-relative skal accepteres
+    if (substr($s, 0, 3) === '../') return $s;
+    if (substr($s, 0, 1) === '/') return $s;
+    return '';
 })($returside);
 $locat      = if_isset($_GET, NULL, 'locat');
 
@@ -462,7 +466,7 @@ if (file_exists("../temp/$ps_fil.pdf")) {
 
 			} else {
 				print "<table width=100% height=100%><tbody>";
-				if ($returside) $href="\"" . htmlspecialchars($returside, ENT_QUOTES, 'UTF-8') . "\" accesskey=\"L\"";
+				if ($returside) $href="\"" . htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\" accesskey=\"L\"";
 				else $href="\"udskriv.php?valg=tilbage&id=$id&art=$art\" accesskey=\"L\"";
 				print "<td width=\"10%\" height=\"1%\" $top_bund><a href=$href>$ordre_antal ".findtekst('2172|Luk', $sprog_id)."</a></td>";
 				print "<td width=\"80%\" $top_bund align=\"center\" title=\"".findtekst('2179|Klik her for at åbne filen i nyt vindue, højreklik her for at gemme', $sprog_id).">";


### PR DESCRIPTION
## What are the changes about?
returside blev indsat raa i redirect-URL til udskriv.php. Naar brugeren soeger paa kundenavn i ordrelisten indeholder returside-URL search- parametre som f.eks. &valg=faktura, der laekker ud som selvstaendige GET-parametre i udskriv.php. Dette medforer at $valg saettes til 'faktura' i stedet for 'pdf', PDF-fremviseren springes over, og brugeren ender paa en forkert 'Udskriftsvalg'-side.

Urlencode() paa $returside sikrer at & og ? i vaerdien er korrekt kodet og ikke fortolkes som URL-separatorer.
## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form redirects by safely encoding return-page information, helping ensure users are sent back to the correct location after printing.
  * Restricted return-page links to relative paths and added safeguards for navigation links, preventing unsafe redirects and injected content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->