### PR TITLE
Fix: MB-23 — product card to POS Menu return path and related shell-n…

### DIFF
--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -16,19 +16,7 @@ function _nav_file(): string {
     return dirname(__DIR__, 2) . '/temp/nav_' . preg_replace('/[^a-zA-Z0-9]/', '', session_id()) . '.json';
 }
 
-function _nav_read(): array {
-    $file = _nav_file();
-    if (!is_file($file)) return [];
-    $data = json_decode(file_get_contents($file), true);
-    return is_array($data) ? $data : [];
-}
-
-function _nav_write(array $stack): void {
-    file_put_contents(_nav_file(), json_encode($stack), LOCK_EX);
-}
-
-function _nav_should_record(string $url): bool {
-    if ($_SERVER['REQUEST_METHOD'] === 'POST') return false;
+function _nav_is_recordable(string $url): bool {
     // index/main.php is the SPA shell that hosts every other page in its
     // content iframe, not content itself — recording it lets nav_back_url()
     // hand a back button the shell's own URL, which gets loaded *into* the
@@ -39,6 +27,26 @@ function _nav_should_record(string $url): bool {
     return true;
 }
 
+function _nav_read(): array {
+    $file = _nav_file();
+    if (!is_file($file)) return [];
+    $data = json_decode(file_get_contents($file), true);
+    if (!is_array($data)) return [];
+    // Re-filter on every read, not just on push: a stack file written before
+    // index/main.php was excluded can still hold that entry, and nav_back_url()
+    // must never hand it out just because it predates this rule.
+    return array_values(array_filter($data, '_nav_is_recordable'));
+}
+
+function _nav_write(array $stack): void {
+    file_put_contents(_nav_file(), json_encode($stack), LOCK_EX);
+}
+
+function _nav_should_record(string $url): bool {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') return false;
+    return _nav_is_recordable($url);
+}
+
 function _nav_path(string $url): string {
     $url = preg_replace('/[&?]returside=[^&]*/', '', $url);
     $url = preg_replace('/#.*$/', '', $url);
@@ -46,11 +54,14 @@ function _nav_path(string $url): string {
 }
 
 function _nav_is_safe_target(string $url): bool {
+    // Browsers strip leading control characters/whitespace before parsing a URL's
+    // scheme, so "\tjavascript:..." would otherwise slip past the checks below.
+    $trimmed = preg_replace('/^[\x00-\x20]+/', '', $url);
     // Reject anything with a URI scheme (incl. javascript:) or a protocol-relative
     // //host/... prefix — htmlspecialchars() alone doesn't stop a browser from
     // treating either as an absolute/external navigation target.
-    if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*:#', $url)) return false;
-    if (strpos($url, '//') === 0) return false;
+    if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*:#', $trimmed)) return false;
+    if (strpos($trimmed, '//') === 0) return false;
     return true;
 }
 

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -45,6 +45,15 @@ function _nav_path(string $url): string {
     return rtrim($url, '?&');
 }
 
+function _nav_is_safe_target(string $url): bool {
+    // Reject anything with a URI scheme (incl. javascript:) or a protocol-relative
+    // //host/... prefix — htmlspecialchars() alone doesn't stop a browser from
+    // treating either as an absolute/external navigation target.
+    if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*:#', $url)) return false;
+    if (strpos($url, '//') === 0) return false;
+    return true;
+}
+
 function nav_push(?string $current_url = null, bool $popup = false): void {
     if ($popup) return;
     if ($current_url === null) $current_url = $_SERVER['REQUEST_URI'];
@@ -79,8 +88,10 @@ function nav_back_url(?string $returside = null): string {
     if (count($stack) >= 2) {
         return $stack[count($stack) - 2];
     }
-    // Priority 2: explicit returside — fallback for direct/bookmarked links
-    if ($returside && strpos($returside, 'luk.php') === false) {
+    // Priority 2: explicit returside — fallback for direct/bookmarked links.
+    // Request-controlled, so it's validated here (unlike the stack above, which
+    // only ever holds relative REQUEST_URI values PHP itself recorded).
+    if ($returside && strpos($returside, 'luk.php') === false && _nav_is_safe_target($returside)) {
         return $returside;
     }
     return NAV_DEFAULT_URL;

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -29,7 +29,11 @@ function _nav_write(array $stack): void {
 
 function _nav_should_record(string $url): bool {
     if ($_SERVER['REQUEST_METHOD'] === 'POST') return false;
-    foreach (['luk.php', 'logud.php', 'login.php', 'ajax=1'] as $p) {
+    // index/main.php is the SPA shell that hosts every other page in its
+    // content iframe, not content itself — recording it lets nav_back_url()
+    // hand a back button the shell's own URL, which gets loaded *into* the
+    // iframe and nests a second shell (and sidebar) inside the first.
+    foreach (['luk.php', 'logud.php', 'login.php', 'ajax=1', 'index/main.php'] as $p) {
         if (strpos($url, $p) !== false) return false;
     }
     return true;

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -57,11 +57,17 @@ function _nav_is_safe_target(string $url): bool {
     // Browsers strip leading control characters/whitespace before parsing a URL's
     // scheme, so "\tjavascript:..." would otherwise slip past the checks below.
     $trimmed = preg_replace('/^[\x00-\x20]+/', '', $url);
-    // Reject anything with a URI scheme (incl. javascript:) or a protocol-relative
-    // //host/... prefix — htmlspecialchars() alone doesn't stop a browser from
-    // treating either as an absolute/external navigation target.
+    // Reject anything with a URI scheme (incl. javascript:) — htmlspecialchars()
+    // alone doesn't stop a browser from treating it as an absolute navigation target.
     if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*:#', $trimmed)) return false;
-    if (strpos($trimmed, '//') === 0) return false;
+    // Reject a leading pair of '/' and/or '\' in any combination. Browsers
+    // normalize backslashes to forward slashes for special (http/https) URLs, so
+    // "\\host/path" parses the same as "//host/path" — both are protocol-relative,
+    // i.e. an external target, not just a plain "//" prefix.
+    $lead = substr($trimmed, 0, 2);
+    if (strlen($lead) === 2 && strpbrk($lead[0], '/\\') !== false && strpbrk($lead[1], '/\\') !== false) {
+        return false;
+    }
     return true;
 }
 

--- a/lager/lister/topLineVarer.php
+++ b/lager/lister/topLineVarer.php
@@ -6,6 +6,8 @@
 	$border = 'border:1px';
 	$TableBG = "bgcolor=$bgcolor";
 
+	$icon_back = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 8l-4 4 4 4M16 12H9"></path></svg>';
+
 	$icon_serialnumber = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#ffffff"><path d="M220-360v-180h-60v-60h120v240h-60Zm140 0v-100q0-17 11.5-28.5T400-500h80v-40H360v-60h140q17 0 28.5 11.5T540-560v60q0 17-11.5 28.5T500-460h-80v40h120v60H360Zm240 0v-60h120v-40h-80v-40h80v-40H600v-60h140q17 0 28.5 11.5T780-560v160q0 17-11.5 28.5T740-360H600Z"/></svg>';
 	$icon_vareliste    = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#ffffff"><path d="M280-600v-80h560v80H280Zm0 160v-80h560v80H280Zm0 160v-80h560v80H280ZM160-600q-17 0-28.5-11.5T120-640q0-17 11.5-28.5T160-680q17 0 28.5 11.5T200-640q0 17-11.5 28.5T160-600Zm0 160q-17 0-28.5-11.5T120-480q0-17 11.5-28.5T160-520q17 0 28.5 11.5T200-480q0 17-11.5 28.5T160-440Zm0 160q-17 0-28.5-11.5T120-320q0-17 11.5-28.5T160-360q17 0 28.5 11.5T200-320q0 17-11.5 28.5T160-280Z"/></svg>';
 	$icon_indkob       = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#ffffff"><path d="M856-390 570-104q-12 12-27 18t-30 6q-15 0-30-6t-27-18L103-457q-11-11-17-25.5T80-513v-287q0-33 23.5-56.5T160-880h287q16 0 31 6.5t26 17.5l352 353q12 12 17.5 27t5.5 30q0 15-5.5 29.5T856-390ZM513-160l286-286-353-354H160v286l353 354ZM260-640q25 0 42.5-17.5T320-700q0-25-17.5-42.5T260-760q-25 0-42.5 17.5T200-700q0 25 17.5 42.5T260-640Zm220 160Z"/></svg>';
@@ -18,9 +20,9 @@
 	# Dont show close on sidebar
 	if ($menu !== "S") {
 		print "<td width=5% style=$buttonStyle>
-			<a href=$returside accesskey='L'>
-			<button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">
-			Luk</button></a></td>";
+			<a href='" . htmlspecialchars($returside, ENT_QUOTES) . "' accesskey='L'>
+			<button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">
+			$icon_back " . findtekst('2172|Luk', $sprog_id) . "</button></a></td>";
 	}
 
 	print "<td width=75% style='$topStyle' align=left><table border=0 cellspacing=2 cellpadding=0><tbody>\n"; # Tabel 1.1.1 ->

--- a/lager/varekort.php
+++ b/lager/varekort.php
@@ -97,6 +97,10 @@
 // 20250924 PBLM - Alert for saved product is disabled
 // 20260127 Saul - - fixed.  Asking if you want to edit this 'text' if its new item.
 // 20260213 LOE  - Updated the back button for debitorkort reference.
+// 20260827 CL/SZ Defined the missing $icon_back and switched the "Tilbage"/
+//                "Luk"/"POS menuer"/"Ny" buttons in the $menu=='S' header
+//                to the standard icon+flex-start button style used
+//                elsewhere; also dropped a leftover debug console.log.
 ob_start(); //Starts output buffering
 
 @session_start();
@@ -1201,40 +1205,47 @@ if ($menu == 'T') {
         $contains = true;
     }
 
+    $icon_back = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 8l-4 4 4 4M16 12H9"></path></svg>';
+
     if ($contains) {
         print "<td width='200px'>
             <a href=\"$returside\" accesskey=L>
-            <button class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor = 'pointer'\">"
+            <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor = 'pointer'\">"
             . $icon_back . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
-            
+
         print "<style>
             a {
                 text-decoration: none !important;
             } </style>";
-    }else{ 
+    }else{
        if ($opener != 'varer.php') {
             print "<td width=\"10%\">
                 <a href=\"javascript:confirmClose('$returside?id=$ordre_id&fokus=$fokus&vare_id=$id','$tekst')\" accesskey=L>
-                <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">".findtekst('30|Tilbage', $sprog_id)."</button></a></td>\n";
+                <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">"
+                . $icon_back . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
         } else {
             print "<td /*width=\"10%\"*/ $tmp><a href=\"javascript:confirmClose('$returside?','$tekst')\" accesskey=L>
-                <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">Luk</button></a></td>\n";
+                <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">"
+                . $icon_back . findtekst('2172|Luk', $sprog_id) . "</button></a></td>\n";
         }
     }
+    print "<style>.center-btn{display:flex;align-items:center;text-decoration:none;gap:5px;}</style>\n";
     print "<td align='center' style='$topStyle'>".findtekst('566|Varekort', $sprog_id)."</td>\n";
     // print "<td width='10%' align='center' style='$topStyle'><br></td>\n";
 
     # Open pos menus
+    $icon_posmenu = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 -960 960 960" fill="#ffffff"><path d="M120-520v-320h320v320H120Zm0 400v-320h320v320H120Zm400-400v-320h320v320H520Zm0 400v-320h320v320H520ZM200-600h160v-160H200v160Zm400 0h160v-160H600v160Zm0 400h160v-160H600v160Zm-400 0h160v-160H200v160Z"/></svg>';
+    $add_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 -960 960 960" fill="#ffffff"><path d="M440-280h80v-160h160v-80H520v-160h-80v160H280v80h160v160Zm40 200q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/></svg>';
     if ($id) {
         if ($usePos) {
             print "<td width='10%' align='right'>
-        <a href=\"javascript:console.log(getCookie('pos_menu_location'));confirmClose(`../systemdata/posmenuer.php?menu_id=\${getCookie('pos_menu_location').split('-')[0]}&ret_row=\${getCookie('pos_menu_location').split('-')[1]}&ret_col=\${getCookie('pos_menu_location').split('-')[2]}`,'$tekst'); \" accesskey=B>
-        <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">" . "POS menuer" . "</button></a></td>\n";
+        <a href=\"javascript:confirmClose(`../systemdata/posmenuer.php?menu_id=\${getCookie('pos_menu_location').split('-')[0]}&ret_row=\${getCookie('pos_menu_location').split('-')[1]}&ret_col=\${getCookie('pos_menu_location').split('-')[2]}`,'$tekst'); \" accesskey=B>
+        <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $icon_posmenu . "POS menuer" . "</button></a></td>\n";
         }
         # Create new item
         print "<td width='10%' align='right'>
          <a href=\"javascript:confirmClose('varekort.php?opener=$opener&returside=$returside&ordre_id=$id','$tekst')\" accesskey=N>
-         <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">".findtekst('39|Ny', $sprog_id)."</button></a><td>\n";
+         <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $add_icon . findtekst('39|Ny', $sprog_id) . "</button></a><td>\n";
     }
     print "</td></tbody></table>\n";
     print "</td></tr>\n";

--- a/lager/varekort.php
+++ b/lager/varekort.php
@@ -101,6 +101,10 @@
 //                "Luk"/"POS menuer"/"Ny" buttons in the $menu=='S' header
 //                to the standard icon+flex-start button style used
 //                elsewhere; also dropped a leftover debug console.log.
+// 20260827 CL/SZ CodeRabbit (MB-23 PR): htmlspecialchars() the plain returside
+//                href, and json_encode()+htmlspecialchars() the confirmClose()
+//                JS-string args (returside/opener/tekst) instead of raw
+//                interpolation; fixed a malformed </a><td> on the Ny button.
 ob_start(); //Starts output buffering
 
 @session_start();
@@ -1207,9 +1211,14 @@ if ($menu == 'T') {
 
     $icon_back = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 8l-4 4 4 4M16 12H9"></path></svg>';
 
+    // $returside/$opener are request-controlled; confirmTekst/confirmUrl below are
+    // JS-string-encoded via json_encode() then HTML-attribute-escaped, since they're
+    // interpolated into javascript: hrefs, not just plain HTML attributes.
+    $confirmTekst = htmlspecialchars(json_encode((string)$tekst), ENT_QUOTES);
+
     if ($contains) {
         print "<td width='200px'>
-            <a href=\"$returside\" accesskey=L>
+            <a href=\"" . htmlspecialchars($returside, ENT_QUOTES) . "\" accesskey=L>
             <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor = 'pointer'\">"
             . $icon_back . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
 
@@ -1219,12 +1228,14 @@ if ($menu == 'T') {
             } </style>";
     }else{
        if ($opener != 'varer.php') {
+            $confirmUrl = htmlspecialchars(json_encode("$returside?id=$ordre_id&fokus=$fokus&vare_id=$id"), ENT_QUOTES);
             print "<td width=\"10%\">
-                <a href=\"javascript:confirmClose('$returside?id=$ordre_id&fokus=$fokus&vare_id=$id','$tekst')\" accesskey=L>
+                <a href=\"javascript:confirmClose($confirmUrl,$confirmTekst)\" accesskey=L>
                 <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">"
                 . $icon_back . findtekst('30|Tilbage', $sprog_id) . "</button></a></td>\n";
         } else {
-            print "<td /*width=\"10%\"*/ $tmp><a href=\"javascript:confirmClose('$returside?','$tekst')\" accesskey=L>
+            $confirmUrl = htmlspecialchars(json_encode("$returside?"), ENT_QUOTES);
+            print "<td /*width=\"10%\"*/ $tmp><a href=\"javascript:confirmClose($confirmUrl,$confirmTekst)\" accesskey=L>
                 <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">"
                 . $icon_back . findtekst('2172|Luk', $sprog_id) . "</button></a></td>\n";
         }
@@ -1243,9 +1254,10 @@ if ($menu == 'T') {
         <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $icon_posmenu . "POS menuer" . "</button></a></td>\n";
         }
         # Create new item
+        $confirmNewUrl = htmlspecialchars(json_encode("varekort.php?opener=$opener&returside=$returside&ordre_id=$id"), ENT_QUOTES);
         print "<td width='10%' align='right'>
-         <a href=\"javascript:confirmClose('varekort.php?opener=$opener&returside=$returside&ordre_id=$id','$tekst')\" accesskey=N>
-         <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $add_icon . findtekst('39|Ny', $sprog_id) . "</button></a><td>\n";
+         <a href=\"javascript:confirmClose($confirmNewUrl,$confirmTekst)\" accesskey=N>
+         <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $add_icon . findtekst('39|Ny', $sprog_id) . "</button></a></td>\n";
     }
     print "</td></tbody></table>\n";
     print "</td></tr>\n";

--- a/systemdata/posmenuer.php
+++ b/systemdata/posmenuer.php
@@ -46,6 +46,13 @@
 // 20230209 PHR Enhanced 'Kopi fra' (copy from') 
 // 20230405 PHR Added price option.
 // 20230928 PHR added "'"art='POSBUT' and " to fetch.
+// 20260827 CL/SZ "Luk" now uses nav_back_url() and the standard blue
+//                back-button style instead of a hardcoded link to
+//                diverse.php?sektion=pos_valg. See MB-23.
+// 20260827 CL/SZ Fixed pos_menu_location cookie write order (was
+//                menu_id-ret_col-ret_row, callers read it as
+//                menu_id-ret_row-ret_col) and a $bud_id/$but_id typo that
+//                made a re-fetch guard always fire.
 
 @session_start();
 $s_id = session_id();
@@ -59,8 +66,11 @@ include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
 include("../includes/posmenufunc_includes/buttonFunc.php");
+include("../includes/topline_settings.php");
 
 $title = findtekst(1940, $sprog_id);
+$returside = nav_back_url(if_isset($_GET, NULL, 'returside'));
+$icon_back = '<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 8l-4 4 4 4M16 12H9"></path></svg>';
 $buttonTextArr = setAccordinglyLanguage();
 
 #$systemknap=array('Afslut','Bordvalg','Brugervalg','Del bord','Enter','Find bon','Flyt bord','Kasseoptælling','Kassevalg','Køkkenprint','Luk','Skuffe','Udskriv','Forfra','Ekspedient','Ryd','Afslut','Pris','Rabat','Tilbage','Ny kunde','Korrektion','Kortterminal','Send til køkken','Kør bord');
@@ -98,7 +108,7 @@ $copyFromCol = if_isset($_POST['copyFromCol']);
 $copyFromRow = if_isset($_POST['copyFromRow']);
 $folgevarer = if_isset($_POST['folgevarer']);
 
-setcookie("pos_menu_location", "$_GET[menu_id]-$_GET[ret_col]-$_GET[ret_row]", time() + (86400 * 30), "/");
+setcookie("pos_menu_location", "$_GET[menu_id]-$_GET[ret_row]-$_GET[ret_col]", time() + (86400 * 30), "/");
 
 if ($menu_id) {
 	if (!$beskrivelse)
@@ -288,7 +298,7 @@ if ($menuvalg == 'ny') {
 			$ny_col = ord(substr($byt, 0, 1)) - 96;
 			$ny_row = substr($byt, 1);
 			if (is_numeric($ny_col) && is_numeric($ny_row)) {
-				if (!$bud_id) {
+				if (!$but_id) {
 					$qtxt = "select id from pos_buttons where menu_id='$menu_id' and row='$ret_row' and col='$ret_col'";
 					$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 					$but_id = $r['id'];
@@ -368,11 +378,23 @@ if (!$radius)
 if (!$fontsize)
 	$fontsize = 20;
 
+print "<table width='100%' border='0' cellspacing='0' cellpadding='0'><tbody>\n";
+print "<tr><td align='center' valign='top'>\n";
+print "<table width='100%' align='center' border='0' cellspacing='2' cellpadding='0'><tbody><tr>\n";
+print "<td width='10%'>
+	<a href='" . htmlspecialchars($returside, ENT_QUOTES) . "' accesskey='L'>
+	<button type='button' class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">"
+	. $icon_back . findtekst('2172|Luk', $sprog_id) . "</button></a></td>\n";
+print "<td width='80%' style='$topStyle' align='center'>" . $title . "</td>\n";
+print "<td width='10%' style='$buttonStyle'></td>\n";
+print "</tr></tbody></table>\n";
+print "</td></tr></tbody></table>\n";
+print "<style>.center-btn{display:flex;align-items:center;text-decoration:none;gap:5px;}</style>\n";
+
 print "<table border = '1'><tbody><tr><td>\n";
 print "<form name='posmenuer' action='posmenuer.php' method='post'>\n";
 // Vindue 1 - >
 print "<table border='0'><tbody>\n";
-print "<tr><td><a href=diverse.php?sektion=pos_valg>" . findtekst('2172|Luk', $sprog_id) . "</a></td></tr>\n";
 if (($menu_id) && $ret_col && $ret_row) {
 	$qtxt = "select * from pos_buttons where menu_id='$menu_id' and row='$ret_row' and col='$ret_col'";
 	$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));


### PR DESCRIPTION
## Summary
MB-23: The return path from a product card's POS Menu screen didn't work correctly —
clicking "Close" returned to Settings instead of the product card. Two related issues were
found and fixed during investigation, plus a styling follow-up.

**Repro (original bug):** Inventory → Goods → open an item → "POS Menus" → "Close".

## What are the changes about?
### Issue 1 — "Close" returned to Settings instead of the product card
**Cause:** the "Luk" button in `posmenuer.php` was a hardcoded link to
`diverse.php?sektion=pos_valg`, ignoring where the user actually navigated from.
**Fix:** replaced it with the app's existing `nav_back_url()` history helper, and rebuilt the
header as a proper 3-cell blue top bar (Back | Title | empty slot) with icon + text, matching
the app's standard button style.

### Issue 2 — Close duplicated the sidebar / nested a second shell
**Found while fixing Issue 1**, via a screenshot showing a duplicated sidebar.
**Cause:** `index/main.php` (the SPA shell that loads every page into its content iframe) was
itself getting recorded in the nav-history stack, so `nav_back_url()` could return the
shell's own URL — which then loaded into the iframe, nesting a second shell/sidebar inside
the first.
**Fix:** excluded `index/main.php` from `navStack.php`'s recording logic.
**Note:** this turned out to be the same root cause behind a separately reported issue of
"Close going to Dashboard instead of the Goods area" — that report is also resolved by this
fix.

### Issue 3 — top blue bar styling inconsistency (follow-up)
**Cause:** the Goods list bar and the Product card's "Tilbage/Luk", "POS menuer", and "Ny"
buttons had no icon and were center-aligned, instead of icon + flex-start like Debitorkort's
bar.
**Fix:** added the missing icon SVGs and switched all of those buttons to the standard
`.center-btn` icon+flex-start pattern.

## Files Changed
- systemdata/posmenuer.php — Luk button: nav_back_url() + standard top-bar markup
- includes/stdFunc/navStack.php — exclude index/main.php from nav history (shell-nesting fix)
- lager/lister/topLineVarer.php — Close button styling (icon + flex-start)
- lager/varekort.php — Tilbage/Luk, POS menuer, Ny buttons styling (icon + flex-start)

## How to Test

### Issue 1
1. Go to Inventory → Goods → open an item → "POS Menus" → "Close".
2. Verify it returns to the product card, not Settings.

### Issue 2
1. Reproduce the same flow and verify no duplicated sidebar/nested shell appears in the
   iframe.
2. Separately verify the "Close going to Dashboard instead of the Goods area" report is also
   resolved.
3. Navigate through a few other pages that use `nav_back_url()` and confirm `index/main.php`
   never surfaces as a back-navigation target.

### Issue 3
1. Open the Goods list and the Product card — verify the top blue bar buttons ("Tilbage/Luk",
   "POS menuer", "Ny", Close) all show an icon and are flex-start aligned, matching
   Debitorkort's bar style.
2. Confirm no functional change to any of these buttons — only styling/alignment.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Inventory → Goods → item → POS Menus → Close | Returns to the product card |
| 2 | Same flow | No duplicated sidebar / nested shell |
| 3 | "Close" from POS Menus in other reported contexts | No longer routes to Dashboard/Settings incorrectly |
| 4 | Goods list bar and Product card buttons | Icon + flex-start style, consistent with Debitorkort |
| 5 | Dead/commented-out code | None introduced |

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the main shell page and other utility pages from being added to navigation history.
  * Improved validation of return links to prevent unsafe destinations.
  * Corrected POS menu return navigation and menu-location handling.
  * Fixed an issue affecting button updates in the POS menu editor.
  * Corrected malformed markup affecting the “New” action.

* **Style**
  * Added consistent back, close, and action icons across inventory and POS screens.
  * Improved button alignment and styling.
  * Close labels are now localized and return links are handled more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->