### PR TITLE
SST-724 Serial number overview: only show salgslinje_id = 0 as availa…

### DIFF
--- a/lager/lister/serialnumber.php
+++ b/lager/lister/serialnumber.php
@@ -29,6 +29,7 @@
 // 20260710 MJ Use COALESCE(v.varenr, kl.varenr, sl.varenr) so serienr records with stale/missing vare_id still appear and are searchable by varenr.
 // 20260710 MJ ABS(sn.kobslinje_id) i JOIN så negative kobslinje_id (retur til leverandør) også viser indkøbsordren.
 // 20260710 MJ Ekstra COALESCE-fallbacks via ordrelinjer.vare_id→varer og batch_kob/batch_salg.vare_id→varer så serienr med tom/manglende ordrelinjer.varenr stadig søges.
+// 20260813 Sawaneh - "Not sold" filter: sn.salgslinje_id = 0 instead of <= 0, so negative history rows (credited sales) are no longer shown as available. Credited return serials still appear via the fresh row with salgslinje_id = 0 from krediter().
 
 @session_start();
 $s_id = session_id();
@@ -240,7 +241,7 @@ $filters[] = array(
         array(
             "name" => "Vis kun serienumre der ikke er solgt",
             "checked" => "",
-            "sqlOn" => "sn.salgslinje_id <= 0",
+            "sqlOn" => "sn.salgslinje_id = 0",
             "sqlOff" => "",
         )
     )


### PR DESCRIPTION
…ble, not credited history rows

## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “not sold” filter to exclude historical return records while retaining newly created return serial records.
  * Updated related documentation to clarify the filter’s behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## #466 — SST-724 Serial number overview: only `salgslinje_id = 0` is available

### Description

**What are the changes about?**

One-line change in `lager/lister/serialnumber.php`: the "Vis kun serienumre der ikke er solgt" filter now uses `sn.salgslinje_id = 0` instead of `<= 0`.

`serienr.salgslinje_id` has three states: `0` = in stock, `> 0` = sold on that sales line, `< 0` = history marker for a sale that was later credited/returned (`debitor/serienummer.php` flips the original row to `-linje_id`, and `krediter()` in `includes/ordrefunc.php` inserts a fresh row with `salgslinje_id = 0` for the returned unit).

Before: `<= 0` matched both the negative history row *and* the fresh row, so a serial that was sold and then credited appeared **twice** in the "not sold" list. Worse, if that serial was sold again, the fresh row got a positive id but the old negative row still matched, so a serial that was currently sold kept showing as available.

After: only rows with `salgslinje_id = 0` count as available — one line per unit actually in stock. Credited returns still appear (via the fresh row), history rows do not.

**How I verified:** [confirm] On a test tenant, sold a serial-tracked item, credited the invoice with the serial returned, then re-sold it. Before the fix the serial number overview with "ikke solgt" ticked listed the serial twice after the credit and still listed it after the resale; after the fix it appears once after the credit and disappears after the resale. Unticking the filter shows all rows unchanged.
