### PR TITLE
F-002: kassekladde.php plain-load warning flood (init pass, no behavior change)

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -461,10 +461,13 @@ if (!isset($tidspkt))
 	$tidspkt = 0;
 if (!isset($row['tidspkt']))
 	$row['tidspkt'] = null;
+$kksort    = null;
+$kkdir     = null;
+$returside = null;
 
-$visipop = if_isset($_GET['visipop']);
-$udskriv = if_isset($_GET['udskriv']);
-if ($tjek = if_isset($_GET['tjek'])) {
+$visipop = if_isset($_GET, null, 'visipop');
+$udskriv = if_isset($_GET, null, 'udskriv');
+if ($tjek = if_isset($_GET, null, 'tjek')) {
 	$tidspkt = microtime();
 	list($a, $b) = explode(" ", $tidspkt);
 	$qtxt = "select bogfort,tidspkt,hvem from kladdeliste where (bogfort = '-' or bogfort = 'S') and id = $tjek";
@@ -546,7 +549,7 @@ $r = db_fetch_array(db_select("select box4,box10 from grupper where art = 'DIV' 
 ($r['box4'])  ? $forskellige_datoer = 1 : $forskellige_datoer = 0;
 ($r['box10']) ? $vis_bet_id = 1         : $vis_bet_id = 0;
 if ($_GET) {
-	$returside = if_isset($_GET['returside']);
+	$returside = if_isset($_GET, null, 'returside');
 	if (!$returside)           $returside = "../finans/kladdeliste.php";
 	if (isset($_GET['fokus'])) $fokus     = $_GET['fokus'];
 	$sort            =       if_isset($_GET, 		null,   'sort');
@@ -695,6 +698,7 @@ if ($_POST) {
 	$ny_kladdenote = db_escape_string(trim(if_isset($_POST['ny_kladdenote'], '')));
 	$antal_ny      = if_isset($_POST['antal_ny']);
 	$antal_ex      = if_isset($_POST['antal_ex']);
+	$antal         = 0;
 	$fokus         = if_isset($_POST['fokus']);
 	#$momsfri       = if_isset($_POST['momsfri']);
 	$id            = if_isset($_POST['id']);
@@ -2921,7 +2925,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		if ($vis_bilag && !$fejl && isset($id[$y])) { #### use
 			$qtxt = "select id,filename,filepath from documents where source = 'kassekladde' and source_id = '$id[$y]' order by id limit 1";  //20230630
 			$docRow = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
-			$hasDoc = ($dokument[$y] || $docRow) ? true : false;
+			$hasDoc = (($dokument[$y] ?? null) || $docRow) ? true : false;
 			if ($hasDoc) {
 				$clip = 'paper.png';
 				$titletxt =  findtekst('1454|klik her for at åbne bilaget', $sprog_id);
@@ -3063,7 +3067,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 
 		// Delete button - disabled if document attached
 		$qtxt = "SELECT id FROM documents WHERE source = 'kassekladde' AND source_id = '$id[$y]'";
-		$hasDoc = ($dokument[$y] || db_fetch_array(db_select($qtxt, __FILE__ . " line " . __LINE__)));
+		$hasDoc = (($dokument[$y] ?? null) || db_fetch_array(db_select($qtxt, __FILE__ . " line " . __LINE__)));
 
 		if ($hasDoc) {
 			$deleteTitle = "Remove attached document first";
@@ -3188,10 +3192,10 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			if ($x == 1) {
 				$next = $last_bilag;
 			} else {
-				$next = $bilag[$x-1] + 1;
+				$next = ($bilag[$x-1] ?? 0) + 1;
 			}
 		} else {
-			$next = $bilag[$x-1] + 1;
+			$next = ($bilag[$x-1] ?? 0) + 1;
 		}
 		if($dato[$x] == ''){
 			$dato[$x] = (isset($dato[$x - 1]) && $dato[$x - 1] != '') ? $dato[$x - 1] : dkdato(date("Y-m-d"));
@@ -3202,8 +3206,8 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		if ($vis_bilag && !$fejl) { #20140425
 			#if ($kladde_id && $intern_bilag) print "<td title='".findtekst('1455|klik her for at vedhæfte et bilag', $sprog_id)."'><a href='../includes/bilag.php?kilde=kassekladde&bilag_id=$id[$x]&bilag=$bilag[$x]&ny=ja&kilde_id=$kladde_id&fokus=bila$x'><img  style='border: 0px solid' src='../ikoner/clip.png'></a></td>\n";
 			if ($intern_bilag) {
-				$id[$y]        = (int)if_isset($id[$y],0);
-				$dokument[$y] = if_isset($dokument[$y],NULL);
+				$id[$y]        = (int)($id[$y] ?? 0);
+				$dokument[$y] = $dokument[$y] ?? NULL;
 				$qtxt = "select id from documents where source = 'kassekladde' and source_id = '$id[$y]'";  //20230630
 				if ($dokument[$y] || db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 					$clip = 'paper.png';
@@ -3245,10 +3249,10 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			if ($x == 1) {
 				$next = $last_bilag;
 			} else {
-				$next = $bilag[$x-1] + 1;
+				$next = ($bilag[$x-1] ?? 0) + 1;
 			}
 		} else {
-			$next = $bilag[$x-1] + 1;
+			$next = ($bilag[$x-1] ?? 0) + 1;
 		}
 		if($dato[$x] == ''){
 			$dato[$x] = (isset($dato[$x - 1]) && $dato[$x - 1] != '') ? $dato[$x - 1] : dkdato(date("Y-m-d"));


### PR DESCRIPTION
## Background

`finans/kassekladde.php` is one of the largest warning sources in every release-gate run (200+ hits per run on ~15 source lines) — finding F-002 in the August test sweeps. Each warning is a candidate fatal under a future PHP upgrade, and the volume drowns real errors in the PHP log. This is a warning-silencing pass only: **no behavioral change**.

## Changes

- **`if_isset($_GET['...'])` → `if_isset($_GET, null, '...')`** for `visipop`, `udskriv`, `tjek`, `returside`. The array-first form evaluates the missing key before the helper runs, which is exactly the warning the helper exists to prevent (see the usage doc in `includes/std_func.php:175`). Return values are identical.
- **Initialise `$kksort` / `$kkdir` / `$returside` to `null`** at the top. They are read (header sort links at ~2543, `build_kassekladde_query` at ~2082, back-link at ~1496) before the KASKL defaults load at ~2604. `$kkdir` is deliberately initialised to `null`, not `'asc'` — the sort-toggle links compare `== 'asc'`, so `'asc'` would flip their direction; `null` keeps behaviour byte-identical.
- **Initialise `$antal = 0`** in the POST intake. `$antal` is never assigned anywhere in the file, so the "insert balance line after last line" block at ~1220 (`$x == $antal - 1`) has never run. `0` keeps it not running, warning-free. **The inert auto-balance block itself is a separate defect** (SD-617-adjacent) and should get its own ticket — deliberately not activated here because that would change posting behaviour.
- **`??` guards** on `$dokument[$y]`, `$id[$y]`, and `$bilag[$x-1]` reads in the row-render loops, matching the `?? ''` style the surrounding 2025 code already uses. Missing keys already behaved as null; now they do so without warning. (Note: `$y` in the new-row clip block at ~3205 is stale from the previous loop — that is pre-existing and untouched.)

## Verification

- `php -l` clean.
- Every changed expression evaluates to the same value as before for the undefined case (see the `$kkdir` note above for the one trap).

Part of the F-002/F-003/F-011 warning sweep (testy findings ledger); sibling PRs fix `debitorkort.php` and `ordreliste.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cash journal stability when optional values or form inputs are missing.
  * Prevented warnings and unexpected behavior when processing document attachments and voucher numbers.
  * Improved handling of empty or undefined data during cash journal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->