### PR TITLE
Fix cash journal shortcut letters crashing the VAT lookup (JOB-081)

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -65,6 +65,8 @@
 // 20260812 LOE .kassekladde-scroll-container; increased the subtraction in height to leave more room for the footer buttons.
 // 20260812 CX/PHR - Preserve and display the journal line VAT code; apply account default VAT when the account changes.
 // 20260819 CX/PHR - Synchronize VAT exemption with both VAT fields and confirm intentional one-sided VAT.
+// 20260820 Sawaneh Shortcut letters (genvej) in debit/credit crashed the VAT lookup with a numeric
+//                  SQL error; non-numeric input is now resolved via genvej before querying kontonr.
 
 ob_start(); //Starter output buffering  
 
@@ -162,6 +164,16 @@ function lookup_account_vat_code($account_no, $account_type, $regnaar, $vat_code
 
     if ($account_no === '' || ($account_type !== '' && $account_type !== 'F')) {
         return '';
+    }
+    if (!is_numeric($account_no)) {
+        if (strlen($account_no) != 1) {
+            return '';
+        }
+        $qtxt = "select kontonr from kontoplan where genvej='" . db_escape_string(strtoupper($account_no)) . "' and regnskabsaar='" . db_escape_string($regnaar) . "'";
+        if (!$row = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+            return '';
+        }
+        $account_no = trim($row['kontonr']);
     }
     $qtxt = "select moms from kontoplan where kontonr='" . db_escape_string($account_no) . "' and regnskabsaar='" . db_escape_string($regnaar) . "'";
     $query = db_select($qtxt, __FILE__ . " linje " . __LINE__);

--- a/includes/db_query.php
+++ b/includes/db_query.php
@@ -37,6 +37,8 @@
 // 20260804 SZ transaktion(): only reset $db_modify_fejl on the outermost 'begin' (track nesting
 //             depth), so bogfor()'s own inner begin/commit no longer erases a failure recorded
 //             by the caller's outer transaction before bogfor() ran (SD-595)
+// 20260820 Sawaneh The fallback alert text used the HTML entity &aelig;, which JS alert() shows
+//                  literally; replaced with a literal æ like the rest of the string
 
 if (!function_exists('get_relative')) {
     function get_relative() {
@@ -239,7 +241,7 @@ if (!function_exists('db_modify')) {
 					#mysqli_query($connection, "ROLLBACK");
 				#}
 						
-				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset h&aelig;ndelse, kontakt salditeamet på telefon 4690 2208";
+				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset hændelse, kontakt salditeamet på telefon 4690 2208";
 				if ($webservice) {
 					global $db_modify_fejl; #20260729 SZ surface write failures so posting-path callers can detect a failed statement even though they don't check this return value (SD-595)
 					$db_modify_fejl = true;
@@ -326,12 +328,12 @@ if (!function_exists('db_select')) {
 					fwrite($ff,date("U")."\n");
 					fclose($ff);
 				} 
-				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset h&aelig;ndelse, kontakt salditeamet på telefon 4690 2208"; 
+				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset hændelse, kontakt salditeamet på telefon 4690 2208";
 				if (strpos($spor,'sqlquery_io')) echo "$errtxt<br>";
 				alert("$alerttekst");
 			} else {
 				#	$customAlertText saettes i connect.php;
-				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset h&aelig;ndelse, kontakt salditeamet på telefon 4690 2208"; 
+				(isset($customAlertText))?$alerttekst=$customAlertText:$alerttekst="Uforudset hændelse, kontakt salditeamet på telefon 4690 2208";
 				echo $fejltxt; 
 				alert("$alerttekst");
 				exit;


### PR DESCRIPTION
## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VAT lookups now correctly resolve valid single-character account shortcuts.
  * Invalid or unresolved shortcuts no longer produce incorrect VAT results.
  * Database error alerts now display the Danish character “æ” correctly instead of showing HTML encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->