### PR TITLE
SST-746 (skeleton): e-invoice discount-to-allowance splitter, pending EasyUBL schema answer

### DIFF
--- a/includes/einvoiceAllowance.php
+++ b/includes/einvoiceAllowance.php
@@ -1,0 +1,81 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- includes/einvoiceAllowance.php --- patch 5.0.0 --- 2026-08-28 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+//
+// Copyright (c) 2008-2026 Danosoft.ApS
+// ----------------------------------------------------------------------
+//
+// 20260828 CL SST-746: Peppol BIS 3.0 (BR-27) rejects invoice lines with a negative
+//             item net price, but Saldi stores order-level discounts as ordinary
+//             order lines with a negative unit price (typically varenr '999rabat').
+//             This helper splits a built invoiceLines array by SIGN of lineAmount:
+//             negative lines become document-level allowanceCharges entries with a
+//             POSITIVE amount and isCharge=false, everything else passes through
+//             untouched. Detection is by sign, not varenr - the DB holds negative
+//             lines under several item numbers and 224 with none at all.
+//
+//             NOT yet wired into debitor/api.php sendInvoice(). Wiring notes:
+//             - Must run on lines that still carry their ORIGINAL sign: the
+//               credit-note branch at the top of the ordrelinjer loop abs()'es
+//               pris, which flips a rebate to a positive charge and makes the
+//               credit note credit too much. Split first, abs() after.
+//             - The allowance must carry the same VAT category/rate as the goods
+//               (the discount line itself has momssats=0, but the order's VAT is
+//               computed AFTER discount). Field name for VAT on an allowance is
+//               pending confirmation from EasyUBL - see the vatPercent TODO below.
+
+/**
+ * Split built e-invoice lines into (lines to send, document-level allowances).
+ *
+ * @param array $lines           Line arrays as built in sendInvoice(); each must
+ *                               carry at least 'lineAmount' and 'description'.
+ * @param float $goodsVatPercent VAT rate the allowance must be deducted under -
+ *                               the goods' rate, NOT the discount line's own
+ *                               momssats (which is 0 in the DB).
+ * @return array [0] => lines with non-negative lineAmount, reindexed;
+ *               [1] => allowanceCharges entries (EasyUBL stub field names).
+ */
+function einvoice_split_allowances(array $lines, $goodsVatPercent)
+{
+	$invoiceLines = array();
+	$allowances = array();
+	foreach ($lines as $l) {
+		$lineAmount = isset($l['lineAmount']) ? (float)$l['lineAmount'] : 0.0;
+		if ($lineAmount < 0) {
+			$allowances[] = array(
+				'isCharge'   => false,               // false = allowance (discount)
+				'reasonCode' => '95',                // UNCL5189: 95 = Discount
+				'reason'     => isset($l['description']) && trim((string)$l['description']) !== ''
+									? $l['description'] : 'Rabat',
+				'percentage' => 0,
+				'amount'     => round(abs($lineAmount), 2),
+				'baseAmount' => 0,
+				// TODO SST-746: confirm with EasyUBL which field carries the VAT
+				// category/rate for an allowance; without it the allowance lands
+				// outside the goods' VAT base and totals fail BR-CO-10/BR-CO-13.
+				'vatPercent' => (float)$goodsVatPercent,
+			);
+		} else {
+			$invoiceLines[] = $l;
+		}
+	}
+	return array($invoiceLines, $allowances);
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,5 +21,8 @@
     <testsuite name="restapi">
       <directory suffix="Test.php">tests/restapi</directory>
     </testsuite>
+    <testsuite name="einvoice">
+      <directory suffix="Test.php">tests/einvoice</directory>
+    </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/einvoice/EinvoiceAllowanceSplitTest.php
+++ b/tests/einvoice/EinvoiceAllowanceSplitTest.php
@@ -1,0 +1,86 @@
+<?php
+// tests/einvoice/EinvoiceAllowanceSplitTest.php
+//
+// SST-746: order-level discounts stored as negative-price order lines must leave
+// invoiceLines and become document-level allowances (Peppol BR-27 forbids a
+// negative item net price). The fixture is the real rejected invoice from the
+// ticket: MEDSHOP faktura 236656 / ordre 159417.
+//
+// History:
+// 20260828 CL SST-746: created with the splitter (skeleton PR - splitter not yet
+//             wired into debitor/api.php sendInvoice()).
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/einvoiceAllowance.php';
+
+final class EinvoiceAllowanceSplitTest extends TestCase
+{
+	/** Lines of faktura 236656 (ordre 159417) as sendInvoice() builds them today. */
+	private function faktura236656Lines(): array
+	{
+		return [
+			['id' => '100', 'lineAmount' => 17196.00, 'price' => 17196.00, 'description' => 'EKG SE-1200 EKG 12-kanal', 'vatPercent' => 25],
+			['id' => '200', 'lineAmount' => 0.00,     'price' => 0.00,     'description' => 'SN: 460016-M25201720003', 'vatPercent' => 0],
+			['id' => '300', 'lineAmount' => -600.00,  'price' => -600.00,  'description' => 'Rabat', 'vatPercent' => 0],
+			['id' => '400', 'lineAmount' => 49.00,    'price' => 49.00,    'description' => 'EKG-papir - EDAN-1200', 'vatPercent' => 25],
+		];
+	}
+
+	public function testDiscountLineBecomesPositiveAllowance(): void
+	{
+		[$lines, $allowances] = einvoice_split_allowances($this->faktura236656Lines(), 25);
+
+		$this->assertCount(3, $lines, 'the three non-negative lines stay invoice lines');
+		$this->assertCount(1, $allowances);
+
+		$a = $allowances[0];
+		$this->assertFalse($a['isCharge'], 'a discount is an allowance, not a charge');
+		$this->assertSame('95', $a['reasonCode'], 'UNCL5189 code 95 = Discount');
+		$this->assertSame(600.00, $a['amount'], 'amount is POSITIVE (BR-27)');
+		$this->assertSame('Rabat', $a['reason']);
+		$this->assertSame(25.0, $a['vatPercent'],
+			'allowance carries the GOODS VAT rate, not the discount line\'s momssats=0');
+	}
+
+	public function testTotalsStillReconcile(): void
+	{
+		[$lines, $allowances] = einvoice_split_allowances($this->faktura236656Lines(), 25);
+
+		$lineSum = round(array_sum(array_column($lines, 'lineAmount')), 2);
+		$allowanceSum = round(array_sum(array_column($allowances, 'amount')), 2);
+
+		$this->assertSame(17245.00, $lineSum, '17196 + 0 + 49');
+		// Header of ordre 159417: sum = 16645.00, moms = 4161.25 (25% of the discounted base).
+		$this->assertSame(16645.00, round($lineSum - $allowanceSum, 2), 'matches ordrer.sum');
+		$this->assertSame(4161.25, round(($lineSum - $allowanceSum) * 0.25, 2), 'matches ordrer.moms');
+	}
+
+	public function testInvoiceWithoutDiscountIsUntouched(): void
+	{
+		$input = [
+			['id' => '100', 'lineAmount' => 100.00, 'description' => 'Vare A', 'vatPercent' => 25],
+			['id' => '200', 'lineAmount' => 0.00,   'description' => 'Tekstlinje', 'vatPercent' => 0],
+		];
+		[$lines, $allowances] = einvoice_split_allowances($input, 25);
+		$this->assertSame($input, $lines, 'discount-free payloads must be byte-identical');
+		$this->assertSame([], $allowances);
+	}
+
+	public function testCreditNoteRebateStaysAllowanceWithOriginalSign(): void
+	{
+		// The credit-note branch in sendInvoice() abs()'es prices BEFORE lines are
+		// built, which turns a -600 rebate into +600 and over-credits the customer.
+		// The splitter must therefore receive lines with their ORIGINAL sign; given
+		// that, a rebate on a credit note is still an allowance, never a charge.
+		$creditLines = [
+			['id' => '100', 'lineAmount' => 17196.00, 'description' => 'EKG SE-1200 EKG 12-kanal', 'vatPercent' => 25],
+			['id' => '300', 'lineAmount' => -600.00,  'description' => 'Rabat', 'vatPercent' => 0],
+		];
+		[$lines, $allowances] = einvoice_split_allowances($creditLines, 25);
+		$this->assertCount(1, $lines);
+		$this->assertCount(1, $allowances);
+		$this->assertFalse($allowances[0]['isCharge']);
+		$this->assertSame(600.00, $allowances[0]['amount']);
+	}
+}


### PR DESCRIPTION
## What are the changes about?

Skeleton for the SST-746 fix (MEDSHOP: discounts must go out as Allowance, not negative invoice lines — Peppol BR-27). This PR adds the pure splitter + tests so the actual fix is a same-day wiring job once EasyUBL answers the schema question; it deliberately does **not** touch `sendInvoice()` yet.

- `includes/einvoiceAllowance.php`: `einvoice_split_allowances()` — splits built invoice lines **by sign of lineAmount** (not varenr — the DB has 4,249 negative lines across several item numbers, 224 with none): negative lines become `allowanceCharges` entries with a positive amount, `isCharge: false`, reasonCode 95, and the **goods' VAT rate** (the discount line's own momssats is 0, but the order's VAT is computed after discount — a 0% allowance fails BR-CO-10/13).
- `tests/einvoice/EinvoiceAllowanceSplitTest.php`: reproduces the rejected MEDSHOP invoice 236656 (ordre 159417): 17.196 + 0 + (−600) + 49 → 3 lines + one 600,00 allowance; totals reconcile to `sum = 16.645` / `moms = 4.161,25`; discount-free payloads byte-identical; credit-note rebates stay allowances (documents the `abs()` over-credit bug the wiring must fix).
- `phpunit.xml`: new `einvoice` testsuite.

## Gated on (before un-drafting)
1. EasyUBL's answer: does `isAllowanceCharge: true` with a negative amount get transformed server-side (then a3220aba may suffice and this simplifies), and which field carries VAT on an allowance? (Mail drafted; alternatively resending faktura 236656 after Friday's deploy answers question 1 empirically.)
2. Wiring in `sendInvoice()` must run **before** the credit-note `abs()` at the top of the ordrelinjer loop, and must supersede the a3220aba flag for negative lines — one mechanism, not two.

## How I verified this
`php tools/php/phpw.php vendor/bin/phpunit --testsuite einvoice` → OK (4 tests, 16 assertions). `php -l` clean. No runtime behavior changes in this PR — nothing includes the new helper yet.

Related: SST-746 (Jira has the full verification of master's current partial state).

## Have you checked the following?
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)