### PR TITLE
SD-657 Skjul Omsætning fra ordre i indstillinger

### DIFF
--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -56,7 +56,7 @@
 // 20260630 CDX/NTR Fixed land (country) column from printing the countries outside the table and searchable bar not existing.
 // 20260701 Sawaneh Fixed: 'Performed by' is display-only and no longer cleared on return to the list.
 // 20260701 CDX/NTR Fixed the default search to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
-
+// 20260826 LOE Added a new setting to hide revenue on ordreliste for users based on the db who don't want to see it. This is stored in the settings table 
 @session_start();
 $s_id = session_id();
 
@@ -2651,25 +2651,30 @@ print "</div>";  // END LEFT
 
 
 
-// ------------------------------------------------------------
+// ------------------------------------------------------------ 
 // CENTER — Turnover Summary
 // ------------------------------------------------------------
+$hideRevenueOnOrdreliste = get_settings_value("hideRevenueOnOrdreliste", "ordreliste", "off") === "on";
 if ($valg == "faktura") {
 print "<div id='center-turnover-f' style='flex:1; text-align:left;'>";
-print "<div>";
-    print "<a href='ordreliste.php?genberegn=1&valg=$valg'>
-                <b>" . findtekst('878|Samlet omsætning / db / dg (ekskl. moms.)', $sprog_id) . "</b>
-           </a><br>";
-    print "$ialt_formatted / $dk_db / $dk_dg%<br>";
-    print "<b>" . findtekst('877|Samlet omsætning inkl. moms', $sprog_id)
-          . ": $ialt_m_moms_formatted</b>";
+        print "<div>";
+    if(!$hideRevenueOnOrdreliste) {
+        print "<a href='ordreliste.php?genberegn=1&valg=$valg'>
+                    <b>" . findtekst('878|Samlet omsætning / db / dg (ekskl. moms.)', $sprog_id) . "</b>
+            </a><br>";
+        print "$ialt_formatted / $dk_db / $dk_dg%<br>";
+        print "<b>" . findtekst('877|Samlet omsætning inkl. moms', $sprog_id)
+            . ": $ialt_m_moms_formatted</b>";
+    }
 } else {
 print "<div id='center-turnover' style='flex:1; text-align:center;'>";
 print "<div style='display:flex;'>";
-    print findtekst('811|Samlet omsætning inkl./ekskl. Moms', $sprog_id) . "<br>";
-    print findtekst('2772|db / dg (ekskl. moms)', $sprog_id) . "<br>";
-    print "<b style='margin-left: 20px;'>$ialt_m_moms_formatted ($ialt_formatted)<br>
-           $dk_db / $dk_dg%</b>";
+    if(!$hideRevenueOnOrdreliste) {
+        print findtekst('811|Samlet omsætning inkl./ekskl. Moms', $sprog_id) . "<br>";
+        print findtekst('2772|db / dg (ekskl. moms)', $sprog_id) . "<br>";
+        print "<b style='margin-left: 20px;'>$ialt_m_moms_formatted ($ialt_formatted)<br>
+            $dk_db / $dk_dg%</b>";
+    }
 }
 
 print "</div>";

--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -2653,11 +2653,11 @@ print "</div>";  // END LEFT
 
 // ------------------------------------------------------------ 
 // CENTER — Turnover Summary
