### PR TITLE
Fix: Kontokort1 crash/Kasseklade lockup and cross-report creditor bal…

### DIFF
--- a/finans/kontokort_standalone.php
+++ b/finans/kontokort_standalone.php
@@ -25,6 +25,9 @@
 // ----------------------------------------------------------------------
 //
 //20260429 LOE Created standalone version of kontokort repoort for easy navigation
+//20260824 CL/SZ Cast konto_fra/konto_til to int - unescaped GET values hit the
+//                numeric(15,0) kontonr columns and threw "invalid input syntax
+//                for type numeric" (SST-672)
 @session_start();
 $s_id = session_id();
 
@@ -44,8 +47,8 @@ $aar_fra     = if_isset($_GET, null, 'aar_fra');
 $aar_til     = if_isset($_GET, null, 'aar_til');
 $dato_fra    = if_isset($_GET, null, 'dato_fra');
 $dato_til    = if_isset($_GET, null, 'dato_til');
-$konto_fra   = if_isset($_GET, null, 'konto_fra');
-$konto_til   = if_isset($_GET, null, 'konto_til');
+$konto_fra   = (int) if_isset($_GET, null, 'konto_fra');
+$konto_til   = (int) if_isset($_GET, null, 'konto_til');
 $rapportart  = if_isset($_GET, null, 'rapportart');
 $ansat_fra   = if_isset($_GET, null, 'ansat_fra');
 $ansat_til   = if_isset($_GET, null, 'ansat_til');

--- a/includes/db_query.php
+++ b/includes/db_query.php
@@ -39,6 +39,11 @@
 //             by the caller's outer transaction before bogfor() ran (SD-595)
 // 20260820 Sawaneh The fallback alert text used the HTML entity &aelig;, which JS alert() shows
 //                  literally; replaced with a literal æ like the rest of the string
