### PR TITLE
MB-27: remove dead 'Sprog' language selector and its unused write path

### DIFF
--- a/systemdata/diverseIncludes/language.php
+++ b/systemdata/diverseIncludes/language.php
@@ -58,5 +58,10 @@ function language () {
     print "</select></td></tr>";
     print "<tr><td colspan='2'><small>".findtekst('2716|Nuværende sprog', $sprog_id).": ".findtekst('1|Dansk', $cookieLanguageId)."</small></td></tr>";
     print "</form>";
-    
+
+    // 20260828 CL/SZ Restored the link to tekster.php that lived on the removed dead "Sprog"
+    // form (SirRolin, MB-27 review) - its own visible text now states what it does, instead
+    // of an underlined language name with only a hover title explaining it.
+    print "<tr><td colspan='2'><a href='tekster.php?sprog_id=$cookieLanguageId'>".findtekst('2717|Klik her for at rette tekster', $sprog_id)."</a></td></tr>";
+
 } # endfunc sprog

--- a/systemdata/diverseIncludes/language.php
+++ b/systemdata/diverseIncludes/language.php
@@ -1,21 +1,19 @@
 <?php
+// 20260827 CL/SZ Removed the dead top "Sprog" form (settings.languages/
+//                languageId were never populated, so it always rendered with
+//                zero options) and int-cast cookieLanguageId before it hits
+//                SQL. Sprogindstillinger below is the only working selector. MB-27.
 function language () {
-    include("../includes/languages.php"); #20210112
     global $bgcolor,$bgcolor5,$bruger_id,$brugernavn;
     global $db;
-    global $s_id,$sprog_id; 
+    global $s_id,$sprog_id;
 
-    $languageId=$sprog_id;
-    
-    $csvfile = "../importfiler/tekster.csv";
-    $g1 =csv_to_array($csvfile);
-    $x=0;
     $user_id = null;
     $user_id = (abs($bruger_id)); //20210517
     
     // Handle cookie language setting (same as index.php)
     if(isset($_POST['cookieLanguageId'])){
-        $cookieLanguageId = $_POST['cookieLanguageId'];
+        $cookieLanguageId = (int)$_POST['cookieLanguageId'];
         $unixtime = time();
         include("../includes/connect.php");
         $qtxt = "UPDATE online SET logtime='$unixtime', language_id='$cookieLanguageId' WHERE session_id='$s_id'";
@@ -32,61 +30,6 @@ function language () {
         $cookieLanguageId = 1;
     }
 
-    print "<form name=diverse action=diverse.php?sektion=sprog method=post>";
-    print "<tr><td colspan='6'><hr></td></tr>";
-    print "<tr bgcolor='$bgcolor5'><td colspan='6'><b><u>".findtekst(801,$sprog_id)."</b></u></td></tr>"; // 20210303
-    print "<tr><td colspan='6'><br></td></tr>";
-    
-    if (isset($_POST['newLanguageId']) && $_POST['newLanguageId'])  {
-        $newLanguageId = $_POST['newLanguageId'];
-        $qtxt = "select id from settings where var_name = 'languageId' and user_id='0'";
-        if ($r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
-            $qtxt = "update settings set var_value = '$newLanguageId' where id = '$r[id]'";
-        } else {
-            $qtxt = "insert into settings(var_name,var_grp,var_value,var_description,user_id) values ";
-            $qtxt.= "('languageId','globals','$newLanguageId','Active default language','0')";
-        }
-        db_modify($qtxt,__FILE__ . " linje " . __LINE__);
-        $languageId = $newLanguageId;
-        include("../includes/connect.php");
-        $qtxt = "update online set language_id = '$languageId' where session_id='$s_id'";
-        db_modify($qtxt,__FILE__ . " linje " . __LINE__);
-        print "<meta http-equiv=\"refresh\" content=\"0;URL=diverse.php?sektion=sprog\">";
-        exit;
-    }
-    include("../includes/connect.php");
-    $qtxt = "select id, var_value from settings where var_name = 'languages' order by id limit 1";
-    $r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__));
-    $languages=explode(chr(9),$r['var_value']);
-    include("../includes/online.php");
-    
-    $tekst1=findtekst('1|Dansk', $sprog_id);
-    $tekst2=findtekst('2|Vælg aktivt sprog', $sprog_id);
-    for ($x=1; $x<count($languages);$x++) {
-        if ($languageId == $x) $languageName  = $languages[$x];
-    }
-    if (!$languageId) {
-        $languageId = 1;
-        $languageName = 'Dansk';
-    }
-    #print "<tr><td title='Klik her for at rette tekster'><a href=tekster.php?sprog_id=1>$tekst1</a></td>";
-    print "<tr><td title='".findtekst('2717|Klik her for at rette tekster', $sprog_id)."'><a href=tekster.php?sprog_id=$languageId>$languageName</a></td>"; #20210818
-    print "<td><SELECT class='inputbox' NAME='newLanguageId' title='$tekst2'>";
-    #		if ($box3[$x]) print"<option>$box3[$x]</option>";
-    for ($x=1; $x<count($languages);$x++) {
-        if ($languageId == $x) print "<option value='$x'>$languages[$x]</option>";
-    }
-    for ($x=1; $x<count($languages);$x++) {
-        if ($languageId != $x) print "<option value='$x'>$languages[$x]</option>";
-    }
-    print "</SELECT></td></tr>";
-#	}
-    print "<tr><td><br></td></tr>";
-
-    $tekst1=findtekst('3|Gem', $sprog_id);
-    print "<tr><td align = right colspan='4'><input class='button green medium' type=submit value='$tekst1' name='submit'></td></tr>";
-    print "</form>";
-    
     // Cookie language selector (same as index.php)
     print "<form method='POST' action='diverse.php?sektion=sprog'>";
     print "<tr><td colspan='6'><hr></td></tr>";


