### PR TITLE
Stripe subscriptions: customer-facing UI + styled email CTA (re-land pa master)

### DIFF
--- a/api/stripe/afbrudt.php
+++ b/api/stripe/afbrudt.php
@@ -28,6 +28,8 @@
 //                the page cannot be used to probe or forward signatures.
 //                No DB writes, no Stripe calls.
 // 20260818 CL/LH Anchored branch-added include paths to __DIR__.
+// 20260820 CL/LH Presentation only: shared shell from stripePage.php. The
+//                retry link still renders ONLY on a verified id+sig pair.
 
 header('Content-Type: text/html; charset=utf-8');
 header('Cache-Control: no-store');
@@ -37,6 +39,7 @@ header('Referrer-Policy: no-referrer');
 
 include(__DIR__ . '/../../includes/connect.php');
 include(__DIR__ . '/../../includes/stripeIncludes/stripeBootstrap.php');
+include(__DIR__ . '/../../includes/stripeIncludes/stripePage.php');
 include(__DIR__ . '/../../includes/stripeIncludes/stripeLink.php');
 
 $order_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
@@ -45,20 +48,8 @@ $retry    = '';
 if ($stripe_boot_ok && $order_id > 0 && stripe_link_verify($order_id, $sig)) {
 	$retry = 'subscribe.php?id=' . $order_id . '&sig=' . htmlspecialchars($sig, ENT_QUOTES, 'UTF-8');
 }