+// 20260824 CL/SZ db_select(): ROLLBACK the connection on a Postgres query error - reproduced
+//                that without it, one failed query inside an open transaction ("current
+//                transaction is aborted...") silently fails every later query on that same
+//                connection for the rest of the request; confirmed harmless when no
+//                transaction is open (SST-672)
 
 if (!function_exists('get_relative')) {
     function get_relative() {
@@ -285,7 +290,10 @@ if (!function_exists('db_select')) {
 			$qtext = str_replace(' like ', ' ilike ', $qtext);
 			$query = pg_query($use_connection, $qtext);
 			$errtxt = pg_last_error($use_connection);
-			if ($errtxt) error_log("db_select failed: $qtext");
+			if ($errtxt) {
+				error_log("db_select failed: $qtext");
+				pg_query($use_connection, "ROLLBACK"); // 20260824 CL/SZ a failed query inside an open transaction otherwise poisons every later query on this connection for the rest of the request ("current transaction is aborted..."); harmless no-op outside a transaction (SST-672)
+			}
 		}
 
 		if ($errtxt)	{		

--- a/includes/reportFunc/accountChart.php
+++ b/includes/reportFunc/accountChart.php
@@ -28,6 +28,9 @@
 // 20251002 MS Removed "Width=80%" and added padding to allow the Print/Email buttons to have the intended size, while still centering the text
 // 20260423 PHR Corrected call to text number for text
 // 20260429 PHR Removed 'unalign' from Openpost / AllAcount
+// 20260824 CL/SZ Restore caller's dato_fra/dato_til (not just konto_fra/til)
+//                when the saved KRV/DRV filter overwrites them - detail view
+//                was silently running against a stale date range (SST-672)
 
 if (!function_exists('accountchart')) {
 function accountchart($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,$kontoart) {
@@ -83,6 +86,8 @@ if ($bruger_id == -1) echo "$qtxt<br>";
 	else $returnpath="../debitor/";
 
 	$tmp=$konto_fra;
+	$tmpDatoFra=$dato_fra;
+	$tmpDatoTil=$dato_til;
 	($kontoart=='D')?$tekst='DRV':$tekst='KRV';
 	$qtxt = "select * from grupper where art = '$tekst' and kodenr = '$bruger_id'";
 	if(isset($_GET['returside'])) $returside= $_GET['returside'];
@@ -105,6 +110,8 @@ if ($bruger_id == -1) echo "$qtxt<br>";
 		$returside="rapport.php?rapportart=$rapportart"; //&submit=ok&regnaar=$regnaar&dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til";
 		$konto_fra=$tmp;
 		$konto_til=$konto_fra;
+		$dato_fra=$tmpDatoFra;
+		$dato_til=$tmpDatoTil;
 	} elseif (!$returside) $returside="rapport.php?dato_fra=$dato_fra&dato_til=$dato_til&konto_fra=$konto_fra&konto_til=$konto_til";
 
 	if ($dato_fra && $dato_til) {

--- a/includes/reportFunc/showOpenPosts.php
+++ b/includes/reportFunc/showOpenPosts.php
@@ -38,6 +38,10 @@
 //                  the other four aging columns.
 // 20260812 Sawaneh Review: the firm-name search folds case with mb_strtolower/mb_strtoupper,
 //                  so names containing ae, oe or aa match regardless of case.
+// 20260824 CL/SZ Re-derive valutakurs from the valuta table when a foreign-
+//                currency row has kurs=100 (uncaptured rate), instead of
+//                treating it as 1:1 DKK parity - was producing DKK totals
+//                wildly out of sync with kontokort/accountChart (SST-672)
 
 if (!function_exists('openpost_account_filter')) {
 /**
@@ -284,8 +288,17 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 				$aligned = 0;
 			}
 			if (!$aligned) $accountAligned = 0;
-      if ((float)$r['valutakurs'] && $r['valuta']!='-') {
-				$kontrolAmount=afrund($r['amount']*$r['valutakurs']/100,2); //2012.03.30 afrunding rettet til 2 (Ørediff hos saldi_390) 
+			if ($r['valuta']) $valuta=$r['valuta']; // <- 2009.05.05
+			else $valuta=$baseCurrency;
+			if ($r['valutakurs']) $valutakurs=$r['valutakurs'];
+			else $valutakurs=100;
+			if ($valuta!=$baseCurrency && $valutakurs==100) { // 20260824 CL/SZ kurs=100 on a foreign-currency row is the "no real rate captured" placeholder, not parity - re-derive it like accountChart.php/generalLedger.php do (SST-672)
+				$r3=db_fetch_array(db_select("select kodenr from grupper where box1 = '$valuta' and art='VK'",__FILE__ . " linje " . __LINE__));
+				$r3=db_fetch_array(db_select("select kurs from valuta where gruppe ='$r3[kodenr]' and valdate <= '$r[transdate]' order by valdate desc",__FILE__ . " linje " . __LINE__));
+				if ($r3['kurs']) $valutakurs=$r3['kurs']*1;
+			}
+			if ((float)$valutakurs && $r['valuta']!='-') {
+				$kontrolAmount=afrund($r['amount']*$valutakurs/100,2); //2012.03.30 afrunding rettet til 2 (Ørediff hos saldi_390)
 			} else {
 				$kontrolAmount=afrund($r['amount'],2);
 			}
@@ -306,11 +319,7 @@ function vis_aabne_poster($dato_fra,$dato_til,$konto_fra,$konto_til,$rapportart,
 				$oid=$r['id'];
 
 				$transdate=$r['transdate'];
-				
-				if ($r['valuta']) $valuta=$r['valuta']; // <- 2009.05.05
-				else $valuta=$baseCurrency;
-				if ($r['valutakurs']) $valutakurs=$r['valutakurs'];
-				else $valutakurs=100;
+
 #				$accountAligned="0";
 				($valuta==$baseCurrency)?$amount=afrund($r['amount'],2):$amount=afrund($r['amount'],3); //2012.04.03 se saldi_
 				if (!$forfaldsdag && $kontoart=='D' && $amount < 0) $forfaldsdag=$r['transdate'];


### PR DESCRIPTION
## Summary
Two reported issues on the Medshop account (saldi_390), bundled in one ticket:

1. **Kontokort1 crash + Kasseklade lockup** — opening the Kontokort1 account report could
   trigger a generic error popup, after which the cash journal (Kasseklade) became
   inaccessible for the rest of the session.
2. **Creditor balance mismatches across reports** — for the same foreign-currency vendor
   (EUR/USD), three different creditor report screens showed three different balances for
   the same period.

These are two independent root causes in unrelated parts of the codebase, bundled here
because they were reported together in the same customer ticket.

## What are the changes about?
### Problem 1 — Kontokort1 crash / Kasseklade lockup
**Root cause:** the report page reads the account-range filter directly from the URL
without validating it's numeric. A missing or malformed value (stale bookmark, browser
back/forward, a link missing a parameter) was interpolated directly into a SQL query
against a numeric-only column. Postgres rejected the query, and the app surfaced only a
generic "something broke" popup instead of handling it. Confirmed by reproducing the exact
database error locally and confirming the fix stops it.

- Cast the account-range filter to a number before use, so a blank/malformed value becomes
  `0` instead of reaching SQL unvalidated.
- **Related defensive fix (not confirmed as the root cause of the Kasseklade lockup):**
  found that a query failure mid-way through a multi-step database operation causes every
  subsequent query to silently fail until the connection is reset — which never happened.
  Added that reset. This bug is real and verified in isolation, but it could **not** be
  confirmed that this specific report actually triggers that multi-step scenario — a good
  defensive fix regardless, but it may not fully explain the reported Kasseklade lockup.

### Problem 2 — creditor balance mismatches
**Root cause, two separate bugs:**
1. The "click the vendor number for details" report view was quietly reusing a leftover
   date range from a previously run report, instead of the date range actually selected on
   screen.
2. The summary report trusted a stored exchange rate even when that rate was an unrecorded
   placeholder, instead of looking up the real historical rate the other two report screens
   already correctly use — mixing foreign-currency amounts with DKK amounts as if equal.

- Fixed the detail view to retain and use the correct, currently selected date range.
- Fixed the summary report to use the same real historical-exchange-rate lookup already used
  correctly by the other two report screens.

## Files Changed
- finans/kontokort_standalone.php — Kontokort1 report account-filter validation (Problem 1)
- includes/db_query.php — connection reset after mid-transaction query failure (Problem 1)
- includes/reportFunc/accountChart.php — creditor detail view date-range fix (Problem 2)
- includes/reportFunc/showOpenPosts.php — creditor summary report exchange-rate fix (Problem 2)

## How to Test

### Problem 1
1. Open the Kontokort1 report for account 06509 with a deliberately missing/malformed
   account-range parameter — verify no crash, sensible default behavior instead.
2. Confirm valid filter values still work as before.
3. Trigger a query failure mid multi-step DB operation and verify the connection resets
   correctly rather than silently breaking subsequent queries.
4. Attempt to reproduce the original Kasseklade lockup end-to-end and note whether the fix
   resolves it in practice.

### Problem 2
1. Open the creditor overview, detail view, and summary report for the same
   foreign-currency vendor (e.g. creditor 1104 or 1011) over the same date range — verify
   all three now agree.
2. Run the detail view immediately after an unrelated report with different dates — verify
   it uses its own correct date range.
3. For a vendor/period with an unrecorded placeholder exchange rate, verify the summary
   report performs a real historical rate lookup instead.
4. Confirm DKK-denominated vendors are unaffected by either change.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Malformed/missing account-range filter on Kontokort1 | No crash; defaults to 0 instead of reaching SQL unvalidated |
| 2 | Valid filter values | Report behaves exactly as before |
| 3 | Query failure mid multi-step DB operation | Connection resets; subsequent queries not silently broken |
| 4 | Same foreign-currency vendor across overview/detail/summary reports | All three show the same balance |
| 5 | Detail view run after an unrelated report with different dates | Uses its own currently selected date range |
| 6 | Summary report with unrecorded placeholder exchange rate | Uses real historical rate lookup |
| 7 | DKK-denominated vendors | Unaffected |

## Not Confirmed
- Whether the Kontokort1 report is the actual trigger for the reported Kasseklade lockup —
  the connection-reset fix is a genuine, verified bug fix, but its connection to that
  specific symptom is unconfirmed.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