### PR DESCRIPTION
## Summary
`systemdata/diverseIncludes/language.php` rendered two language selectors on the same
settings page (System → Settings → Misc. → Language). The top "Sprog" form was completely
dead: it built its dropdown from `settings.languages`, a DB row that was either missing
entirely or had been overwritten with a version string like `4.0.5` by a bug in
`opdat_4.0.php`'s updater. With no valid data, the render loop
(`for ($x=1; $x<count($languages); $x++)`) never ran, so the `<SELECT>` rendered with zero
options, its link label was blank, and Save was a no-op.

The bottom "Sprogindstillinger" selector is the real, working mechanism — cookie-based,
reads `importfiler/tekster.csv` directly. Per the ticket's own recommendation, the dead top
form is deleted rather than repaired, since the working selector already covers the same
functionality on the same page.

## What are the changes about?
### 1. Removed the dead "Sprog" form and everything that only existed to feed it
- The `newLanguageId` POST handler (settings insert/update block).
- The `settings.languages` DB query and its `include("../includes/connect.php")` /
  `include("../includes/online.php")` (both only needed for that query).
- The unused `include("../includes/languages.php")`, `$g1 = csv_to_array(...)`,
  `$languageId = $sprog_id`, and a stray commented-out `#print` line and `# }`.
- Confirmed via grep that `newLanguageId` and the top form's write path aren't referenced
  anywhere else in the codebase, so nothing else depends on them.
- `opdat_4.0.php` (the source of the `4.0.5` corruption bug) was **not** touched — it's a
  protected update file per repo convention, and the ticket's own analysis is read-only on
  that file.

### 2. Int-cast on the working cookie-language handler's SQL input
Per the ticket's explicit acceptance criteria ("externally sourced request input used in SQL
must be int-cast or escaped"): the working cookie handler was interpolating
`$_POST['cookieLanguageId']` directly into an `UPDATE online SET ... language_id=
'$cookieLanguageId' ...` query with no cast/escaping. Added `(int)` casting where it's read
from `$_POST`.

## Files Changed
- systemdata/diverseIncludes/language.php

## Out of Scope
- `opdat_4.0.php` — protected update file; the `4.0.5` corruption bug there is a separate,
  read-only finding from this ticket's analysis, not fixed here.
- `index/install.php`'s two related inconsistencies (missing leading dummy in the languages
  string, and the `language_id` vs `languageId` key mismatch) — flagged by the ticket as
  related but not in this ticket's scope.

## How to Test
1. Navigate to System → Settings → Misc. → Language.
2. Verify only the working "Sprogindstillinger" selector is shown — the dead top "Sprog"
   form (blank dropdown, blank link label) no longer appears.
3. Switch the language via the remaining selector (e.g. to English) and verify the whole UI
   (sidebar, buttons) translates correctly, with the page reloading with no HTTP errors.
4. Submit the cookie-language form with a non-numeric/malformed `cookieLanguageId` value and
   confirm it's safely int-cast rather than reaching SQL raw.
5. Confirm no other page or feature that referenced `newLanguageId` or the deleted form's
   write path is affected (grep confirms none exist, but worth a visual sanity pass).
6. Confirm no commented-out or dead code remains in the file after the change.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | System → Settings → Misc. → Language page | Only the working Sprogindstillinger selector is shown |
| 2 | Switching language via the remaining selector | UI translates correctly, page reloads with no errors |
| 3 | cookieLanguageId POST value | Int-cast before reaching SQL; no raw request input in SQL |
| 4 | Dead/commented-out code | None remains in the final diff |
| 5 | One ticket per PR | This PR addresses MB-27 only |

## Verification
- Verified live via Playwright: logged in → saldidb2 → Settings → Language. The page now
  shows only the working "Sprogindstillinger" selector (matches the ticket's screenshot minus
  the dead red-boxed form above it).
- Switched the language to English through the selector — the whole UI (sidebar, buttons)
  translated correctly and the page reloaded with no HTTP errors, confirming the working form
  is untouched and still functional.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the non-functional language selection form from the language settings page.
  * Improved handling of language selections submitted through cookies.
  * Removed unused language data and text-loading behavior.
* **Improvements**
  * Restored the link to the text management page below the cookie language selector.
  * The link now displays clear, dedicated text and uses the selected cookie language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->