-?>
-<!DOCTYPE html><html lang="da"><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex,nofollow">
-<title>Betaling afbrudt</title>
-<style>body{font-family:Arial,Helvetica,sans-serif;background:#f4f4f4;margin:0;padding:2em 1em}
-.card{max-width:560px;margin:0 auto;background:#fff;border:1px solid #ddd;border-radius:6px;padding:2em}
-h1{font-size:1.3em;margin-top:0}.muted{color:#666;font-size:.85em}
-.btn{display:inline-block;background:#356e35;color:#fff;border-radius:4px;padding:.7em 1.6em;text-decoration:none}</style></head><body>
-<div class="card">
-<h1>Betalingen blev afbrudt</h1>
-<p>Der er ikke trukket noget beløb, og der er ikke oprettet noget abonnement.</p>
-<?php if ($retry) { ?>
-<p><a class="btn" href="<?php print $retry; ?>">Prøv igen</a></p>
-<?php } ?>
-<p class="muted">Din faktura er stadig gyldig og kan betales som hidtil. Spørgsmål? Besvar blot fakturamailen.</p>
-</div></body></html>
+
+stripe_status_page(200, 'stop', 'Betalingen blev afbrudt',
+	['Der er ikke trukket noget beløb, og der er ikke oprettet noget abonnement.'],
+	$retry ? "<a class='btn' href='" . $retry . "'>Prøv igen</a>" : '',
+	'Din faktura er stadig gyldig og kan betales som hidtil. Spørgsmål? Besvar blot fakturamailen.');

--- a/api/stripe/subscribe.php
+++ b/api/stripe/subscribe.php
@@ -26,6 +26,8 @@
 // 20260807 CL/LH Created: signed subscription link endpoint.
 //                Contract: doc/stripe/INTERFACE_CONTRACT.md.
 // 20260818 CL/LH Moved per-order rate limit after link verification.
+// 20260820 CL/LH Presentation only: page shells moved to stripeIncludes/
+//                stripePage.php, new customer-facing design. No logic changes.
 //
 // GET  = verify HMAC, load the order, match every line against stripe_catalog,
 //        render a Danish confirm page. ZERO Stripe calls, ZERO writes - mail
@@ -54,38 +56,22 @@ if (isset($_GET['db']) || isset($_POST['db']) || isset($_REQUEST['db'])) {
 
 include(__DIR__ . "/../../includes/connect.php");
 include(__DIR__ . "/../../includes/stripeIncludes/stripeBootstrap.php");
+include(__DIR__ . "/../../includes/stripeIncludes/stripePage.php");
 include(__DIR__ . "/../../includes/stripeIncludes/stripeLink.php");
 include(__DIR__ . "/../../includes/stripeIncludes/stripeRateLimit.php");
 include(__DIR__ . "/../../includes/stripeIncludes/stripeAlertMail.php");
 include(__DIR__ . "/../../includes/stripeIncludes/stripeHttp.php");
 
-// ---------- page shells (self-contained, Danish, no JS) ----------
-function stripe_page($title, $bodyHtml, $status = 200) {
-	http_response_code($status);
-	ob_end_clean();
-	print "<!DOCTYPE html><html lang='da'><head><meta charset='utf-8'>";
-	print "<meta name='viewport' content='width=device-width, initial-scale=1'>";
-	print "<meta name='robots' content='noindex,nofollow'>";
-	print "<title>" . htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . "</title>";
-	print "<style>body{font-family:Arial,Helvetica,sans-serif;background:#f4f4f4;margin:0;padding:2em 1em}
-.card{max-width:560px;margin:0 auto;background:#fff;border:1px solid #ddd;border-radius:6px;padding:2em}
-h1{font-size:1.3em;margin-top:0}table{width:100%;border-collapse:collapse;margin:1em 0}
-td,th{padding:.4em .2em;text-align:left;border-bottom:1px solid #eee}td.r,th.r{text-align:right}
-.total td{font-weight:bold;border-top:2px solid #333;border-bottom:none}
-.btn{display:inline-block;background:#356e35;color:#fff;border:none;border-radius:4px;padding:.7em 1.6em;font-size:1em;cursor:pointer}
-.muted{color:#666;font-size:.85em}</style></head><body><div class='card'>" . $bodyHtml . "</div></body></html>";
-	exit;
-}
+// ---------- page shells (shared shell in stripePage.php, Danish, no JS) ----------
 function stripe_fail_page($status, $headline, $text) {
-	stripe_page($headline, "<h1>" . htmlspecialchars($headline, ENT_QUOTES, 'UTF-8') . "</h1><p>"
-		. htmlspecialchars($text, ENT_QUOTES, 'UTF-8') . "</p>", $status);
+	stripe_status_page($status, 'warn', $headline, [$text]);
 }
 function stripe_park_page() {
 	// Deliberately vague: no varenr, prices or reasons leak to the visitor.
-	stripe_page('Kontakt os', "<h1>Vi kan ikke oprette abonnementet automatisk</h1>"
-		. "<p>Der er en detalje på din aftale, som vi lige skal se på manuelt, før automatisk betaling kan sættes op.</p>"
-		. "<p>Vi er allerede blevet adviseret og vender tilbage til dig. Du kan også blot besvare fakturamailen.</p>"
-		. "<p class='muted'>Din faktura er stadig gyldig og kan betales som hidtil.</p>", 200);
+	stripe_status_page(200, 'info', 'Vi kan ikke oprette abonnementet automatisk',
+		['Der er en detalje på din aftale, som vi lige skal se på manuelt, før automatisk betaling kan sættes op.',
+		 'Vi er allerede blevet adviseret og vender tilbage til dig.'],
+		"<div class='box'><p>Vil du selv kontakte os, kan du blot besvare fakturamailen eller skrive til <a href='mailto:" . STRIPE_PAGE_SUPPORT . "'>" . STRIPE_PAGE_SUPPORT . "</a>.</p></div>");
 }
 
 // ---------- order matching (shared by GET and POST) ----------
@@ -163,7 +149,8 @@ if (!$stripe_boot_ok) stripe_fail_page(503, 'Midlertidigt utilgængelig', 'Prøv
 
 // Master switch (stripe_valg "Aktiv"): off = no new signups, full stop.
 if (stripe_setting('enabled', 'off') !== 'on') {
-	stripe_fail_page(503, 'Ikke tilgængelig', 'Abonnementstilmelding er ikke aktiveret. Din faktura er stadig gyldig og kan betales som hidtil - besvar fakturamailen ved spørgsmål.');
+	// The shared shell already appends the "faktura stadig gyldig" note.
+	stripe_fail_page(503, 'Ikke tilgængelig', 'Abonnementstilmelding er ikke aktiveret. Besvar fakturamailen ved spørgsmål.');
 }
 
 $isPost   = ($_SERVER['REQUEST_METHOD'] === 'POST');
@@ -199,9 +186,9 @@ elseif (trim((string)$order['valuta']) !== '' && strtoupper(trim($order['valuta'
 if (!$parkReason) {
 	$sub = db_fetch_array(db_select("select stripe_subscription_id from stripe_customers where konto_id = " . (int)$order['konto_id'] . " and status in ('active','trialing','past_due')", __FILE__ . " linje " . __LINE__));
 	if ($sub) {
-		stripe_page('Abonnement findes allerede', "<h1>Du har allerede et aktivt abonnement</h1>"
-			. "<p>Automatisk betaling er allerede sat op for jeres aftale, så du behøver ikke foretage dig noget.</p>"
-			. "<p class='muted'>Er det en fejl, eller ønsker du at ændre noget, så besvar fakturamailen.</p>");
+		stripe_status_page(200, 'ok', 'Du har allerede et aktivt abonnement',
+			['Automatisk betaling er allerede sat op for jeres aftale, så du behøver ikke foretage dig noget.'],
+			'', 'Er det en fejl, eller ønsker du at ændre noget, så besvar fakturamailen.');
 	}
 }
 
@@ -248,18 +235,19 @@ if (!$isPost) {
 		: 'pr. ' . ($match['interval_count'] > 1 ? $match['interval_count'] . ' x ' : '') . ($match['interval'] === 'year' ? 'år' : $match['interval']);
 	$firm = htmlspecialchars($order['firmanavn'], ENT_QUOTES, 'UTF-8');
 	stripe_page('Bekræft dit abonnement',
-		"<h1>Dit Saldi-abonnement</h1>"
-		. "<p>$firm</p>"
-		. "<table><tr><th>Ydelse</th><th class='r'>Antal</th><th class='r'>Stk.</th><th class='r'>I alt</th></tr>"
+		"<p class='eyebrow'>$firm</p>"
+		. "<h1>Dit Saldi-abonnement</h1>"
+		. "<p>Beløbet svarer til din seneste faktura. Fremover trækkes det automatisk på dit betalingskort, og du modtager stadig faktura på mail.</p>"
+		. "<table><tr><th>Ydelse</th><th class='r'>Antal</th><th class='r'>Stk.pris</th><th class='r'>I alt</th></tr>"
 		. $rows
 		. "<tr class='total'><td colspan='3'>I alt $per, ekskl. moms</td><td class='r'>" . stripe_kr($match['total_ore']) . " kr</td></tr></table>"
-		. "<p>Beløbet svarer til din seneste faktura. Fremover trækkes det automatisk på dit betalingskort, og du modtager stadig faktura på mail.</p>"
 		. "<form method='post' action='subscribe.php'>"
 		. "<input type='hidden' name='id' value='" . (int)$order_id . "'>"
 		. "<input type='hidden' name='sig' value='" . htmlspecialchars($sig, ENT_QUOTES, 'UTF-8') . "'>"
 		. "<button class='btn' type='submit'>Fortsæt til betaling</button>"
 		. "</form>"
-		. "<p class='muted'>Du sendes videre til vores betalingspartner Stripe. Moms (25%) lægges til ved betaling. Abonnementet kan opsiges når som helst ved at besvare fakturamailen.</p>");
+		. "<p class='muted' style='margin:16px 0 0;text-align:center'>Du sendes videre til vores betalingspartner Stripe. Moms (25 %) lægges til ved betaling. Abonnementet kan opsiges når som helst ved at besvare fakturamailen.</p>"
+		. "<div class='trust'><svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='#6b7590' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='4' y='11' width='16' height='10' rx='2'/><path d='M8 11V7a4 4 0 0 1 8 0v4'/></svg>Sikker betaling via Stripe</div>");
 }
 
 // ---------- POST: create the Checkout Session ----------

--- a/api/stripe/tak.php
+++ b/api/stripe/tak.php
@@ -27,23 +27,18 @@
 //                reads nothing, writes nothing, books nothing - a query
 //                parameter is not proof of payment. The webhook is the only
 //                source of truth for what happened.
+// 20260820 CL/LH Presentation only: shared shell from stripePage.php (pure
+//                markup helpers, no DB/session - the page stays dumb).
 
 header('Content-Type: text/html; charset=utf-8');
 header('Cache-Control: no-store');
 header('X-Frame-Options: DENY');
 header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: no-referrer');
-?>
-<!DOCTYPE html><html lang="da"><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex,nofollow">
-<title>Tak for din tilmelding</title>
-<style>body{font-family:Arial,Helvetica,sans-serif;background:#f4f4f4;margin:0;padding:2em 1em}
-.card{max-width:560px;margin:0 auto;background:#fff;border:1px solid #ddd;border-radius:6px;padding:2em}
-h1{font-size:1.3em;margin-top:0}.muted{color:#666;font-size:.85em}</style></head><body>
-<div class="card">
-<h1>Tak for din tilmelding!</h1>
-<p>Automatisk betaling er nu sat op. Du modtager en bekræftelse og kvittering fra Stripe på mail.</p>
-<p>Du behøver ikke foretage dig mere - fremtidige fakturaer betales automatisk, og du modtager dem fortsat på mail.</p>
-<p class="muted">Spørgsmål? Besvar blot fakturamailen.</p>
-</div></body></html>
+
+include(__DIR__ . '/../../includes/stripeIncludes/stripePage.php');
+
+stripe_status_page(200, 'ok', 'Tak for din tilmelding!',
+	['Automatisk betaling er nu sat op. Du modtager en bekræftelse og kvittering fra Stripe på mail.',
+	 'Du behøver ikke foretage dig mere - fremtidige fakturaer betales automatisk, og du modtager dem fortsat på mail.'],
+	'', 'Spørgsmål? Besvar blot fakturamailen.');

--- a/includes/formFuncIncludes/oldSendMail.php
+++ b/includes/formFuncIncludes/oldSendMail.php
@@ -107,7 +107,8 @@ print "<!--function send_mails start-->";
 	if (strpos($mailtext,'$abonnementslink') !== false || strpos($subjekt,'$abonnementslink') !== false) {
 		include_once(__DIR__ . "/subscriptionLink.php");
 		$abonnementslink = subscriptionLinkUrl($ordre_id);
-		$mailtext = str_replace('$abonnementslink', $abonnementslink ? "<a href=\"$abonnementslink\">Tilmeld automatisk betaling</a>" : '', $mailtext);
+		# 20260820 CL/LH styled CTA block (shared builder) instead of a naked anchor.
+		$mailtext = str_replace('$abonnementslink', subscriptionLinkHtml($abonnementslink), $mailtext);
 		$subjekt  = str_replace('$abonnementslink', '', $subjekt);
 	}
 	$mailtext = str_replace("\n\r","\n\r<br>",$mailtext);
@@ -305,10 +306,14 @@ print "<!--function send_mails start-->";
 	#	$mail->AddAttachment("/tmp/image.jpg", "new.jpg");
 	$mail->IsHTML(true);                               // send as HTML
 	$ren_text=html_entity_decode($mailtext,ENT_COMPAT,$charset);
+	# 20260820 CL/LH parity with sendMail.php: flatten anchors to "text: url",
+	# then strip remaining tags (the CTA block's <table>) from the plain part.
+	$ren_text=preg_replace('/<a[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/is','$2: $1',$ren_text) ?? $ren_text;
 	$ren_text=str_replace("<br>","\n",$ren_text);
 	$ren_text=str_replace("<b>","*",$ren_text);
 	$ren_text=str_replace("</b>","*",$ren_text);
 	$ren_text=str_replace("<hr>","------------------------------",$ren_text);
+	$ren_text=strip_tags($ren_text);
 	$mail->Subject  =  "$subjekt";
 	$mail->Body     =  "$mailtext";
 	$mail->AltBody  =  "$ren_text";

--- a/includes/formFuncIncludes/sendMail.php
+++ b/includes/formFuncIncludes/sendMail.php
@@ -132,7 +132,8 @@ print "<!--function send_mails start-->";
 	if (strpos($mailtext,'$abonnementslink') !== false || strpos($subjekt,'$abonnementslink') !== false) {
 		include_once(__DIR__ . "/subscriptionLink.php");
 		$abonnementslink = subscriptionLinkUrl($ordre_id);
-		$mailtext = str_replace('$abonnementslink', $abonnementslink ? "<a href=\"$abonnementslink\">Tilmeld automatisk betaling</a>" : '', $mailtext);
+		# 20260820 CL/LH styled CTA block (shared builder) instead of a naked anchor.
+		$mailtext = str_replace('$abonnementslink', subscriptionLinkHtml($abonnementslink), $mailtext);
 		$subjekt  = str_replace('$abonnementslink', '', $subjekt);
 	}
 	$mailtext = str_replace("\n\r","\n\r<br>",$mailtext);
@@ -408,6 +409,9 @@ print "<!--function send_mails start-->";
 	$ren_text=str_replace("<b>","*",$ren_text);
 	$ren_text=str_replace("</b>","*",$ren_text);
 	$ren_text=str_replace("<hr>","------------------------------",$ren_text);
+	# 20260820 CL/LH the CTA block's <table> markup (and any other template HTML)
+	# must not reach the plain-text part raw - anchors are already flattened above.
+	$ren_text=strip_tags($ren_text);
 	$mail->Subject  =  "$subjekt";
 	$mail->Body     =  "$mailtext";
 	$mail->AltBody  =  "$ren_text";

--- a/includes/formFuncIncludes/subscriptionLink.php
+++ b/includes/formFuncIncludes/subscriptionLink.php
@@ -32,6 +32,8 @@
 //                a customer without subscription lines is the NORMAL case.
 //                Contract: doc/stripe/INTERFACE_CONTRACT.md
 // 20260818 CL/LH Guarded subscription links when stripe_catalog is unavailable.
+// 20260820 CL/LH Added subscriptionLinkHtml(): shared email-safe CTA block for
+//                the HTML invoice mailers (sendMail.php/oldSendMail.php).
 
 include_once(__DIR__ . '/../stripeIncludes/stripeSettings.php');
 include_once(__DIR__ . '/../stripeIncludes/stripeLink.php');
@@ -73,10 +75,43 @@ if (!function_exists('subscriptionLinkUrl')) {
 			$catalog_exists[$db] = !empty($r['table_name']);
 		}
 		if (!$catalog_exists[$db]) return '';
+		// Already subscribed (mirrors subscribe.php's guard): renewal invoices
+		// keep going out, but a paying subscriber gets no sign-up button.
+		static $customers_exists = [];
+		if (!isset($customers_exists[$db])) {
+			$r = db_fetch_array(db_select("select to_regclass('stripe_customers') as table_name", __FILE__ . " linje " . __LINE__));
+			$customers_exists[$db] = !empty($r['table_name']);
+		}
+		if ($customers_exists[$db] && (int)$o['konto_id'] > 0) {
+			$s = db_fetch_array(db_select("select stripe_subscription_id from stripe_customers where konto_id = " . (int)$o['konto_id'] . " and status in ('active','trialing','past_due')", __FILE__ . " linje " . __LINE__));
+			if ($s) return '';
+		}
 		// At least one line must map to an active catalog row - otherwise this
 		// simply is not a subscription customer.
 		$q = db_select("select l.id from ordrelinjer l join stripe_catalog c on c.active = true and c.varenr = l.varenr where l.ordre_id = " . $ordre_id . " limit 1", __FILE__ . " linje " . __LINE__);
 		if (!db_fetch_array($q)) return '';
 		return stripe_link_url($ordre_id);
+	}
+}
+
+if (!function_exists('subscriptionLinkHtml')) {
+	// Email-safe CTA block replacing the $abonnementslink token in the HTML
+	// mailers: table + inline styles (Gmail strips <style>; Outlook needs the
+	// table for the button shape) with exactly ONE <a>, so the AltBody anchor
+	// flatten still yields "Tilmeld automatisk betaling: url". Built as a
+	// single line - the template pipeline rewrites "\n\r" to <br>, which must
+	// not fire inside the block. '' in, '' out (not a subscription customer).
+	function subscriptionLinkHtml($url) {
+		if (!$url) return '';
+		$u = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+		return "<table role='presentation' cellpadding='0' cellspacing='0' border='0' style='margin:12px 0;border-collapse:separate'>"
+			. "<tr><td style='background:#2563eb;border-radius:8px'>"
+			. "<a href=\"$u\" style='display:inline-block;padding:12px 28px;font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:bold;color:#ffffff;text-decoration:none'>Tilmeld automatisk betaling</a>"
+			// The lone \n keeps the plain-text (AltBody) rendering readable after
+			// strip_tags and never matches the template's "\n\r" -> <br> rewrite.
+			. "</td></tr>\n<tr><td style='padding-top:8px;font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#6b7590'>"
+			. "Slip for at taste kortoplysninger hver gang - fremtidige fakturaer betales automatisk. "
+			. "Du modtager stadig faktura på mail, og du kan opsige når som helst."
+			. "</td></tr></table>";
 	}
 }

--- a/includes/stripeIncludes/stripePage.php
+++ b/includes/stripeIncludes/stripePage.php
@@ -1,0 +1,108 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- includes/stripeIncludes/stripePage.php --- 2026.08.20
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Saldi.dk ApS
+// ----------------------------------------------------------------------
+// 20260820 CL/LH Created: shared customer-facing page shell for the Stripe
+//                subscription endpoints (subscribe.php/tak.php/afbrudt.php).
+//                Pure markup helpers - no DB, no session, no JS - so tak.php
+//                stays deliberately dumb. Callers escape their own dynamic
+//                values in $extraHtml; everything else is escaped here.
+//                Fonts are a local system stack on purpose: these are public
+//                EU-facing pages, so no Google Fonts (GDPR) and no CDNs.
+
+// The integration is pinned to one tenant (stripeConfigDb), so the page
+// identity is a constant: tak.php may not open a DB connection to look it up.
+if (!defined('STRIPE_PAGE_SENDER'))  define('STRIPE_PAGE_SENDER', 'Danosoft ApS');
+if (!defined('STRIPE_PAGE_SUPPORT')) define('STRIPE_PAGE_SUPPORT', 'faktura@danosoft.dk');
+
+if (!function_exists('stripe_page')) {
+	function stripe_page($title, $bodyHtml, $status = 200, $centered = false) {
+		http_response_code($status);
+		while (ob_get_level()) ob_end_clean();
+		$cardClass = $centered ? 'card center' : 'card';
+		print "<!DOCTYPE html><html lang='da'><head><meta charset='utf-8'>";
+		print "<meta name='viewport' content='width=device-width, initial-scale=1'>";
+		print "<meta name='robots' content='noindex,nofollow'>";
+		print "<title>" . htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . "</title>";
+		print "<style>
+body{margin:0;padding:40px 16px 24px;background:#f3f5f9;font-family:'Inter','Segoe UI',system-ui,-apple-system,Arial,sans-serif;color:#1f2a44}
+.page{max-width:560px;margin:0 auto;text-align:center}
+.logo{height:30px;margin-bottom:26px}
+.card{background:#fff;border:1px solid #e3e8f2;border-radius:14px;padding:36px 40px 30px;box-shadow:0 1px 2px rgba(22,62,128,.06),0 12px 32px rgba(22,62,128,.07);text-align:left}
+.card.center{text-align:center}
+h1{margin:0 0 10px;font-size:22px;line-height:1.3;font-weight:700;color:#163e80}
+p{margin:0 0 12px;font-size:15px;line-height:1.6;color:#475069}
+a{color:#2563eb}
+.eyebrow{margin:0 0 6px;font-size:13px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#6b7590}
+.badge{width:56px;height:56px;border-radius:50%;margin:0 auto 20px;display:flex;align-items:center;justify-content:center}
+.badge.ok{background:#e8f7ee}.badge.stop{background:#f1f4f9}.badge.info{background:#eaf0fc}.badge.warn{background:#fbf3e6}
+table{width:100%;border-collapse:collapse;margin:12px 0 24px}
+th{font-size:12px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#6b7590;text-align:left;padding:0 0 10px;border-bottom:1px solid #e3e8f2}
+td{font-size:15px;color:#1f2a44;padding:13px 0;border-bottom:1px solid #eef1f7}
+td.r,th.r{text-align:right;padding-left:12px;font-variant-numeric:tabular-nums}
+tr.total td{font-weight:600;color:#163e80;border-top:2px solid #163e80;border-bottom:none;padding:14px 0 0}
+tr.total td.r{font-size:16px;font-weight:700}
+.btn{display:block;box-sizing:border-box;width:100%;background:#2563eb;color:#fff;text-align:center;text-decoration:none;font-size:15px;font-weight:600;font-family:inherit;padding:14px 24px;border:none;border-radius:10px;cursor:pointer}
+.muted{font-size:13px;line-height:1.6;color:#8a93a8}
+.note{margin:24px 0 0;padding-top:20px;border-top:1px solid #eef1f7;font-size:13px;line-height:1.6;color:#8a93a8}
+.box{background:#f6f8fc;border:1px solid #e3e8f2;border-radius:10px;padding:16px 20px;margin:0 0 8px}
+.box p{margin:0;font-size:14px}
+.trust{display:flex;justify-content:center;align-items:center;gap:7px;margin-top:20px;padding-top:18px;border-top:1px solid #eef1f7;font-size:13px;color:#6b7590}
+.site{margin:22px 0 0;font-size:13px;color:#8a93a8}
+.site a{color:#6b7590}
+@media (max-width:480px){body{padding:24px 12px 20px}.card{padding:28px 22px 24px}}
+</style></head><body><div class='page'>";
+		print "<img class='logo' src='../../img/SaldiMainLogo.png' alt='Saldi'>";
+		print "<div class='" . $cardClass . "'>" . $bodyHtml . "</div>";
+		print "<p class='site'>" . htmlspecialchars(STRIPE_PAGE_SENDER, ENT_QUOTES, 'UTF-8')
+			. " &middot; <a href='mailto:" . htmlspecialchars(STRIPE_PAGE_SUPPORT, ENT_QUOTES, 'UTF-8') . "'>"
+			. htmlspecialchars(STRIPE_PAGE_SUPPORT, ENT_QUOTES, 'UTF-8') . "</a></p>";
+		print "</div></body></html>";
+		exit;
+	}
+
+	// 56px tinted circle with a stroke icon: ok (green check), stop (grey cross),
+	// info (blue speech bubble), warn (amber info mark).
+	function stripe_page_badge($kind) {
+		$icons = [
+			'ok'   => "<svg width='28' height='28' viewBox='0 0 24 24' fill='none' stroke='#16a34a' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M20 6L9 17l-5-5'/></svg>",
+			'stop' => "<svg width='28' height='28' viewBox='0 0 24 24' fill='none' stroke='#64748b' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><circle cx='12' cy='12' r='9'/><path d='M15 9l-6 6M9 9l6 6'/></svg>",
+			'info' => "<svg width='28' height='28' viewBox='0 0 24 24' fill='none' stroke='#2563eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.8-.85L3 20l1.1-5.2a8.1 8.1 0 0 1-.9-3.7A8.38 8.38 0 0 1 11.7 2.8h.8a8.35 8.35 0 0 1 8.5 8.2z'/></svg>",
+			'warn' => "<svg width='28' height='28' viewBox='0 0 24 24' fill='none' stroke='#d97706' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='12' cy='12' r='9'/><path d='M12 8v4.5'/><circle cx='12' cy='16' r='0.5' fill='#d97706'/></svg>",
+		];
+		if (!isset($icons[$kind])) $kind = 'warn';
+		return "<div class='badge " . $kind . "'>" . $icons[$kind] . "</div>";
+	}
+
+	// Centered status card: badge, headline, paragraphs, optional raw extra
+	// (button/contact box - CALLER escapes), muted note under a divider.
+	function stripe_status_page($status, $kind, $headline, $texts, $extraHtml = '', $note = 'Din faktura er stadig gyldig og kan betales som hidtil.') {
+		$h = stripe_page_badge($kind);
+		$h .= "<h1>" . htmlspecialchars($headline, ENT_QUOTES, 'UTF-8') . "</h1>";
+		foreach ((array)$texts as $t) $h .= "<p>" . htmlspecialchars($t, ENT_QUOTES, 'UTF-8') . "</p>";
+		if ($extraHtml !== '') $h .= $extraHtml;
+		if ($note !== '') $h .= "<p class='note'>" . htmlspecialchars($note, ENT_QUOTES, 'UTF-8') . "</p>";
+		stripe_page($headline, $h, $status, true);
+	}
+}


### PR DESCRIPTION
## Hvorfor denne PR
#488 blev merged ind i `feature/stripe-debtor-optout` EFTER at den branch allerede var squash-merged til master (#485, kl. 10:42). GitHubs automatiske retarget sker kun når base-branchen slettes - det blev den ikke - så #488's ændringer nåede aldrig master. Denne PR er en ren cherry-pick af #488's squash-commit (975a5ba3) ovenpå master. Ingen nye ændringer.

## Indhold (= #488, review'et og godkendt af SirRolin)
- Fælles side-skal `includes/stripeIncludes/stripePage.php` til de offentlige abonnementssider (logo, hvidt kort, footer)
- Nyt design på `subscribe.php` (bekræftelse/park/fejl), `tak.php`, `afbrudt.php` - kun præsentation, guard-kæde/POST-flow/HTTP-koder urørte
- Styled mail-CTA: `subscriptionLinkHtml()` knap-blok i stedet for nøgent anker; AltBody anker-udfladning også i oldSendMail.php
- Ny guard: debitor med aktivt/trialing/past_due abonnement får ingen tilmeldingsknap på fornyelsesfakturaer

## Verifikation
- Cherry-pick uden konflikter; `php -l` grøn på alle 7 filer i #488's egen test (lokal docker, test_12)
- Live-røgtesten i dag (ordre 17176 fra master) viste at mailer-hook + link virker - denne PR giver linket den styled knap og kunde-siderne det nye design

🤖 Generated with [Claude Code](https://claude.com/claude-code)