### PR TITLE
Fix: MB-16 single-label print produces an extra blank label (MB-16)

### DIFF
--- a/lager/labelprint_includes/newlabel.php
+++ b/lager/labelprint_includes/newlabel.php
@@ -33,6 +33,11 @@
 // 20260824 CL/NTR Track mit salg rows per cell in $hasMyLabelRow instead of one flag per print, and
 //                 reset the cell arrays per label, so each cell falls back individually and no data
 //                 leaks from the previous label on the sheet.
+// 20260826 CL/SZ  Printing a specific label (a plain item-card print, or one entry of a printIds
+//                 batch) now renders exactly one cell instead of the template's full rows x cols
+//                 sheet grid - only a real full-sheet ($page, no specific id) print still uses the
+//                 whole grid. Fixes a single-label print producing an extra, effectively blank
+//                 second label (MB-16).
 
 $line=explode("\n",$txt);
 $top=$txt='';
@@ -97,8 +102,19 @@ if (($varenr || $stregkode) && (!$account || !$condition)) {
 $fp=fopen($filename,'w');
 fwrite ($fp, $top);
 for ($l=0;$l<count($labels);$l++) {
-	for ($a=1;$a<=$rows;$a++) {
-		for ($b=1;$b<=$cols;$b++) {
+	// $rows/$cols describe the physical sheet layout, meant to be filled with
+	// ONE mylabel row per (row,col) - see the $page branch below, the only one
+	// that legitimately populates more than cell (1,1). Printing a specific
+	// label ($labels[$l] set - a plain item-card print, or one entry of a
+	// printIds batch) must render exactly that one cell, not the whole sheet -
+	// otherwise every other cell in the grid renders with fallback/blank data
+	// nobody asked for (MB-16: a single-label print produced a second,
+	// effectively blank label). 20260826 CL/SZ.
+	$sheetPrint = (!$labels[$l] && $page && $account && $condition);
+	$cellRows = $sheetPrint ? $rows : 1;
+	$cellCols = $sheetPrint ? $cols : 1;
+	for ($a=1;$a<=$cellRows;$a++) {
+		for ($b=1;$b<=$cellCols;$b++) {
 			$barcode[$a][$b]=NULL;
 			$description[$a][$b]=NULL;
 			$price[$a][$b]=NULL;
@@ -178,8 +194,8 @@ for ($l=0;$l<count($labels);$l++) {
 		elseif ($varenr) $img=barcode($varenr);
 	}
 	if (!$brotherTD) fwrite ($fp, "<div id=\"main\">\n");
-	for ($a=1;$a<=$rows;$a++) {
-		for ($b=1;$b<=$cols;$b++) {
+	for ($a=1;$a<=$cellRows;$a++) {
+		for ($b=1;$b<=$cellCols;$b++) {
 			$labelTxt=$txt;
 			$dkkpris=str_replace(',00',',-',dkdecimal($salgspris,2));
 			# Uden mit salg data - et print uden konto - ville labelen komme ud tom, så

--- a/tests/characterization/lager/labelprint_includes/NewlabelCharacterizationTest.test.php
+++ b/tests/characterization/lager/labelprint_includes/NewlabelCharacterizationTest.test.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CHARACTERIZATION suite for lager/labelprint_includes/newlabel.php, pinning
+ * the MB-16 fix: printing a SPECIFIC label (a plain item-card print, or one
+ * entry of a printIds batch) must render exactly one cell, never the
+ * template's full rows x cols sheet grid. Before the fix, a 2-column
+ * template turned a single requested label into two - the second rendered
+ * with fallback/blank data nobody asked for.
+ *
+ * newlabel.php is a legacy top-level script (no functions to unit-test in
+ * isolation): it reads globals ($id/$printIds/$page/$account/...), queries
+ * the mit-salg (mylabel) table directly, and writes its HTML output to
+ * $filename. This suite drives it exactly as lager/labelprint.php does,
+ * against a real Postgres tenant, mirroring the reproduction used to
+ * root-cause MB-16.
+ *
+ * Requires a local Postgres reachable with includes/connect.php's checked-in
+ * dev credentials (localhost/postgres), and a "saldi_chartest" database
+ * already cloned from the saldidb template - the same tenant convention
+ * used by tests/characterization/order-creation on the SD-600 branch.
+ */
+final class NewlabelCharacterizationTest extends TestCase
+{
+    private const TENANT_DB = 'saldi_chartest';
+    private const KONTONR = '87654321';
+
+    // includes/connect.php's own checked-in dev defaults. Not read back off
+    // its globals: connect.php is require_once'd from inside this method,
+    // so its top-level `$sqhost = ...`-style assignments land in THIS
+    // method's local scope, not the true global scope db_connect() reads -
+    // reusing them via `global $sqhost` would silently pull undefined
+    // globals and leave the connection on connect.php's own default (the
+    // schema-less "saldidb" master, which has none of the tenant tables
+    // below).
+    private const PG_HOST = 'localhost';
+    private const PG_USER = 'postgres';
+    private const PG_PASS = 'saul3112';
+
+    private static string $repoRoot;
+    private static string $originalCwd;
+    private static int $accountId;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$repoRoot = dirname(__DIR__, 4);
+        self::$originalCwd = getcwd();
+
+        $_SERVER['REQUEST_URI'] = '/saldi/lager/labelprint.php';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        // newlabel.php and db_query.php's own logging both resolve paths
+        // relative to cwd via get_relative() - stay inside lager/ for the
+        // whole test lifecycle (matching how labelprint.php always runs),
+        // restored only in tearDownAfterClass.
+        chdir(self::$repoRoot . '/lager');
+        ob_start();
+        require_once self::$repoRoot . '/includes/connect.php';
+        require_once self::$repoRoot . '/includes/std_func.php';
+        ob_end_clean();
+
+        global $db, $connection;
+        $db = self::TENANT_DB;
+        $connection = db_connect(self::PG_HOST, self::PG_USER, self::PG_PASS, $db);
+
+        db_modify("delete from adresser where kontonr = '" . self::KONTONR . "'", __FILE__ . ' linje ' . __LINE__);
+        db_modify(
+            "insert into adresser (kontonr, art, firmanavn) values ('" . self::KONTONR . "', 'D', 'MB-16 characterization konto')",
+            __FILE__ . ' linje ' . __LINE__
+        );
+        $row = db_fetch_array(db_select(
+            "select id from adresser where kontonr = '" . self::KONTONR . "'",
+            __FILE__ . ' linje ' . __LINE__
+        ));
+        self::$accountId = (int)$row['id'];
+
+        // newlabel.php resolves the consignor's own item card via
+        // `varenr like 'kn___<kontonr>'` (mit-salg "new condition" naming
+        // convention) even when printing by mylabel id - seed a matching
+        // item so that lookup succeeds exactly as it would in production.
+        db_modify("delete from varer where varenr = 'knXXX" . self::KONTONR . "'", __FILE__ . ' linje ' . __LINE__);
+        db_modify(
+            "insert into varer (varenr, beskrivelse, gruppe, salgspris, kostpris) values " .
+            "('knXXX" . self::KONTONR . "', 'MB-16 characterization item', 0, '1.00', '0.50')",
+            __FILE__ . ' linje ' . __LINE__
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        db_modify('delete from mylabel where account_id = ' . self::$accountId, __FILE__ . ' linje ' . __LINE__);
+        db_modify("delete from adresser where kontonr = '" . self::KONTONR . "'", __FILE__ . ' linje ' . __LINE__);
+        db_modify("delete from varer where varenr = 'knXXX" . self::KONTONR . "'", __FILE__ . ' linje ' . __LINE__);
+        chdir(self::$originalCwd);
+    }
+
+    protected function setUp(): void
+    {
+        db_modify('delete from mylabel where account_id = ' . self::$accountId, __FILE__ . ' linje ' . __LINE__);
+    }
+
+    /**
+     * A two-column template ($cols=2, $rows=1) with a single mit-salg row
+     * for the requested printId. Before the MB-16 fix this rendered 2 <p>
+     * blocks (cell (1,2) blank on barcode/date); after the fix, exactly 1.
+     */
+    public function testPrintingOneSpecificLabelRendersExactlyOneCellOnAMultiColumnTemplate(): void
+    {
+        db_modify(
+            'insert into mylabel (account_id, price, description, barcode, hidden, created) values ' .
+            '(' . self::$accountId . ", 50, 'MB-16 consignor item', 'BC0001', FALSE, '010126')",
+            __FILE__ . ' linje ' . __LINE__
+        );
+        $labelRow = db_fetch_array(db_select(
+            'select id from mylabel where account_id = ' . self::$accountId . ' order by id limit 1',
+            __FILE__ . ' linje ' . __LINE__
+        ));
+        $requestedId = (int)$labelRow['id'];
+
+        $html = $this->renderLabel([
+            'txt' => $this->twoColumnTemplate(),
+            'account' => self::KONTONR,
+            'condition' => 'new',
+            'printIds' => (string)$requestedId,
+        ]);
+
+        self::assertSame(1, preg_match_all('/<p>/', $html), 'expected exactly one rendered label cell for one requested id');
+        self::assertStringContainsString('MB-16 consignor item', $html);
+    }
+
+    /**
+     * Two distinct requested printIds against the same two-column template
+     * must render exactly 2 cells (one per requested id), not 4 (2 per id).
+     */
+    public function testPrintingTwoSpecificLabelsRendersExactlyTwoCells(): void
+    {
+        db_modify(
+            'insert into mylabel (account_id, price, description, barcode, hidden, created) values ' .
+            '(' . self::$accountId . ", 50, 'First consignor item', 'BC0001', FALSE, '010126'), " .
+            '(' . self::$accountId . ", 75, 'Second consignor item', 'BC0002', FALSE, '020126')",
+            __FILE__ . ' linje ' . __LINE__
+        );
+        $rows = db_select(
+            'select id from mylabel where account_id = ' . self::$accountId . ' order by id',
+            __FILE__ . ' linje ' . __LINE__
+        );
+        $ids = [];
+        while ($r = db_fetch_array($rows)) {
+            $ids[] = $r['id'];
+        }
+
+        $html = $this->renderLabel([
+            'txt' => $this->twoColumnTemplate(),
+            'account' => self::KONTONR,
+            'condition' => 'new',
+            'printIds' => implode(',', $ids),
+        ]);
+
+        self::assertSame(2, preg_match_all('/<p>/', $html), 'expected exactly two rendered label cells for two requested ids');
+    }
+
+    /**
+     * A single-column template ($cols=1, $rows=1) already only had one cell
+     * to begin with - this must stay unchanged by the fix (regression guard
+     * on the common case).
+     */
+    public function testPrintingOneSpecificLabelOnASingleColumnTemplateIsUnaffected(): void
+    {
+        db_modify(
+            'insert into mylabel (account_id, price, description, barcode, hidden, created) values ' .
+            '(' . self::$accountId . ", 50, 'MB-16 consignor item', 'BC0001', FALSE, '010126')",
+            __FILE__ . ' linje ' . __LINE__
+        );
+        $labelRow = db_fetch_array(db_select(
+            'select id from mylabel where account_id = ' . self::$accountId . ' order by id limit 1',
+            __FILE__ . ' linje ' . __LINE__
+        ));
+
+        $html = $this->renderLabel([
+            'txt' => "\$cols=1;\n\$rows=1;\n\$txtlen=50;\n<top>\n<div id=\"main\">\n</top>\n\n" .
+                "<p>\n\$minbeskrivelse<br>\nPris \$minpris<br>\nStregkode: \$barcode<br>\n</p>\n\n" .
+                "<bottom>\n</div>\n/bottom;",
+            'account' => self::KONTONR,
+            'condition' => 'new',
+            'printIds' => (string)(int)$labelRow['id'],
+        ]);
+
+        self::assertSame(1, preg_match_all('/<p>/', $html));
+    }
+
+    private function twoColumnTemplate(): string
+    {
+        return "\$cols=2;\n\$rows=1;\n\$txtlen=50;\n<top>\n<div id=\"main\">\n</top>\n\n" .
+            "<p>\n\$minbeskrivelse<br>\nPris \$minpris<br>\nStregkode: \$barcode<br>\nDato: \$createdate<br>\n</p>\n\n" .
+            "<bottom>\n</div>\n/bottom;";
+    }
+
+    /**
+     * @param array{txt: string, account: string, condition: string, printIds: string} $args
+     */
+    private function renderLabel(array $args): string
+    {
+        $txt = $args['txt'];
+        $account = $args['account'];
+        $condition = $args['condition'];
+        $printIds = $args['printIds'];
+
+        $id = null;
+        $labelId = null;
+        $img = null;
+        $stregkode = null;
+        $varenr = null;
+        $page = null;
+        $qty = null;
+        $brotherTD = 0;
+        $filename = tempnam(sys_get_temp_dir(), 'mb16_char_') . '.html';
+
+        include self::$repoRoot . '/lager/labelprint_includes/newlabel.php';
+
+        $html = file_get_contents($filename);
+        unlink($filename);
+
+        return $html;
+    }
+}


### PR DESCRIPTION
# Summary
Printing a single label (a plain item-card print, or one entry of a multi-label `printIds`
batch) printed two labels instead of one — the first correct, the second blank.

## Related tickets — deliberate scoping note
MB-16, MB-17, and MB-18 are all POS label bugs flagged as likely sharing a root cause in the
label-settings save handler. Having root-caused MB-16, its cause (a render-loop grid-sizing
bug) is distinct from what MB-17 (edits not persisted) and MB-18 (saving one setting clobbers
the rest) describe, which point at the settings-save path rather than the print-render path.
This PR addresses MB-16 only; MB-17/MB-18 are not touched here and should still be
investigated as their own (possibly related) issue.

## Root Cause
`lager/labelprint_includes/newlabel.php`'s render loop always iterated the label template's
full `rows × cols` sheet grid, regardless of what kind of print was requested. That grid is
only meant to be filled for a genuine full-sheet batch print (`$page` mode, where each grid
cell gets a distinct row from the database). For a single-item or single-`printId` print, the
real data only ever fills cell (1,1) — but the loop still rendered every other cell in the
grid, and those extra cells had no data, so they rendered blank.

On a 2-column template, this turned 1 requested label into 2 (1 real + 1 blank); on a 2-item
batch, 2 requested became 4.

## What are the changes about?
- Added a `$sheetPrint` check: only a genuine full-sheet `$page` print (no specific label
  id/printId) uses the full `rows × cols` grid. Any specific-label print now renders exactly
  `1 × 1` — just the cell it actually has data for.
- Applied to both loops in the file (the reset loop and the render loop).
- Appended a file-history comment per repo convention.

## Files Changed
- lager/labelprint_includes/newlabel.php — the fix (two loop-bound changes + history comment)
- tests/characterization/lager/labelprint_includes/NewlabelCharacterizationTest.test.php (new) — regression test (3 cases) pinning this behavior

## Not Touched (flagged, not fixed)
Two pre-existing, unrelated bugs found during investigation:
- A stale `mylabel.condition`/`state` column-rename mismatch.
- Dead `<bottom>` template parsing that's never written to output.

Neither is in scope for MB-16; flagging for a separate ticket.

## How to Test
1. In the local docker stack, print a single item-card label — verify exactly 1 label is
   produced, with no trailing blank label.
2. Print a 2-item `printIds` batch — verify exactly 2 labels are produced, not 4.
3. Print a genuine full-sheet `$page` batch print — verify it still correctly fills the full
   `rows × cols` grid as before (no regression on the actual batch-print path).
4. Run the new characterization test
   (`NewlabelCharacterizationTest.test.php`) and confirm all 3 cases pass.
5. Run the full characterization suite and confirm 29/29 pass (no side effects elsewhere).
6. Revert the fix locally (`git stash`) and confirm the tests fail exactly as expected (2
   rendered instead of 1, 4 instead of 2) — proving the test actually pins this bug.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Single item-card print | Exactly 1 label produced, no blank label |
| 2 | Multi-label printIds batch (e.g. 2 items) | Exact requested count produced, no extras |
| 3 | Genuine full-sheet $page batch print | Full rows × cols grid still fills correctly (no regression) |

## Verification
- Reverted the fix and re-ran the test — failed exactly as predicted (2 rendered instead of
  1, 4 instead of 2).
- Restored the fix — confirmed green, plus ran the full characterization suite (29/29) to
  check for side effects.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
