### PR TITLE
SST-719 Kassekladde: buttons only half visible

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -63,8 +63,8 @@
 // 20260729 MJ Rettet fejl: location.reload() gensendte POST-data og oprettede dubletter via auto-balance forududfyldning
 // 20260729 MJ Rettet fejl: clipDragSourceId-rest forhindrede fil-drop naar forrige clip-drag ikke var ryddet op
 // 20260729 MJ Rettet fejl: upload-succces opdaterer nu kun clip-ikonet i DOM istedet for at genindlaese siden
-
-ob_start(); //Starter output buffering
+// 20260812 LOE .kassekladde-scroll-container; increased the subtraction in height to leave more room for the footer buttons.
+ob_start(); //Starter output buffering  
 
 register_shutdown_function(function() {
     $e = error_get_last();
@@ -4287,7 +4287,7 @@ body {
        .kassekladde-footer row below (padding+border+margin+button row is
        ~70-80px on its own), so the footer's tail was clipped once html/body
        stopped allowing page-level scroll. */
-    height: calc(100vh - 130px);
+    height: calc(100vh - 150px);
     overflow-y: auto;
     border: 1px solid #ddd;
     margin-bottom: 10px;


### PR DESCRIPTION
Changes Made
File: kassekladde.php

Specific Change:
.kassekladde-scroll-container height calculation updated from calc(100vh - 130px) to calc(100vh - 150px).

Scope: Pure CSS/HTML layout adjustment. Zero changes to PHP logic, JavaScript, or database queries.

Acceptance Criteria Verification
Reproduce and verify on macOS at affected viewport sizes:
Verified on a real macOS environment (via BrowserStack, macOS Tahoe/Sequoia) with Chrome 139. The issue was successfully reproduced at the 1024×768 resolution and resolved after applying the fix.

General Replication and Comparison: Zoom in to about 120 to 145% of the current file and compare to this updated version on Chrome using Windows or Linux. 

PR requires a security-focused review before merge:
Since the fix is purely presentational, a security reviewer can quickly confirm no new attack vectors are introduced. I have explicitly noted the absence of PHP changes to facilitate an expedited review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the height of the cash journal scroll area to display more content and reduce unnecessary scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->