### PR TITLE
F-011: ordreliste.php per-row sprog_id warning + show_shop_link init

### DIFF
--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -1089,7 +1089,7 @@ $custom_columns = array(
         "decimalPrecision" => 2,
         "searchable" => true,
         "render" => function ($value, $row, $column) use ($valg, &$ialt, &$ialt_m_moms, &$ialt_kostpris) {
-            global $genberegn;
+            global $genberegn, $sprog_id;
 
             if ($genberegn) {
                 $kostpris = genberegn($row['id']);
@@ -1979,6 +1979,7 @@ print "<div style='width: 100%; height: calc(100vh - 34px - 16px);'>";
 
 
 // Shop order integration logic (ported from ordrelisteOld.php)
+$show_shop_link = false;
 if ($r=db_fetch_array(db_select("select box4, box5, box6 from grupper where art='API' and box4 != ''",__FILE__ . " linje " . __LINE__))) {
     $api_fil=trim($r['box4']);
     $api_fil2=trim($r['box5']);


### PR DESCRIPTION
## Background

The order/invoice list warns once per displayed row — the single biggest warning source in a release-gate run (finding F-011, found by the AI UI tester 2026-08-10). Two causes:

1. The `sum` column render closure imports `global $genberegn` but not `$sprog_id`, so the `findtekst('1442|Ikke udlignet', $sprog_id)` tooltip call warns on **every faktura row** and always falls back to the default language instead of the user's configured one. The sibling closure at ~762 already imports `$sprog_id` correctly.
2. `$show_shop_link` is only assigned inside the shop-API config branch (~1986), so every load without a shop integration warns at the footer check (~2645).

## Changes

- `global $genberegn, $sprog_id;` in the `sum` render closure.
- `$show_shop_link = false;` before the shop-integration block.

Behavioral note: the "Ikke udlignet" tooltip now renders in the user's configured language on non-Danish accounts — that is the bug being fixed; everything else is byte-identical.

## Verification

- `php -l` clean.

Part of the F-002/F-003/F-011 warning sweep (testy findings ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
