### PR TITLE
MB-28: remove dead mySaleTest checkbox, its mislabeled query, and str…

### DIFF
--- a/systemdata/sys_div_func.php
+++ b/systemdata/sys_div_func.php
@@ -110,6 +110,10 @@
 //                 $minbeskrivelse/$minpris as the default; translated via findtekst(), tekst_id 5056.
 // 20260824 CL/NTR loadLabelText()/saveLabelText() prefer account_id 0 over null legacy rows and only
 //                 touch global rows, matching what the label editor shows.
+// 20260827 CL/SZ Removed the dead "MySalesTest" checkbox row and its duplicate mySale
+//                query (was mislabeled $mySaleTest but still read var_name='mySale');
+//                also dropped the debug echo block referencing it. Never saved
+//                ($_POST['mySaleTest'] was read nowhere) and had no consumer. MB-28.
 include("sys_div_func_includes/chooseProvision.php");
 include_once("../includes/connect.php"); 
 
@@ -865,10 +869,6 @@ function div_valg() {
 	$r    = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 	($r['var_value']) ? $mySale = "checked='checked'" : $mySale = NULL;
 
-	$qtxt = "select var_value from settings where var_grp='debitor' and var_name='mySale'";
-	$r    = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
-	($r['var_value']) ? $mySaleTest = "checked='checked'" : $mySaleTest = NULL;
-
 	$qtxt = "select var_value from settings where var_grp='debitor' and var_name='mySaleLabel'";
 	$r    = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 	($r['var_value']) ? $mySaleLabel = "checked='checked'" : $mySaleLabel = NULL;
@@ -963,24 +963,12 @@ function div_valg() {
 	print "<!-- 768 : Brug 'Mit salg' -->";
 	print "<input name='labelsize' class='inputbox' type='text' value='$labelsize'>\n";
 	print "</td></tr>\n";
-/*
-	echo "mySale: $mySale <br>";
-	echo "mySaleLabel: $mySaleLabel <br>";
-	echo "mySaleTest: $mySaleTest";
-*/
 	if ($mySale) {
 		print "<tr>\n<td title='Deaktivere labels for kunder så det kun er ejeren der kan oprette dem'>Deaktiver labels for kunder</td>\n";
 		print "<td title='Deaktiver labels for kunder'>\n";
 		print "<input name='mySaleLabel' class='inputbox' type='checkbox' $mySaleLabel>\n";
 		print "</td></tr>\n";
 	}
-
-	print "<tr>\n<td title='Test'>mySaleTest</td>\n";
-	print "<td title='mySaleTest'>\n";
-	print "<input name='mySaleTest' class='inputbox' type='checkbox' $mySaleTest>\n";
-	print "</td></tr>\n";
-
-
 
 	print "<tr bgcolor='$bgcolor5'>\n<td title='".findtekst('194|Jobkort findes i debitorkonti. Her kan du definere opgavebeskrivelser til medarbejdere osv.', $sprog_id)."'>".findtekst('168|Brug jobkort', $sprog_id)."</td>\n";
 	print "<td title='".findtekst('194|Jobkort findes i debitorkonti. Her kan du definere opgavebeskrivelser til medarbejdere osv.', $sprog_id)."'>\n";


### PR DESCRIPTION
## Summary
On System → Settings → Misc. → Miscellaneous options, there was a checkbox labeled
"MySalesTest" that was a completely dead leftover from a debugging session — it had no
storage, no save logic, and no consumer.

## Root Cause — three separate problems
1. **Wrong query, so it always mirrored a different setting.** `sys_div_func.php:868-870`
   was a copy-paste of the `mySale` query directly above it, with only the PHP variable
   renamed to `$mySaleTest` — the SQL still selected `var_name='mySale'`. So the checkbox
   just echoed whatever "Aktivér 'Mit salg'" was set to, never its own value.
2. **Never saved.** `$_POST['mySaleTest']` was never read anywhere in the codebase — ticking
   the box and saving had zero effect; it reverted on reload.
3. **No consumer, no storage.** There's no `mySaleTest` settings row anywhere, and nothing
   else in the system queries for one. It also rendered unconditionally (outside the
   `if ($mySale) {...}` block that its neighbor field uses), so it showed up blank/broken
   even on accounts with no `mySale` setting configured at all (e.g. pos_152).

## What are the changes about?
- Removed the duplicate/mislabeled `mySale` query block that had been masquerading as the
  `mySaleTest` lookup.
- Removed the commented-out debug `echo` block (`echo "mySale: ...`, `mySaleLabel: ...`,
  `mySaleTest: ...`) sitting directly above the row — it only existed to debug the variable
  being deleted, and both repo convention and this ticket's acceptance criteria disallow
  leaving commented-out code in the diff.
- Removed the `mySaleTest` `<tr>` row itself.
- Added a file-history line per repo convention.

## Files Changed
- systemdata/sys_div_func.php

## Out of Scope (per the ticket's explicit instruction)
- `diverse.php`'s unrelated POST-data debug log that writes to a file on every save — kept
  as a separate ticket, not touched here.

## How to Test
1. Navigate to System → Settings → Misc. → Miscellaneous options.
2. Verify the page goes directly from "Aktivér 'Mit salg'" to "Label maxlength" with no
   trace of "mySaleTest"/"MySalesTest" anywhere.
3. Confirm the Save button and the rest of the form (all other fields on this page) remain
   intact and functional.
4. Check the browser console and network tab — confirm no new errors introduced.
5. Confirm no commented-out code remains in the diff.
6. Spot-check an account with `mySale` enabled and one without, confirming the removed field
   never rendered incorrectly for either case now that it's gone entirely.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | System → Settings → Misc. → Miscellaneous options page | "mySaleTest"/"MySalesTest" no longer appears anywhere |
| 2 | Save button and rest of the form | Unaffected, fully functional |
| 3 | Dead/commented-out code | None remains in the final diff |
| 4 | Scope | Limited to mySaleTest removal only; div_valg debug log left for a separate ticket |
| 5 | One ticket per PR | This PR addresses MB-28 only |

## Verification
- Live-verified via Playwright: the page now goes straight from "Aktivér 'Mit salg'" to
  "Label maxlength" with no trace of "mySaleTest"/"MySalesTest" anywhere, the Save button and
  rest of the form are intact, and there are no new console/HTTP errors.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
