### PR TITLE
MB-20 + MB-19: invoice print - item-number early wrap (unit bug) and description/quantity overlap

### DIFF
--- a/includes/formfunk.php
+++ b/includes/formfunk.php
@@ -411,9 +411,7 @@ if (!function_exists('ombryd')) {
 			$lokation = $parts[1] ?? NULL;
 			$vare_note = $parts[2] ?? NULL;
 		}
-		error_log("tekst before wrap: " . json_encode($tekst) . " length: " . strlen($tekst) . " laengde: " . $laengde);
 		$tekst = wordwrap($tekst, $laengde, "\n", true);
-		error_log("tekst after wrap: " . json_encode($tekst));
 		$nytekst = "";
 		if (strstr($tekstinfo, 'ordrelinjer')) {
 			list($tmp, $Opkt) = explode("_", $tekstinfo);
@@ -2075,22 +2073,37 @@ if (!function_exists('formularprint')) {
 								break;
 							}
 						}
-						if ($beskriv_z && isset($laengde[$beskriv_z]) && $laengde[$beskriv_z] > 0) {
+						// 20260818 LH MB-19: a template laengde wider than the physical span to the next
+						// column (typically antal) let long description lines print into the quantity
+						// column. Cap the wrap width by the span in points (xa is mm, x2.86 in skriv()),
+						// reserving room for a right-aligned neighbour's value.
+						$beskriv_laengde = ($beskriv_z && isset($laengde[$beskriv_z])) ? (int)$laengde[$beskriv_z] : 0;
+						if ($beskriv_z && $str[$beskriv_z] > 0) {
+							$next_xa = 0; $next_str = 0; $next_just = '';
+							for ($z_tmp = 1; $z_tmp <= $var_antal; $z_tmp++) {
+								if ($z_tmp != $beskriv_z && $xa[$z_tmp] > $xa[$beskriv_z] && (!$next_xa || $xa[$z_tmp] < $next_xa)
+									&& $variabel[$z_tmp] != 'lokation' && $variabel[$z_tmp] != 'vare_note' && substr($variabel[$z_tmp], 0, 8) != 'fritekst') {
+									$next_xa = $xa[$z_tmp]; $next_str = $str[$z_tmp]; $next_just = $justering[$z_tmp];
+								}
+							}
+							if ($next_xa) {
+								$reserve = ($next_just == 'H') ? 8 * 0.55 * ($next_str > 0 ? $next_str : $str[$beskriv_z]) : 0;
+								$span_chars = max(12, (int)(((($next_xa - $xa[$beskriv_z]) * 2.86) - $reserve) / (0.55 * $str[$beskriv_z])));
+								$beskriv_laengde = ($beskriv_laengde > 0) ? min($beskriv_laengde, $span_chars) : $span_chars;
+							}
+						}
+						if ($beskriv_z && $beskriv_laengde > 0) {
 							// Get the description text (handle tab-separated lokation/vare_note)
 							$check_tekst = $beskrivelse[$x];
 							if (strpos($check_tekst, chr(9)) !== false) {
 								list($check_tekst) = explode(chr(9), $check_tekst);
 							}
-							$wrappedText = wordwrap($check_tekst, $laengde[$beskriv_z], "\n", true);
+							$wrappedText = wordwrap($check_tekst, $beskriv_laengde, "\n", true);
 							$descLines = count(explode("\n", $wrappedText));
 							$totalHeightNeeded = ($descLines - 1) * $linjeafstand;
 
-							// DEBUG: Log to file
-							file_put_contents("../temp/debug_pagebreak.txt", "DEBUG line $x: y=$y, Opkt=$Opkt, descLines=$descLines, totalHeight=$totalHeightNeeded, laengde=".$laengde[$beskriv_z].", check=".($y - $totalHeightNeeded)."\n", FILE_APPEND);
-
 							// If description would spill to next page, move entire line to next page first
 							if ($descLines > 1 && ($y - $totalHeightNeeded) <= $Opkt && $y >= $Opkt) {
-								file_put_contents("../temp/debug_pagebreak.txt", "FORCING PAGE BREAK for line $x\n", FILE_APPEND);
 								// Force a page break before writing any fields
 								$y = skriv($id, "$str[$beskriv_z]", "$fed[$beskriv_z]", "$kursiv[$beskriv_z]", "$color[$beskriv_z]", "", "ordrelinjer_" . $Opkt, "$xa[$beskriv_z]", $Opkt - 1, "$justering[$beskriv_z]", "$form_font[$beskriv_z]", "$formular", __LINE__);
 							}
@@ -2108,11 +2121,15 @@ if (!function_exists('formularprint')) {
 							if ($variabel[$z] == "posnr")
 								$svar = skriv($id, "$str[$z]", "$fed[$z]", "$kursiv[$z]", "$color[$z]", "$posnr[$x]", "ordrelinjer_" . $Opkt, "$xa[$z]", "$y", "$justering[$z]", "$form_font[$z]", "$formular", __LINE__);
 							elseif ($variabel[$z] == "varenr") {
-								// Determine wrap width from configured laengde, or compute from column span to beskrivelse
-								$vn_wrap = ($laengde[$z] > 0) ? (int)$laengde[$z]
-									: (($beskriv_z && $str[$z] > 0)
-										? max(12, (int)(($xa[$beskriv_z] - $xa[$z]) / (0.55 * $str[$z])))
-										: 0);
+								// 20260818 LH MB-20: xa positions are template units (mm, x2.86 -> points in skriv())
+								// but str is a point size - the missing 2.86 factor made the span ~3x too small, so
+								// item numbers wrapped after 12-15 chars although the column fits more. Compute the
+								// span in points, and never wrap earlier than the widest of the configured laengde
+								// and the physical span.
+								$vn_span = ($beskriv_z && $str[$z] > 0)
+									? max(12, (int)((($xa[$beskriv_z] - $xa[$z]) * 2.86) / (0.55 * $str[$z])))
+									: 0;
+								$vn_wrap = max((int)$laengde[$z], $vn_span);
 								if ($vn_wrap > 0 && mb_strlen($varenr[$x]) > $vn_wrap) {
 									$vn_wrapped = explode("\n", wordwrap($varenr[$x], $vn_wrap, "\n", true));
 								} else {
@@ -2180,7 +2197,7 @@ if (!function_exists('formularprint')) {
 							}
 						}
 						if ($z = $skriv_beskriv[$x]) {
-							$y2 = ombryd($id, "$str[$z]", "$fed[$z]", "$kursiv[$z]", "$color[$z]", "$beskrivelse[$x]", "ordrelinjer_" . $Opkt, "$xa[$z]", "$y", "$justering[$z]", "$form_font[$z]", $laengde[$z], $formular, $linjeafstand);
+							$y2 = ombryd($id, "$str[$z]", "$fed[$z]", "$kursiv[$z]", "$color[$z]", "$beskrivelse[$x]", "ordrelinjer_" . $Opkt, "$xa[$z]", "$y", "$justering[$z]", "$form_font[$z]", ($beskriv_laengde > 0 ? $beskriv_laengde : $laengde[$z]), $formular, $linjeafstand);
 						}
 						// Use the lowest y (most wrapped lines wins)
 						$y2 = min($y_after_varenr, $y2 ?? $y);


### PR DESCRIPTION
Fixes [MB-20](https://saldi-team.atlassian.net/browse/MB-20) and [MB-19](https://saldi-team.atlassian.net/browse/MB-19) (reported by Thor on ssl3 master, filed two minutes apart — both are invoice-print column-width defects in `includes/formfunk.php`). One PR because the fixes touch the same 30 lines and would conflict as separate branches.

## MB-20 — item number "restricted to 15 characters"

The varenr wrap logic added in 68b3f9e7 (Mar 2026) computes the column span as `(xa[beskrivelse] − xa[varenr]) / (0.55 × fontsize)` — but **xa positions are template millimetres while the font size is in points**. The renderer multiplies all coordinates by 2.86 (mm→pt); the wrap formula forgot that factor, so the computed span is ~3× too small and item numbers wrap after 12–15 characters although the printed column fits more. Nothing is truncated (all wrapped chunks do print), but the number breaks early — which QA read as a 15-char cap.

**Fix:** compute the span in points, and use the widest of the configured field length and the physical span.

**Verified end-to-end** on a clone of golden dataset test_12: a 28-char item number on invoice 217392 wrapped at 12 chars/3 lines before, and now wraps at 17 chars/2 lines — the full physical column width. PostScript output inspected directly.

## MB-19 — description prints into the quantity column

The description wraps purely at the template's configured character count (`laengde`). A template with `laengde` wider than the physical distance to the next column lets long lines print into the right-aligned antal values. 

**Fix:** cap the description wrap width by the physical span (in points) to the nearest column right of beskrivelse, reserving ~8 characters for a right-aligned neighbour's value. Templates whose configured laengde already fits are nearly unchanged (test_12's template went from 48 to 47 chars/line — a one-char-earlier wrap is the cost of guaranteeing no overlap with wide quantities).

## Cleanup in the same path

- Removed two `error_log()` calls in `ombryd()` that fired for **every printed line** on production.
- Removed the `debug_pagebreak.txt` file dump (wrote to `../temp/` on every invoice print).

## Test notes

- Repro/verify recipe: clone a golden tenant, set a line's varenr to a 28-char value, drive `debitor/formularprint.php?id=<ordre>&formular=4` via the characterization-test session harness, and inspect the generated `temp/<db>/<år>/fakt<nr>.ps`.
- Existing invoices with short item numbers and in-bounds descriptions render byte-identical except the removed debug output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)