### PR TITLE
F-003: debitorkort.php undefined lev_* in hidden delivery-address fields

### DIFF
--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -1267,6 +1267,15 @@ if (!isset($efternavn)) $efternavn = null;
 if (!isset($firmanavn)) $firmanavn = null;
 if (!isset($lev_fornavn)) $lev_fornavn = null;
 if (!isset($lev_efternavn)) $lev_efternavn = null;
+if (!isset($lev_firmanavn)) $lev_firmanavn = null;
+if (!isset($lev_addr1)) $lev_addr1 = null;
+if (!isset($lev_addr2)) $lev_addr2 = null;
+if (!isset($lev_postnr)) $lev_postnr = null;
+if (!isset($lev_bynavn)) $lev_bynavn = null;
+if (!isset($lev_land)) $lev_land = null;
+if (!isset($lev_tlf)) $lev_tlf = null;
+if (!isset($lev_email)) $lev_email = null;
+if (!isset($lev_kontakt)) $lev_kontakt = null;
 
 if ($kontotype == "privat") {
 	if (!$fornavn && !$efternavn && $firmanavn) {
@@ -1480,14 +1489,6 @@ if (!isset($bank_konto)) $bank_konto = NULL;
 if (!isset($swift)) $swift = NULL;
 if (!isset($lukket)) $lukket = NULL;
 if (!isset($stripe_fravalg)) $stripe_fravalg = NULL;
-if (!isset($lev_firmanavn)) $lev_firmanavn = NULL;
-if (!isset($lev_addr1)) $lev_addr1 = NULL;
-if (!isset($lev_addr2)) $lev_addr2 = NULL;
-if (!isset($lev_postnr)) $lev_postnr = NULL;
-if (!isset($lev_land)) $lev_land = NULL;
-if (!isset($lev_kontakt)) $lev_kontakt = NULL;
-if (!isset($lev_bynavn)) $lev_bynavn = NULL;
-if (!isset($lev_tlf)) $lev_tlf = NULL;
 if (!isset($notes)) $notes = NULL;
 
 if ($kontotype == 'privat') {


### PR DESCRIPTION
## Background

Opening a debitor kort for a **new** customer (id=0) prints eleven undefined `$lev_*` variables into the hidden delivery-address inputs (~lines 1419–1429), and `split_navn($lev_firmanavn)` at ~1274 reads one of them even earlier. Finding F-003 in the August test sweeps. The file already has `if (!isset(...))` guard blocks for exactly this — but the `lev_*` one sits *after* the print that warns.

## Changes

- Completed the early guard block at ~1265 with the nine missing `lev_*` variables (`lev_firmanavn`, `lev_addr1/2`, `lev_postnr`, `lev_bynavn`, `lev_land`, `lev_tlf`, `lev_email`, `lev_kontakt`) so every `lev_*` is defined before first read. `lev_email` previously had no guard anywhere.
- Removed the late duplicates at ~1483 that the completed early block makes redundant (nothing assigns `lev_*` between the two locations).

No behavioral change: the hidden fields rendered empty values before (with warnings); they render the same empty values now.

## Verification

- `php -l` clean.
- Existing-customer path unchanged — those variables are assigned from the DB row at ~1087 before either guard block runs.

Part of the F-002/F-003/F-011 warning sweep (testy findings ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
