### PR TITLE
SST-652: kreditor order split — fix remaining blank-page paths (Danish decimals, missing lines, posnr overflow)

### DIFF
--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -29,6 +29,10 @@
 // 20260602 PHR Definet $mQt as array if empty.
 // 20260708 MJ Guard all POST arrays; fetch antal/leveret from DB to fix index mismatch causing blank page; guard setval for MySQL.
 // 20260807 CL/NTR Use (float) instead of usdecimal() on DB-fetched antal/leveret; usdecimal() strips '.' as a thousands separator (Danish input format) which turned '2.000' into 2000, multiplying split quantities by 1000.
+// 20260828 CL SST-652: parse mQt/mSQt once (comma as decimal separator) instead of using the raw
+//             POST strings in arithmetic - '1,5' in arithmetic is a PHP8 TypeError = blank page;
+//             guard/int-cast $linje_id (count(null) is likewise fatal); cap posnr bump with LEAST()
+//             so repeated splits cannot overflow the smallint posnr column mid-transaction.
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
@@ -41,12 +45,19 @@ if (!$mQt)    $mQt    = array();
 if (!$mSQt)   $mSQt   = array();
 if (!$maxQt)  $maxQt  = array();
 if (!$maxSQt) $maxSQt = array();
+if (!isset($linje_id) || !is_array($linje_id)) $linje_id = array();
+if (!isset($vare_id)  || !is_array($vare_id))  $vare_id  = array();
 for ($x = 1; $x <= count($mQt); $x++) {
-	if (usdecimal($mQt[$x], 3)  > $maxQt[$x]) {
+	$mQt[$x]    = (float)str_replace(',', '.', (string)$mQt[$x]);
+	$mSQt[$x]   = isset($mSQt[$x])   ? (float)str_replace(',', '.', (string)$mSQt[$x]) : 0;
+	$maxQt[$x]  = isset($maxQt[$x])  ? (float)str_replace(',', '.', (string)$maxQt[$x])  : 0;
+	$maxSQt[$x] = isset($maxSQt[$x]) ? (float)str_replace(',', '.', (string)$maxSQt[$x]) : 0;
+	$linje_id[$x] = isset($linje_id[$x]) ? (int)$linje_id[$x] : 0;
+	if ($mQt[$x] > $maxQt[$x]) {
 		$mQt[$x]  = $maxQt[$x];
 		$submit = 'split';
 	}
-	if ($mSQt[$x] !=	 0 && usdecimal($mSQt[$x], 3) > $maxSQt[$x]) {
+	if ($mSQt[$x] != 0 && $mSQt[$x] > $maxSQt[$x]) {
 		$mSQt[$x] = $maxSQt[$x];
 		$submit = 'split';
 	}
@@ -79,7 +90,7 @@ else {
 		$antal[$x]   = $r ? (float)$r['antal']   : 0;
 		$leveret[$x] = $r ? (float)$r['leveret'] : 0;
 		if ($mQt[$x] && $antal[$x] == $mQt[$x]) {
-			$qtxt = "UPDATE ordrelinjer SET ordre_id = '$newId', posnr=posnr+1000 WHERE id='$linje_id[$x]'";
+			$qtxt = "UPDATE ordrelinjer SET ordre_id = '$newId', posnr=LEAST(posnr+1000,32000) WHERE id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "UPDATE batch_kob SET ordre_id = '$newId' WHERE linje_id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -99,7 +110,7 @@ else {
 			}
 			if (!$antal[$x]) $antal[$x] = 0;
 			if ($mQt[$x]) $antal[$x] = $antal[$x] - $mQt[$x];
-			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], posnr=posnr+1000 WHERE id='$linje_id[$x]'";
+			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], posnr=LEAST(posnr+1000,32000) WHERE id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "UPDATE ordrelinjer SET antal = '$mQt[$x]', leveret = '0', ordre_id = '$newId' WHERE id='$newLineId'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -107,7 +118,7 @@ else {
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		}
 		if ($mSQt[$x] && $antal[$x] == $mSQt[$x]) {
-			$qtxt = "UPDATE ordrelinjer SET ordre_id = '$newId', posnr=posnr+1000 WHERE id='$linje_id[$x]'";
+			$qtxt = "UPDATE ordrelinjer SET ordre_id = '$newId', posnr=LEAST(posnr+1000,32000) WHERE id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "UPDATE batch_kob SET ordre_id = '$newId' WHERE linje_id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -127,7 +138,7 @@ else {
 			}
 			$antal[$x] = $antal[$x] - $mSQt[$x];
 			$leveret[$x] = $leveret[$x] - $mSQt[$x];
-			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], leveret = $leveret[$x], posnr=posnr+1000 WHERE id='$linje_id[$x]'";
+			$qtxt = "UPDATE ordrelinjer SET antal = $antal[$x], leveret = $leveret[$x], posnr=LEAST(posnr+1000,32000) WHERE id='$linje_id[$x]'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 			$qtxt = "UPDATE ordrelinjer SET antal = '$mSQt[$x]', leveret = '$mSQt[$x]', ordre_id = '$newId' WHERE id='$newLineId'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);


### PR DESCRIPTION
## What are the changes about?

**Bug (SST-652, MEDSHOP, PRIORITY):** blank page when splitting a kreditor order (Opdel → Flyt). Two earlier causes are already fixed on master — the July index-mismatch fix and the ×1000 quantity fix (#452, merged 24 Aug, *after* Morten's last 'still broken' check on 5 Aug). This PR closes the three remaining ways the flow dies mid-transaction and blanks the page on PHP 8:

1. **Danish decimal input is fatal.** `mQt`/`mSQt` were validated through `usdecimal()` but the *raw* POST strings were used in arithmetic (`$antal[$x] - $mQt[$x]`) and SQL. Typing `1,5` or `1,00` — the normal Danish way — throws a TypeError in arithmetic / invalid numeric input in SQL. They are now parsed once at the top (comma as decimal separator, consistent with the 20260807 decision to stop treating '.' as a thousands separator), and validation compares the parsed floats.
2. **`count($linje_id)` fatals when null.** `$linje_id`/`$vare_id` come from ordre.php scope and were the only arrays not guarded; `count(null)` is a PHP 8 TypeError. Guarded like the other POST arrays, and line ids are int-cast before use in SQL (per the SST-652 acceptance criteria on request input).
3. **`posnr=posnr+1000` overflows smallint.** posnr is stored ×100, so large orders sit close to the 32767 smallint cap; each split adds 1000 and an overflow aborts the whole transaction. Capped with `LEAST(posnr+1000,32000)` (works on both PostgreSQL and MySQL) in all four sites.

## How I verified this
- `php -l` clean.
- Code-trace of the ticket's repro (Kreditor ordre 15885 → Opdel → move 1 stk to existing order 15541): with plain integer input the flow was already healthy on master post-#452; each of the three fixed paths reproduces the blank page by inspection (TypeError / TypeError / SQL out-of-range inside the `transaktion('begin')` block, where any failed statement aborts the transaction and the redirect never renders).
- Suggest QA re-runs Morten's repro on ssl3 dev after merge, including once with `1,00` as the quantity — that input crashes current master and succeeds with this PR.

One ticket per PR (SST-652 only); no dead code added; all request input used in SQL is cast or parsed to numeric.

Fixes SST-652.

## Have you checked the following?
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order-line splitting when quantity or line-item data is missing, malformed, or formatted with decimal commas.
  * Prevented errors when splitting orders repeatedly, including position-number overflow.
  * Improved handling of line-item identifiers to ensure split operations complete reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->