### PR TITLE
ordre: 'Uforudset haendelse' ved ordre-gem - vis_lev_addr 'off' overflow'er varchar(2)

### DIFF
--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -1082,6 +1082,7 @@ if ($b_submit) {
 	else $lev_bynavn = db_escape_string($lev_bynavn);
 	$lev_kontakt = if_isset($_POST, NULL, 'lev_kontakt') ? db_escape_string(trim($_POST['lev_kontakt'])) : '';
 	$vis_lev_addr = if_isset($_POST, NULL, 'vis_lev_addr');
+	if ($vis_lev_addr != 'on') $vis_lev_addr = ''; // ordrer.vis_lev_addr er varchar(2) ('on'/''): 'off' fra gemt brugerindstilling overflow'er og vaelter hele ordre-opdateringen
 	update_settings_value("vis_lev_addr", "ordrer", $vis_lev_addr, "If the adress field should be showen as standard value", $bruger_id);
 
 	$felt_1 = db_escape_string(trim($_POST['felt_1']));
@@ -5262,7 +5263,7 @@ function ordreside($id, $regnskab)
 			<label style="white-space:nowrap;cursor:pointer;"><?= htmlspecialchars(findtekst('355|Vis leveringsadresse', $sprog_id)) ?>
 			<input type="checkbox" id="vis_lev_addr" name="vis_lev_addr" value="on" <?= $vis_addr == 'on' ? 'checked' : '' ?> onchange="document.getElementById('submit').click();"></label>
 		<?php } else { ?>
-			<input type='hidden' id='vis_lev_addr' name='vis_lev_addr' value='<?= $vis_addr ?? 'on' ?>'><input type="button" onclick="
+			<input type='hidden' id='vis_lev_addr' name='vis_lev_addr' value='<?= ($vis_addr ?? '') == 'on' ? 'on' : '' ?>'><input type="button" onclick="
 			var field = document.getElementById('vis_lev_addr');
 			field.value = field.value === 'on' ? '' : 'on';
 			document.getElementById('submit').click();"


### PR DESCRIPTION
## Problem
Ordresiden kan ikke gemme ordrehovedet (og dermed heller ikke sende ordre-/fakturamail): hver eneste `update ordrer set ...` fejler med

```
ERROR: value too long for type character varying(2)
```

og brugeren ser kun **"Uforudset haendelse, kontakt salditeamet"**.

Ramt i produktion pa ssl3 (saldi_1091, ordre 17175, 3 fejlede gem i `.ht_modify.log`), men rammer alle installationer hvor brugerens `vis_lev_addr`-indstilling star pa default.

## Rodarsag
Den skjulte formular-markoer seedes fra brugerindstillingen med default-strengen `'off'` (debitor/ordre.php:5265 + get_settings_value-default "off"). Kolonnen `ordrer.vis_lev_addr` er `varchar(2)` (admin/opret.php:405) efter checkbox-idiomet `'on'`/`''` - `'off'` er 3 tegn og vaelter hele UPDATE-satningen, sa **alle** ordrehoved-felter (email, mailtekst, betalingsbet., osv.) mister deres aendringer.

## Fix (2 linjer)
- **POST-laesning (linje 1084):** normaliser alt der ikke er `'on'` til `''` FOER vaerdien bade skrives til settings og indgar i ordrer-UPDATE. Dermed helbredes allerede-gemte `'off'`-indstillinger ved naeste gem.
- **Feltudskrivning (linje 5265):** emit kun `'on'`/`''` i den skjulte input, sa foerste POST fra en frisk bruger aldrig baerer `'off'`. JS-togglen flipper i forvejen kun mellem `'on'` og `''` og er uaendret.

Ingen skemaaendring nodvendig - kolonnen kan aldrig indeholde `'off'`, sa der findes ingen data at migrere.

## Test
- `php -l` ren.
- Reproduceret pa ssl3/saldi_1091: ordre-gem fejlede med praecis denne fejl; med normaliseret vaerdi gar samme UPDATE igennem.

NB: pa saldi_1091 er kolonnen midlertidigt udvidet til varchar(4) som akut-unblock - det kan sta (ren udvidelse), men dette fix goer det overflodigt fremadrettet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)