### PR TITLE
MB-22: OIOUBL/OIOXML pages point validation errors at a dead mailbox — now Support@danosoft.dk

### DIFF
--- a/debitor/oioubl_dok.php
+++ b/debitor/oioubl_dok.php
@@ -26,6 +26,7 @@ $s_id=session_id();
 
 // 2012.09.20 Tilføjet integration med ebconnect
 // 2015.12.23 Rettet addslashes til db_escape_string
+// 2026.08.28 CL MB-22: valideringsfejl-mailadresse rettet fra oio@saldi.dk til Support@danosoft.dk
 
 #$testdok="Tester"; # Skal slettes naar test er faerdig
 $css="../css/standard.css";
@@ -135,7 +136,7 @@ if ($r['box8']) {
 	print "<p>Hvis du vil teste OIOUBL-filen kan validering af filen ske med \n";
 	print "<a href=\"https://oioubl-demo.nemhandel.dk/validation\" title=\"ITST - OIOUBL Online Validator\" target=\"blank\">OIOUBL Validator</a>.</p>\n";
 	print "<p>Hvis OIOUBL-filen ikke validerer, s&aring; send filen vedlagt en e-mail til \n";
-	print "<a href=\"mailto:oio@saldi.dk\">oio@saldi.dk</a>, s&aring; vi kan finde &aring;rsagen. P&aring; forh&aring;nd tak.</p>\n\n";  
+	print "<a href=\"mailto:Support@danosoft.dk\">Support@danosoft.dk</a>, s&aring; vi kan finde &aring;rsagen. P&aring; forh&aring;nd tak.</p>\n\n";  
 
 }
 

--- a/debitor/oioxml_dok.php
+++ b/debitor/oioxml_dok.php
@@ -24,6 +24,8 @@ $s_id=session_id();
 // Copyright (c) 2004-2012 DANOSOFT ApS
 // ----------------------------------------------------------------------
 
+// 2026.08.28 CL MB-22: valideringsfejl-mailadresse rettet fra oio@saldi.dk til Support@danosoft.dk
+
 $css="../css/standard.css";
 
 #$form=array();
@@ -89,7 +91,7 @@ print "<a href=\"http://xmltools.oio.dk/oioonlinevalidator/index.aspx\" title=\"
 print "<p>Validatoren kr&aelig;ver, at hele indholdet af OIOXML-filen kopieres ind i tekstfeltet. S&aring; &aring;bn filen i en teksteditor, \n";
 print "mark&eacute;r det hele med CTRL-A, kopi&eacute;r med CTRL-C og inds&aelig;t det i tekstfeltet med CTRL-V.</p>\n\n";
 print "<p>Hvis OIOXML-filen ikke validerer s&aring; send filen vedlagt en e-mail til \n";
-print "<a href=\"mailto:oio@saldi.dk\">oio@saldi.dk</a>, s&aring; vi kan finde &aring;rsagen. P&aring; forh&aring;nd tak.</p>\n\n";  
+print "<a href=\"mailto:Support@danosoft.dk\">Support@danosoft.dk</a>, s&aring; vi kan finde &aring;rsagen. P&aring; forh&aring;nd tak.</p>\n\n";  
 
 # Kommenteringern af disse linjer skal slettes, naar bidragssiden er paa plads - slet ogsaa slut linjen \n"; 
 /*


### PR DESCRIPTION
## What are the changes about?

MB-22: both e-invoice document pages (`debitor/oioubl_dok.php` and the older `debitor/oioxml_dok.php`) tell the user to mail a failing file to **oio@saldi.dk**, which is not monitored — customer validation problems go into a void. Display text and the `mailto:` link now point to **Support@danosoft.dk** on both pages (the ticket only screenshotted the OIOUBL page, but the OIOXML page has the identical sentence).

Two-line change + changelog comments per file convention. No logic touched.

## How I verified this
`php -l` clean on both files; `git grep oio@saldi` returns nothing on the branch — no other occurrence exists in the repo.

Fixes MB-22.

## Have you checked the following?
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the support email address displayed in OIOUBL and OIOXML validation help and error messages.
  * Users are now directed to the correct support contact for validation assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->