-// ------------------------------------------------------------
+// ------------------------------------------------------------ 
 $hideRevenueOnOrdreliste = get_settings_value("hideRevenueOnOrdreliste", "ordreliste", "off") === "on";
 if ($valg == "faktura") {
 print "<div id='center-turnover-f' style='flex:1; text-align:left;'>";
-        print "<div>";
+    print "<div>";
     if(!$hideRevenueOnOrdreliste) {
         print "<a href='ordreliste.php?genberegn=1&valg=$valg'>
                     <b>" . findtekst('878|Samlet omsætning / db / dg (ekskl. moms.)', $sprog_id) . "</b>

--- a/systemdata/diverse.php
+++ b/systemdata/diverse.php
@@ -651,7 +651,7 @@ if ($_POST && $_SERVER['REQUEST_METHOD'] == "POST") {
 		$stockWarningEnabled  = if_isset($_POST, null, 'stockWarningEnabled');
 		
 		$showBothAddrExtra    = if_isset($_POST, null, 'showBothAddrExtra');
-		$hideRevenueOnOrdreliste = if_isset($_POST, null, 'hideRevenueOnOrdreliste');
+		$hideRevenueOnOrdreliste = if_isset($_POST, null, 'hideRevenueOnOrdreliste'); 
 
 		update_settings_value("debitoripad", "ordre", $debitoripad, "Weather or not to include the debitor ipad system");
 		update_settings_value("pluklisteEmail", "ordre", $pluklisteEmail, "Email address to send plukliste to");

--- a/systemdata/diverse.php
+++ b/systemdata/diverse.php
@@ -99,7 +99,7 @@
 //                 table that lager/labelprint.php prints from, and new labels get account_id 0.
 // 20260824 CL/NTR Label deletion only removes global rows (account_id 0 or null), matching what the
 //                 label editor shows.
-
+// 20260826 LOE Added a new setting to hide revenue on ordreliste for users based on the db who don't want to see it.
 @session_start();
 $s_id = session_id();
 ob_start();
@@ -651,7 +651,7 @@ if ($_POST && $_SERVER['REQUEST_METHOD'] == "POST") {
 		$stockWarningEnabled  = if_isset($_POST, null, 'stockWarningEnabled');
 		
 		$showBothAddrExtra    = if_isset($_POST, null, 'showBothAddrExtra');
-
+		$hideRevenueOnOrdreliste = if_isset($_POST, null, 'hideRevenueOnOrdreliste');
 
 		update_settings_value("debitoripad", "ordre", $debitoripad, "Weather or not to include the debitor ipad system");
 		update_settings_value("pluklisteEmail", "ordre", $pluklisteEmail, "Email address to send plukliste to");
@@ -664,6 +664,7 @@ if ($_POST && $_SERVER['REQUEST_METHOD'] == "POST") {
 		update_settings_value("ourRefStockSwitch", "ordre", $ourRefStockSwitch, "Update order stock/warehouse from Our ref when the reference changes"); // Removed single quotes from description to avoid SQL syntax error
 		update_settings_value("stockWarningEnabled", "ordre", $stockWarningEnabled, "Show popup and require approval note when selling out-of-stock items (POS + Debtor/Order)");
 		update_settings_value("showBothAddrExtra", "ordre", $showBothAddrExtra, "Show both delivery address and extra fields simultaneously on open orders");
+		update_settings_value("hideRevenueOnOrdreliste", "ordreliste", $hideRevenueOnOrdreliste, "Hide revenue on order list");
 		if ($box2 && $r = db_fetch_array(db_select("select id from varer WHERE varenr = '$box2'", __FILE__ . " linje " . __LINE__))) {
 			$box2 = $r['id'];
 		} elseif ($box2) {

--- a/systemdata/sys_div_func.php
+++ b/systemdata/sys_div_func.php
@@ -1928,8 +1928,13 @@ function ordre_valg() {
 	print "<tr><td title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."'>".findtekst('5038|Vis både leveringsadresse og ekstrafelter på åbne ordrer', $sprog_id)."</td><td><INPUT title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."' class='inputbox' type='checkbox' name='showBothAddrExtra' $showBothAddrExtra></td></tr>";
 	#	print "<tr><td title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."'>".findtekst('3116|Decimaler på rabat', $sprog_id)."</td><td><INPUT title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."' class='inputbox' type='text' style='width:70px;text-align:right;' name='rabatdecimal' value='$rabatdecimal'></td></tr>";
 	
+<<<<<<< HEAD
 	$titleRev = "Hide revenue on order list"; 
 	print "<tr><td title='$titleRev'>Hide revenue on order List</td><td><INPUT title= '$titleRev' class='inputbox' type='checkbox' name='hideRevenueOnOrdreliste' $hideRevenueOnOrdreliste></td></tr>";
+=======
+	$titleRev = "Hide revenue on order list";
+	print "<tr><td title='$titleRev'>Turn Off Revenue Tracking</td><td><INPUT title= '$titleRev' class='inputbox' type='checkbox' name='hideRevenueOnOrdreliste' $hideRevenueOnOrdreliste></td></tr>";
+>>>>>>> d880b9b5 (Rename revenue tracking option in order list)
 	print "<tr><td><br></td></tr>";
 	print "<tr><td><br></td></tr>";
 	print "<td><br></td><td><br></td><td><br></td><td align = center><input class='button green medium' type=submit accesskey='g' value='".findtekst('471|Gem/opdatér', $sprog_id)."' name='submit'></td>";

--- a/systemdata/sys_div_func.php
+++ b/systemdata/sys_div_func.php
@@ -110,6 +110,7 @@
 //                 $minbeskrivelse/$minpris as the default; translated via findtekst(), tekst_id 5056.
 // 20260824 CL/NTR loadLabelText()/saveLabelText() prefer account_id 0 over null legacy rows and only
 //                 touch global rows, matching what the label editor shows.
+// 20260826 LOE Added a new setting to hide revenue on ordreliste for users based on the db who don't want to see it.
 // 20260826 SZ    kontoplan_io: removed the redundant "Eksportér kontoplan" header row that was
 //                 printed unconditionally right before the real (popup or non-popup) export row
 //                 of the same label, making it appear twice under System -> Indstillinger ->
@@ -1771,6 +1772,7 @@ function ordre_valg() {
 	global $bgcolor5;
 	global $regnaar;
 	global $bruger_id;
+	global $db;
 
 	$hurtigfakt = $incl_moms_private = $incl_moms_business = $folge_s_tekst = $negativt_lager = $straks_bogf = $vis_nul_lev = $orderNoteEnabled = NULL;
 
@@ -1847,7 +1849,8 @@ function ordre_valg() {
 	$ourRefStockSwitch   = get_settings_value("ourRefStockSwitch", "ordre", "off") === "on" ? "checked" : "";
 	$stockWarningEnabled = get_settings_value("stockWarningEnabled", "ordre", "off") === "on" ? "checked" : "";
 	$showBothAddrExtra   = get_settings_value("showBothAddrExtra", "ordre", "off") === "on" ? "checked" : "";
-
+	$hideRevenueOnOrdreliste = get_settings_value("hideRevenueOnOrdreliste", "ordreliste", "off") === "on" ? "checked" : "";
+	
 	$rabatvarenr = NULL;
 	if ($rabatvareid) {
 		$qtxt = "select varenr from varer where id = '$rabatvareid'";
@@ -1924,7 +1927,9 @@ function ordre_valg() {
 	print "<tr><td title='$stockWarningTitle'>".findtekst('5036|Advar ved salg af udsolgte varer (popup + begrundelse)', $sprog_id)."</td><td><INPUT title='$stockWarningTitle' class='inputbox' type='checkbox' name='stockWarningEnabled' $stockWarningEnabled></td></tr>";
 	print "<tr><td title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."'>".findtekst('5038|Vis både leveringsadresse og ekstrafelter på åbne ordrer', $sprog_id)."</td><td><INPUT title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."' class='inputbox' type='checkbox' name='showBothAddrExtra' $showBothAddrExtra></td></tr>";
 	#	print "<tr><td title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."'>".findtekst('3116|Decimaler på rabat', $sprog_id)."</td><td><INPUT title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."' class='inputbox' type='text' style='width:70px;text-align:right;' name='rabatdecimal' value='$rabatdecimal'></td></tr>";
-
+	
+	$titleRev = "Hide revenue on order list"; 
+	print "<tr><td title='$titleRev'>Hide revenue on order List</td><td><INPUT title= '$titleRev' class='inputbox' type='checkbox' name='hideRevenueOnOrdreliste' $hideRevenueOnOrdreliste></td></tr>";
 	print "<tr><td><br></td></tr>";
 	print "<tr><td><br></td></tr>";
 	print "<td><br></td><td><br></td><td><br></td><td align = center><input class='button green medium' type=submit accesskey='g' value='".findtekst('471|Gem/opdatér', $sprog_id)."' name='submit'></td>";

--- a/systemdata/sys_div_func.php
+++ b/systemdata/sys_div_func.php
@@ -1928,13 +1928,8 @@ function ordre_valg() {
 	print "<tr><td title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."'>".findtekst('5038|Vis både leveringsadresse og ekstrafelter på åbne ordrer', $sprog_id)."</td><td><INPUT title='".findtekst('5039|Vis både leveringsadresse og ekstrafelter samtidigt på åbne ordrer', $sprog_id)."' class='inputbox' type='checkbox' name='showBothAddrExtra' $showBothAddrExtra></td></tr>";
 	#	print "<tr><td title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."'>".findtekst('3116|Decimaler på rabat', $sprog_id)."</td><td><INPUT title='".findtekst('3117|Angiv antallet af decimaler på rabatfelter på ordrer', $sprog_id)."' class='inputbox' type='text' style='width:70px;text-align:right;' name='rabatdecimal' value='$rabatdecimal'></td></tr>";
 	
-<<<<<<< HEAD
 	$titleRev = "Hide revenue on order list"; 
 	print "<tr><td title='$titleRev'>Hide revenue on order List</td><td><INPUT title= '$titleRev' class='inputbox' type='checkbox' name='hideRevenueOnOrdreliste' $hideRevenueOnOrdreliste></td></tr>";
-=======
-	$titleRev = "Hide revenue on order list";
-	print "<tr><td title='$titleRev'>Turn Off Revenue Tracking</td><td><INPUT title= '$titleRev' class='inputbox' type='checkbox' name='hideRevenueOnOrdreliste' $hideRevenueOnOrdreliste></td></tr>";
->>>>>>> d880b9b5 (Rename revenue tracking option in order list)
 	print "<tr><td><br></td></tr>";
 	print "<tr><td><br></td></tr>";
 	print "<td><br></td><td><br></td><td><br></td><td align = center><input class='button green medium' type=submit accesskey='g' value='".findtekst('471|Gem/opdatér', $sprog_id)."' name='submit'></td>";


### PR DESCRIPTION
**### **This PR enables approved users to hide total revenue from the ordreliste file.****

 **According to the customer**:
_It would be great to have a setting—perhaps a checkbox—that hides revenue figures in areas like customer orders. Instead of making this a user-specific preference, it should be a global setting that applies to everyone, so that only someone with access to the settings can toggle it on or off.

The reason for this request is that the customer does not want revenue figures displayed on screens (such as the POS/cash register screens) or visible to employees._

**Configuration**
To enable this setting, go to:

System → Settings → Miscellaneous → Order-related options

The option is currently the last checkbox in the list.

**Scope:** hides the aggregate "Samlet omsætning / db / dg" figures as shown in the ticket's attachment. Per-order amounts (Ordresum/Fakturasum) — see the follow-up ticket.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide revenue, contribution margin, and related totals from order lists.
  * The setting can be enabled per database through order list preferences.
  * The preference is saved and applied across invoice and non-invoice order list views.

* **Improvements**
  * Removed redundant and obsolete options from settings screens.
  * Removed an unnecessary export heading from the chart-of-accounts export view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->