### PR TITLE
Sawaneh emballage report status4

### DIFF
--- a/finans/rapport_includes/emballage.php
+++ b/finans/rapport_includes/emballage.php
@@ -8,6 +8,8 @@
 // Packaging tax report (producentansvar). Detailed and Summary views over
 // invoiced packaging within a date range, filtered by delivery country.
 // Copyright (c) 2003-2026 saldi.dk ApS
+// 20260814 Sawaneh Include booked orders (status 4) so the report is not
+//                  empty once invoices are booked.
 
 function emballage($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
                    $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
@@ -140,7 +142,7 @@ function emballage_detailed_view($csv, $dateFilter, $landFilter, $startdato, $sl
 	         JOIN ordrer o ON ol.ordre_id = o.id
 	         JOIN emballage e ON e.varer_id = ol.vare_id
 	         LEFT JOIN adresser a ON a.id = o.konto_id
-	         WHERE o.status = '3' $dateFilter $landFilter
+	         WHERE o.status IN ('3','4') $dateFilter $landFilter
 	         ORDER BY o.fakturadate, e.category, e.type";
 	$q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
 
@@ -193,7 +195,7 @@ function emballage_summary_view($csv, $dateFilter, $landFilter, $startdato, $slu
 	         JOIN ordrer o ON ol.ordre_id = o.id
 	         JOIN emballage e ON e.varer_id = ol.vare_id
 	         LEFT JOIN adresser a ON a.id = o.konto_id
-	         WHERE o.status = '3' $dateFilter $landFilter
+	         WHERE o.status IN ('3','4') $dateFilter $landFilter
 	         GROUP BY periode, e.category, e.waste_sorting, slutbruger
 	         ORDER BY periode, e.category, e.waste_sorting, slutbruger";
 	$q = db_select($qtxt, __FILE__ . " linje " . __LINE__);


### PR DESCRIPTION
## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable API-based synchronization for shop prices, products, variants, stock, and component items.
  * Added retry handling, secure request validation, timeout controls, and structured error reporting.
  * Packaging reports now include booked orders in addition to invoiced orders.

* **Bug Fixes**
  * Synchronization failures are now logged and summarized instead of running silently in the background.
  * Added diagnostic information when packaging reports contain no matching records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->




### Description



**What are the changes about?**
## #471 — Emballage report includes booked orders (status 4)
`finans/rapport_includes/emballage.php` (packaging tax report, detailed and summary views) selected only `ordrer.status = '3'` (invoiced, not yet booked). `bogfor()` sets `status = 4` when the invoice is booked, so once a period's invoices were booked the report for that period came out empty. Both queries now use `status IN ('3','4')`; date range, country filter and grouping are unchanged.

**How I verified:** [confirm] On a test tenant with packaging-registered items: ran the report for a month with invoiced-but-unbooked orders (rows shown before and after), booked the invoices, re-ran — before the fix the report was empty, after the fix the same rows and totals appear. Detailed and summary views and the CSV export checked.

### Replies to CodeRabbit

Both findings are on `includes/stdFunc/shopApiRequest.php`, which is **not part of this PR** — it was only in the branch's diff while the branch was behind master; the current diff is the single `emballage.php` file. Reply once on each and resolve:

> `shopApiRequest.php:169` (no overall time bound): This file is not part of this PR any more (the diff is only `finans/rapport_includes/emballage.php`). The finding was addressed in the version that shipped on master: `shopApiRequest()` now has a per-request wall-clock `timeBudget` (default 30 s) and a `failThreshold` that degrades an endpoint after repeated transport failures, not only on `httpCode === 0` (see the 20260812 history line in the file).

> `shopApiRequest.php:290` (unguarded `mb_substr`): Not part of this PR. On master `shopApiLogFailure()` truncates the body with plain `substr()`, so there is no mbstring dependency on the failure-logging path.