### PR TITLE
SST-705 Regnskabsaar: show fiscal year as Lukket when bookkeeping is …

### DIFF
--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -62,10 +62,10 @@ function check_permissions($permarr)
   return !empty($filtered);
 }
 
-$aktiver = (int)if_isset($_GET['aktiver']);
-$deleteYear = (int)if_isset($_GET['deleteYear']);
-$deleteEmptyYear = (int)if_isset($_GET['deleteEmptyYear']);
-$set_alle = (int)if_isset($_GET['set_alle']);
+$aktiver = (int)filter_input(INPUT_GET, 'aktiver', FILTER_VALIDATE_INT);
+$deleteYear = (int)filter_input(INPUT_GET, 'deleteYear', FILTER_VALIDATE_INT);
+$deleteEmptyYear = (int)filter_input(INPUT_GET, 'deleteEmptyYear', FILTER_VALIDATE_INT);
+$set_alle = (int)filter_input(INPUT_GET, 'set_alle', FILTER_VALIDATE_INT);
 
 if ($set_alle) {
 	db_modify("update brugere set regnskabsaar = '$set_alle'", __FILE__ . " linje " . __LINE__);

--- a/systemdata/regnskabsaar.php
+++ b/systemdata/regnskabsaar.php
@@ -37,6 +37,8 @@
 // 20260130 PHR - Improved check for empty fiscal year before deletion and used ICONSVG icons.
 // 20260730 MJ Tilfoejede Momsperioder-knap; fjernede linket fra finans-sidebaren i main.php
 // 20260801 MJ Sat begge knapper til samme bredde (200px)
+// 20260814 Sawaneh SST-705 Current fiscal year shows Lukket when bookkeeping is
+//                  not allowed (box5) and GET params are int-cast before SQL
 
 @session_start();
 $s_id = session_id();
@@ -60,10 +62,10 @@ function check_permissions($permarr)
   return !empty($filtered);
 }
 
-$aktiver = if_isset($_GET['aktiver']);
-$deleteYear = if_isset($_GET['deleteYear']);
-$deleteEmptyYear = if_isset($_GET['deleteEmptyYear']);
-$set_alle = if_isset($_GET['set_alle']);
+$aktiver = (int)if_isset($_GET['aktiver']);
+$deleteYear = (int)if_isset($_GET['deleteYear']);
+$deleteEmptyYear = (int)if_isset($_GET['deleteEmptyYear']);
+$set_alle = (int)if_isset($_GET['set_alle']);
 
 if ($set_alle) {
 	db_modify("update brugere set regnskabsaar = '$set_alle'", __FILE__ . " linje " . __LINE__);
@@ -290,7 +292,12 @@ foreach($fiscalYears as $index => $row){
 		print "</td>";
 		print renderEmptyFiscalYearButton($canDeleteThisyear, $isEmpty[$x], $row['kodenr'], $sprog_id, $trash_icon);
 	} else {
-		print "<td><font color=#ff0000>" . findtekst('1214|Aktivt', $sprog_id) . "</font></td><td>";
+		# The selected year is only open for posting when box5 (bookkeeping allowed) is on
+		if ($row['box5'] == 'on') {
+			print "<td><font color=#ff0000>" . findtekst('1214|Aktivt', $sprog_id) . "</font></td><td>";
+		} else {
+			print "<td>" . findtekst('387|Lukket', $sprog_id) . "</td><td>";
+		}
 		if ($set_alle) {
 			$title = "" . findtekst('1794|Klik for at sætte regnskabsår', $sprog_id) . " $regnaar " . findtekst('1795|aktivt for alle brugere', $sprog_id) . "";
 			$title2 = "" . findtekst('1796|Sæt regnskabsår', $sprog_id) . " $regnaar " . findtekst('1795|aktivt for alle brugere', $sprog_id) . "?";


### PR DESCRIPTION
…not allowed

## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of fiscal-year selections to ensure reliable processing.
  - Fiscal years now display “Lukket” when bookkeeping is disabled and “Aktivt” when it remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


# #473 — SST-705 Regnskabsår: show the year as "Lukket" when bookkeeping is not allowed

### Description

**What are the changes about?**

`systemdata/regnskabsaar.php` showed the selected fiscal year as red "Aktivt" regardless of the "bogføring tilladt" flag (`grupper.box5` on the RA row). A closed year therefore looked open for posting. The status cell now checks `box5` the same way the delete/activate logic on the same page already does: `on` → "Aktivt" (text 1214), otherwise "Lukket" (text 387).

While in there, the four action parameters (`aktiver`, `deleteYear`, `deleteEmptyYear`, `set_alle`) are read with `filter_input(INPUT_GET, …, FILTER_VALIDATE_INT)` and int-cast before they reach SQL. Anything that is not a plain integer becomes `0`, and every action branch is guarded with `if ($x)`, so a malformed value can no longer select a year for activation, bulk assignment or deletion. `filter_input` also does not emit undefined-key warnings when the parameter is absent.

**How I verified:** [confirm] On a test tenant: closed the current year (Regnskabsår → bogføring ikke tilladt) — the list showed "Aktivt" before the fix and "Lukket" after; reopened it and the cell went back to "Aktivt". Activate / set-for-all / delete-empty-year still work with normal links; `?aktiver=1foo` and `?deleteYear[]=1` now do nothing instead of acting on year 1.