### PR TITLE
Fix Bilagsmatch always returning 0 fundet (ambiguous norm_amount)

### DIFF
--- a/finans/kassekladde_includes/fetchbilagsmatch.php
+++ b/finans/kassekladde_includes/fetchbilagsmatch.php
@@ -30,6 +30,10 @@
 //                   new indexed pool_files.norm_amount column instead of parsing amounts at
 //                   query time.
 // 20260731 NTR - fixed previous rework, it was missing norm_amount in the with statement for pf and trimmed the currency codes.
+// 20260810 CL/LH - removed the inline norm_amount alias again: once betweenUpdates.php has
+//                   created the real pool_files.norm_amount column (which it now does on
+//                   every install), SELECT * plus the alias made pf.norm_amount ambiguous,
+//                   so the query errored and the endpoint always returned "0 fundet".
 
     // Start buffering
     ob_start();
@@ -81,8 +85,11 @@
     // kassekladde.valuta is an integer code, not a currency string - it points at
     // grupper(art='VK').kodenr, whose box1 holds the actual ISO code (same lookup the
     // main kassekladde grid uses in build_kassekladde_query()). No match -> base currency.
-    // pool_files.amount is text and sometimes '' (blank import), so it's converted to
-    // numeric per-row with NULL sentinel default instead of via a precomputed column.
+    // pool_files.norm_amount is the migrated NUMERIC column (populated at write time via
+    // poolAmountNormalizer.php, created + backfilled in betweenUpdates.php). It must NOT
+    // be recomputed here: a) SELECT * already carries the real column, so an alias with
+    // the same name makes every pf.norm_amount reference ambiguous and kills the whole
+    // query, and b) a bare ::numeric cast throws on Danish-formatted amounts ('682,93').
     $qtxt = "
         WITH kl AS (
             SELECT k.*,
@@ -95,7 +102,6 @@
         ), pf AS (
             SELECT *,
                 (CASE WHEN file_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' THEN file_date::date ELSE NULL END) AS safe_file_date,
-                NULLIF(TRIM(amount), '')::numeric as norm_amount,
                 UPPER(TRIM(COALESCE(NULLIF(currency, ''), '$base_currency_escaped'))) AS currency_code
             FROM pool_files
         )


### PR DESCRIPTION
## What are the changes about?

Bilagsmatch on master always shows **"0 fundet"** (reported by the bookkeeper on ssl3). Root cause: two fixes inside PR #424 that each solved the "column norm_amount missing" review finding, but break each other when combined:

1. 20260728 — the `norm_amount`/`pg_trgm` migration moved into `includes/betweenUpdates.php`, so the real `pool_files.norm_amount` column now gets created on every install (runs at login).
2. 20260731 — `fetchbilagsmatch.php` started computing `NULLIF(TRIM(amount), '')::numeric AS norm_amount` inline in the `pf` CTE, on top of `SELECT *`.

Once the real column exists, the CTE has **two** columns named `norm_amount`, and every `pf.norm_amount` reference fails with `ERROR: column reference "norm_amount" is ambiguous`. The endpoint runs with `display_errors=0` + `ob_clean()`, so the failed query silently becomes `[]` → the popup always renders the empty state.

The inline cast was also independently broken: `'682,93'::numeric` throws on Danish-formatted amounts — the exact problem `poolAmountNormalizer.php` was built to solve.

**Fix:** drop the inline alias; the query uses the migrated `norm_amount` column (populated at write time in `extractInvoiceHandler.php`, backfilled + indexed in `betweenUpdates.php`). `betweenUpdates.php` is included unconditionally in `index/login.php`, so the column is guaranteed to exist before anyone can reach kassekladde. No new migration needed.

## How was it tested?

On golden dataset `test_12` (has the migrated column, i.e. same state as ssl3):
- The pre-fix `pf` CTE reproduces `column reference "norm_amount" is ambiguous`.
- The fixed query runs clean; a seeded matching invoice (Danish-format amount `"100,00"`, `norm_amount` 100, DKK, dated 7 days before the journal line) scores **74 → precision "high"** (amount 40 + date 24.9 + text 9.6), as specced in SD-578.
- `php -l` clean.

Note: cross-currency cases (e.g. a EUR invoice booked as DKK) still won't match — that's the SD-578 currency hard gate working as designed; follow-up ticket filed.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved financial document matching by using the stored normalized amount directly.
  * Prevented potential amount-conversion errors and query ambiguity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->