### PR TITLE
Fix: Kontokort report shows identical Saldo on every line (MB-34)

### DIFF
--- a/finans/rapport_includes/kontokort.php
+++ b/finans/rapport_includes/kontokort.php
@@ -31,7 +31,10 @@
 // 20210301 PHR error in csv.
 // 20250130 migrate utf8_en-/decode() to mb_convert_encoding
 // 20260309 LOE Fixed execessive error logging relating to undefined array keys.
-// 20260430 LOE Updated the top menu and made the report header sticky when scrolling. 
+// 20260430 LOE Updated the top menu and made the report header sticky when scrolling.
+// 20260901 CL/LAH Fixed Saldo column showing the same value on every line:
+//                  running balance was only accumulated for rows skipped by
+//                  pagination, never for the printed rows.
 
 function kontokort($regnaar, $maaned_fra, $maaned_til, $aar_fra, $aar_til,
                    $dato_fra, $dato_til, $konto_fra, $konto_til, $rapportart,
@@ -780,9 +783,9 @@ print "<tbody>";
                 // (moved up so it runs before the skip check)
                 $debet_val  = afrund($debet[$tr], 2);
                 $kredit_val = afrund($kredit[$tr], 2);
+                $kontosum += $debet_val - $kredit_val;
 
                 if ($rows_to_skip > 0) {
-                    $kontosum += $debet_val - $kredit_val;
                     $rows_to_skip--;
                     continue;
                 }


### PR DESCRIPTION
## Problem
Finans → Rapporter → Kontokort: the Saldo column shows the same value (the primosaldo) on every line for an account instead of a running balance. The CSV export has the same defect.

## Cause
When pagination was added, the running-balance line (`$kontosum += debet - kredit`) was moved into the `rows_to_skip` branch in `finans/rapport_includes/kontokort.php`. It therefore only ran for rows skipped by pagination — never for the rows actually printed, so every printed line repeated the balance as of the start of the page.

## Fix
Hoist the accumulation out of the skip branch so it runs for every transaction row, printed or skipped. This restores the original semantics (each line's Saldo includes its own posting): the debet/kredit cells print from the row values directly, and the saldo cell — including the currency-account branch dividing by `transkurs` — reads `$kontosum` after the row is applied. Cross-page consistency is unchanged: the next page still re-derives its opening balance by summing the skipped rows.

## Test
- Kontokort for an account with many postings (e.g. 25100 Debitorer): Saldo now changes line by line; last visible line on page 1 equals the opening context of page 2.
- Page 2+ of a paginated account: first line's Saldo continues from where page 1 ended.
- Currency account (kontovaluta set): Saldo still converted via transkurs, tooltip shows DKK value.
- CSV export: Saldo column shows the same running values as the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUrafXy5qSgAsBnzuefqcA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected running-balance calculations in account statements.
  * Balances now remain accurate across paginated and displayed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->