### PR TITLE
SST-743: staff locked out of Mit Salg when customer sets a portal password

### DIFF
--- a/debitor/debitor_kommission.php
+++ b/debitor/debitor_kommission.php
@@ -407,6 +407,9 @@ $folder=trim($_SERVER['PHP_SELF'],'/');
 $folder=str_replace('debitor/debitor_kommission.php','',$folder);
 $myLink="https://". $_SERVER['HTTP_HOST'] .'/'. $folder ."/mysale/mysale.php?id=";
 $myLink=str_replace('bizsys','mysale',$myLink);
+# 20260828 SST-743: mysale.php accepts sha256 of a logged-in staff session as proof the visitor is
+# staff, so a customer's own portal password no longer locks staff out of the commission view.
+$staffToken = hash('sha256', session_id());
 echo "<script>console.log('link: $myLink\n')</script>";
 
 // Add clickable row renderer for all columns (whole row is clickable)
@@ -417,7 +420,7 @@ foreach ($columns as &$column) {
 	
 	if ($field == 'kontonr') {
 		// kontonr keeps special MySale link handling
-		$column["render"] = function ($value, $row, $column) use ($myLink, $db) {
+		$column["render"] = function ($value, $row, $column) use ($myLink, $db, $staffToken) {
 			// Handle kommission links: if mysale is enabled, open MySale link, otherwise go to debitorkort
 			if (isset($row['mysale']) && $row['mysale']) {
 				// Build MySale link with encoded customer data
@@ -426,6 +429,7 @@ foreach ($columns as &$column) {
 				for ($x=0;$x<strlen($txt);$x++) {
 					$lnk.=dechex(ord(substr($txt,$x,1)));
 				}
+				$lnk.='&st='.$staffToken;
 				return "<td align='{$column['align']}' onclick=\"window.open('$lnk','_blank')\" style='cursor:pointer'>$value</td>"; // <a href='$lnk' target='_blank' class='kommission-link'>$value</a>
 			} else {
 				// Link to debitorkort for customers without MySale
@@ -435,7 +439,7 @@ foreach ($columns as &$column) {
 		};
 	} else {
 		// All other columns get onclick handler
-		$column["render"] = function ($value, $row, $column) use ($originalRender, $myLink, $db) {
+		$column["render"] = function ($value, $row, $column) use ($originalRender, $myLink, $db, $staffToken) {
 			// Determine URL based on mysale status
 			if (isset($row['mysale']) && $row['mysale']) {
 				$txt = $row['id'] .'|'. $row['kontonr'] .'@'. $db .'@'. $_SERVER['HTTP_HOST'];
@@ -443,6 +447,7 @@ foreach ($columns as &$column) {
 				for ($x=0;$x<strlen($txt);$x++) {
 					$url.=dechex(ord(substr($txt,$x,1)));
 				}
+				$url.='&st='.$staffToken;
 				$openInPage = ",'_blank'";
 			} else {
 				$url = "debitorkort.php?tjek={$row['id']}&id={$row['id']}&returside=debitor_kommission.php";

--- a/mysale/mysale.php
+++ b/mysale/mysale.php
@@ -125,10 +125,6 @@ $link = $id;
 	else $account=$kto;
 }
 #if ($_SERVER['REMOTE_ADDR'] == '87.62.100.183') echo "db $db<br>";
-if (isset($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'],'debitor/debitor.php')) { # 20210505
-	$_SESSION['mySalePw'] = $s_id;
-	$_SESSION['mySaleAcId'] = $accountId;
-}
 
 if (file_exists('redirect.php')) include ('redirect.php');
 if ($id && !is_numeric($account)) {
@@ -158,6 +154,24 @@ if (!$r=db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
 }
 $qtxt = "delete from online where rettigheder = '0' and regnskabsaar = '0' and logtime < '". $logtime ."'";
 db_modify($qtxt,__FILE__ . " linje " . __LINE__);
+# 20260828 SST-743: staff access from debitor_kommission.php. Replaces the 20210505 referer bypass,
+# which stopped matching when kommissionslisten left debitor/debitor.php and the link became
+# cross-origin (browsers then send only the origin as referer). The list appends
+# st=sha256(bizsys session id); accept it when it matches a logged-in staff session for the same db.
+if (isset($_GET['st']) && $accountId && $db) {
+	$st = strtolower(preg_replace('/[^A-Fa-f0-9]/','',$_GET['st']));
+	if (strlen($st) == 64) {
+		$qtxt = "select session_id from online where db = '". db_escape_string($db) ."' and rettigheder <> '0'";
+		$q = db_select($qtxt,__FILE__ . " linje " . __LINE__);
+		while ($rs=db_fetch_array($q)) {
+			if (hash_equals(hash('sha256',(string)$rs['session_id']),$st)) {
+				$_SESSION['mySalePw'] = $s_id;
+				$_SESSION['mySaleAcId'] = $accountId;
+				break;
+			}
+		}
+	}
+}
 if ($account && !$resetPW) {
 	setcookie("mylabel","$account|$db",time()-60,"/");
 	$qtxt="SELECT column_name FROM information_schema.columns WHERE table_name='online' and column_name='sprog'";


### PR DESCRIPTION
## What are the changes about?

**Bug (SST-743, My Little Luxury / pos_76, HIGH):** when a debtor sets their own Mit Salg password, staff clicking the customer's row in Debitor → Konti → Kommission hit the customer login prompt and cannot see the commission sales. 13 accounts affected at My Little Luxury; support applied a temporary SQL workaround (clearing the passwords), which removes the customer's own protection.

**Root cause:** the staff bypass in `mysale/mysale.php` (20210505) matched `debitor/debitor.php` in the HTTP referer. It broke twice over: the commission list moved to `debitor/debitor_kommission.php` in 4.1.0, and the link opens cross-origin (`bizsys` → `mysale` subdomain), where browsers send only the origin — never the path — as referer. The check could never match again.

**Fix:**
- `debitor/debitor_kommission.php`: appends `st=sha256(staff session id)` to the mysale links in both row-render closures.
- `mysale/mysale.php`: after DB connect, grants the existing password-bypass session vars when the hash matches a logged-in bizsys session for the **same tenant db** (an `online` row with real `rettigheder`, i.e. not the '0' rows the portal itself creates). The dead referer block is removed.

**Security notes:** only the sha256 hash travels in the URL, never the session id itself, so browser history can't leak a usable session. The token is only valid while the staff session exists in `online`, is tenant-scoped, and a customer opening their link without the parameter still gets the normal password prompt — their protection is unchanged.

## How I verified this
- `php -l` clean on both files.
- Code-trace against the reproduction in SST-743 (adresser row 940 / konto 1799): with `st` matching a staff online row, `$_SESSION['mySalePw']` is set before the askPW gate at the (previous) line 185, so `askPW=0`; without `st` (customer's own mail link) behaviour is byte-identical to today.
- Behavioral test on a pos-type install (bizsys+mysale subdomains) still needed — suggest verifying on the ssl3/pos clone before it rides the Friday release: log in as staff, open konto 1799's row, expect the sales view without a prompt; open the same link in a private window, expect the password prompt.

Fixes SST-743.

## Have you checked the following?
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staff can open MySale commission views directly from the debtor grid without being blocked by the customer’s portal password.
  - Generated MySale links now support secure staff authentication.

- **Bug Fixes**
  - Replaced unreliable referrer-based access with validated, time-independent authentication for authorized staff.
  - Customer portal login behavior remains unchanged for regular access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->