### PR TITLE
MB-31: add standardised per-column search to Product sales and Invent…

### DIFF
--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -200,6 +200,10 @@ if ($varenrSoeg && $varenrSoeg != '*') {
 	if (strstr($varenrSoeg, "*")) {
 		if (substr($varenrSoeg,0,1)=='*') $varenrSoeg="%".substr($varenrSoeg,1);
 		if (substr($varenrSoeg,-1,1)=='*') $varenrSoeg=substr($varenrSoeg,0,strlen($varenrSoeg)-1)."%";
+	} else {
+		// MB-31/CodeRabbit - no explicit '*' anchor still needs to match as a substring, same as
+		// every other per-column search box in this grid row (e.g. Enhed just below).
+		$varenrSoeg = "%".$varenrSoeg."%";
 	}
 	$low=strtolower($varenrSoeg);
 	$upp=strtoupper($varenrSoeg);
@@ -209,6 +213,9 @@ if ($varenavn && $varenavn != '*') {
 	if (strstr($varenavn, "*")) {
 		if (substr($varenavn,0,1)=='*') $varenavn="%".substr($varenavn,1);
 		if (substr($varenavn,-1,1)=='*') $varenavn=substr($varenavn,0,strlen($varenavn)-1)."%";
+	} else {
+		// MB-31/CodeRabbit - same substring-match fallback as Varenr. above.
+		$varenavn = "%".$varenavn."%";
 	}
 	$low=strtolower($varenavn);
 	$upp=strtoupper($varenavn);
@@ -277,7 +284,10 @@ global $menu;
 //             with a sticky colgroup-driven column-title row, and a fixed footer with real
 //             (server-side) pagination. $menu != 'S' keeps the old, unstyled chrome unchanged.
 $lsGridMode = ($menu=='S');
+// MB-31/CodeRabbit - propagate every $lsSFields numeric filter (not just varenr/varenavn/enhed),
+// same as $lsBaseUrlParams below does for pagination, so a CSV export matches what the grid shows.
 $lsCsvHref = "lagerstatus.php?dato=$dato&varegruppe=$varegruppe&csv=1&zStock=$zStock&showClosed=$showClosed&lagervalg=$lagervalg&varenr=".urlencode((string)$varenrSoeg)."&varenavn=".urlencode((string)$varenavn)."&enhed=".urlencode((string)$enhedSoeg);
+foreach ($lsSFields as $lsSField) $lsCsvHref .= "&lss_".$lsSField."=".urlencode((string)$lsS[$lsSField]);
 
 if ($lsGridMode) {
 	$lsTilbageIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
@@ -621,7 +631,14 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 		if ($csv) {
 			$linje="$varenr[$x]".";"."$enhed[$x]".";"."$beskrivelse[$x]".";"."$batch_k_antal[$x]".";"."$batch_s_antal[$x]".";".$batch_t_antal[$x].";".dkdecimal($batch_pris[$x]).";".dkdecimal($kostpris[$x]*$batch_t_antal[$x]).";".dkdecimal($salgspris[$x]*$batch_t_antal[$x]);
 #			$linje=mb_convert_encoding($linje, 'ISO-8859-1', 'UTF-8');
-			fwrite($fp,"$linje\n");
+			if ($lsGridMode) {
+				// MB-31/CodeRabbit - deferred so a search actually filters what lands in the CSV too: written
+				// to the file only for matching rows, in the unified filter step below (same $lsMatchIndices
+				// as $lsAllChunks/$lsRowValues, so the index this candidate gets here stays aligned with them).
+				$lsCsvLines[] = $linje;
+			} else {
+				fwrite($fp,"$linje\n");
+			}
 		}
 		if ($lsGridMode) {
 			// MB-31 - snapshot of this item's already-computed values, used only to filter/paginate/total
@@ -673,6 +690,13 @@ if ($lsGridMode) {
 	}
 	for ($lsCi = $lsPageStart; $lsCi < min($lsPageEnd, count($lsMatchIndices)); $lsCi++) {
 		print $lsAllChunks[$lsMatchIndices[$lsCi]];
+	}
+	if ($csv) {
+		// MB-31/CodeRabbit - write only the matching rows' buffered CSV lines (see $lsCsvLines above),
+		// not every item, so a filtered CSV export actually matches what the grid shows on screen.
+		foreach ($lsMatchIndices as $lsI) {
+			if (isset($lsCsvLines[$lsI])) fwrite($fp, $lsCsvLines[$lsI]."\n");
+		}
 	}
 }
 if ($csv){

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -39,6 +39,41 @@
 // 20260217 PHR Removed fiscal_year from 'LG' serach
 // 20260707 CL/SZ Added Grid Framework sticky header and footer to Stock Status report
 // 20260710 SZ Added Grid Framework sticky header+footer with pagination and internal-scroll grid
+// 20260901 CL/SZ MB-31: added a standardised per-column Varenr./Beskrivelse search row directly
+//             under the sticky column-title row (matching lager/lister/vareliste.php's
+//             create_datagrid() search row) - this report had no free-text search at all, unlike
+//             lager/rapport.php's front page. Same wildcard/case-insensitive LIKE pattern already
+//             used there, applied to the existing candidate query. The search term is
+//             $varenrSoeg, not $varenr, to avoid clobbering the existing per-item $varenr[$x] array
+//             further down (caught live against a real tenant - first version silently turned every
+//             result row's item-number display into "Array" and broke pagination links)
+
+// MB-31 - one <input> per grid search column (see $lsSFields further down); every such box uses this
+// same markup.
+function lsSearchInput($name, $value) {
+	return "<input class='inputbox' type='text' name='lss_$name' value='" . htmlspecialchars((string)$value, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+}
+// MB-31 - matches one item's already-computed $values (see $lsRowValues) against every non-blank term
+// in $search (the $lsS array): an exact numeric match (rounded to 2 decimals, same as the report
+// already displays) or a "min:max" range if the box contains a colon - same convention
+// includes/grid.php's own generic search uses for its 'number' column type (Enhed is a plain text
+// column and stays a SQL-level substring filter instead, alongside Varenr./Beskrivelse).
+function lsRowMatchesSearch($values, $search) {
+	foreach ($search as $field => $term) {
+		$term = trim((string)$term);
+		if ($term === '' || !array_key_exists($field, $values)) continue;
+		$value = $values[$field];
+		if (strpos($term, ':') !== false) {
+			list($lo, $hi) = explode(':', $term, 2);
+			$lo = trim((string)$lo) === '' ? -INF : usdecimal($lo);
+			$hi = trim((string)$hi) === '' ? INF : usdecimal($hi);
+			if (round((float)$value, 2) < $lo || round((float)$value, 2) > $hi) return false;
+		} elseif (round((float)$value, 2) != usdecimal($term)) {
+			return false;
+		}
+	}
+	return true;
+}
 
 @session_start();
 $s_id=session_id();
@@ -59,7 +94,18 @@ db_modify("update varer set lukket = '0' where lukket is NULL or lukket = ''",__
 
 # if ($popup) $returside="../includes/luk.php";
 # else $returside="rapport.php";
-$scv = $dato = $dateType = $opdater = $lagervalg = $ret_behold = $zStock = $saldi_lagerstatus = $showClosed = $varegruppe = NULL;
+$scv = $dato = $dateType = $opdater = $lagervalg = $ret_behold = $zStock = $saldi_lagerstatus = $showClosed = $varegruppe = $varenrSoeg = $varenavn = $enhedSoeg = NULL;
+
+// MB-31 - one search box per grid column, matching every other list in the app (create_datagrid()).
+// Enhed is a plain stored column, so like Varenr./Beskrivelse above it stays a SQL-level filter -
+// named $enhedSoeg (not $enhed) to avoid colliding with the existing per-item $enhed[$x] array further
+// down, same reason $varenrSoeg isn't just $varenr. Every other column here is a per-item computed
+// value with no column to filter on directly, so those are read into one array and matched against
+// each item's already-computed value further down (see $lsRowValues/$lsMatchIndices), not the query.
+$lsSFields = array('tilgang','afgang','antal','kobspris','kostpris','salgspris');
+$lsS = array();
+foreach ($lsSFields as $lsSField) $lsS[$lsSField] = isset($_GET['lss_'.$lsSField]) ? trim($_GET['lss_'.$lsSField]) : null;
+$enhedSoeg = isset($_GET['enhed']) ? trim($_GET['enhed']) : null;
 
 $returside="rapport.php";
 
@@ -83,6 +129,12 @@ if (isset($_GET['dato']) && $_GET['dato']) {
 	$lagervalg  = $_GET['lagervalg'];
 	$zStock     = $_GET['zStock'];
 	$showClosed = $_GET['showClosed'];
+	// 20260901 CL/SZ - named $varenrSoeg (not $varenr): this file already has a per-item $varenr[$x]
+	// array further down (the item number shown in each result row) - reusing the bare name here would
+	// silently clobber that array with this scalar search term, so the request field stays "varenr" but
+	// the PHP variable holding it is renamed to avoid the collision.
+	$varenrSoeg = isset($_GET['varenr'])   ? $_GET['varenr']   : null;
+	$varenavn   = isset($_GET['varenavn']) ? $_GET['varenavn'] : null;
 } elseif (!$varegruppe)  {
 	$dato       = date("d-m-Y");
 	$dateType   = 'levdate';
@@ -96,6 +148,10 @@ if (isset($_POST['dato']) && $_POST['dato']) {
 	$lagervalg  = $_POST['lagervalg'];
 	$zStock     = $_POST['zStock'];
 	$showClosed = $_POST['showClosed'];
+	$varenrSoeg = isset($_POST['varenr'])   ? trim($_POST['varenr'])   : null;
+	$varenavn   = isset($_POST['varenavn']) ? trim($_POST['varenavn']) : null;
+	$enhedSoeg  = isset($_POST['enhed'])    ? trim($_POST['enhed'])    : null;
+	foreach ($lsSFields as $lsSField) $lsS[$lsSField] = isset($_POST['lss_'.$lsSField]) ? trim($_POST['lss_'.$lsSField]) : null;
 	setcookie("saldi_lagerstatus", $varegruppe);
 }
 if (!$dateType) $dateType   = 'levdate';
@@ -135,6 +191,35 @@ if (count($lager)>=1) {
 $x=0;
 list($a,$b)=explode(":",$varegruppe);
 
+// 20260901 CL/SZ MB-31 - same wildcard/case-insensitive LIKE pattern lager/rapport.php's forside()
+// already uses for these same two fields; built once and appended (as "and (...)") to whichever of
+// the 4 candidate queries below runs, so a real Jira ticket key/description search actually narrows
+// this report instead of only filtering by Varegruppe/Lager/Dato.
+$vareSearchSql = "";
+if ($varenrSoeg && $varenrSoeg != '*') {
+	if (strstr($varenrSoeg, "*")) {
+		if (substr($varenrSoeg,0,1)=='*') $varenrSoeg="%".substr($varenrSoeg,1);
+		if (substr($varenrSoeg,-1,1)=='*') $varenrSoeg=substr($varenrSoeg,0,strlen($varenrSoeg)-1)."%";
+	}
+	$low=strtolower($varenrSoeg);
+	$upp=strtoupper($varenrSoeg);
+	$vareSearchSql.=" and (varer.varenr LIKE '".db_escape_string($varenrSoeg)."' or lower(varer.varenr) LIKE '".db_escape_string($low)."' or upper(varer.varenr) LIKE '".db_escape_string($upp)."')";
+}
+if ($varenavn && $varenavn != '*') {
+	if (strstr($varenavn, "*")) {
+		if (substr($varenavn,0,1)=='*') $varenavn="%".substr($varenavn,1);
+		if (substr($varenavn,-1,1)=='*') $varenavn=substr($varenavn,0,strlen($varenavn)-1)."%";
+	}
+	$low=strtolower($varenavn);
+	$upp=strtoupper($varenavn);
+	$vareSearchSql.=" and (varer.beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(varer.beskrivelse) LIKE '".db_escape_string($low)."' or upper(varer.beskrivelse) LIKE '".db_escape_string($upp)."')";
+}
+if ($enhedSoeg) {
+	// MB-31 - Enhed's search box: substring match (not exact/wildcard like Varenr./Beskrivelse above),
+	// same convention includes/grid.php's own DEFAULT_GENERATE_SEARCH() uses for its 'text' columns.
+	$vareSearchSql.=" and varer.enhed ILIKE '%".db_escape_string($enhedSoeg)."%'";
+}
+
 if ($a) {
 	if ($lagervalg) {
 		$qtxt = "select varer.id,varer.varenr,varer.enhed,varer.beskrivelse,varer.salgspris,varer.kostpris,varer.varianter,varer.gruppe,";
@@ -142,11 +227,13 @@ if ($a) {
 		$qtxt.= "from varer,lagerstatus where varer.gruppe='$a' and lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
 		if (!$zStock) $qtxt.= "and lagerstatus.beholdning != '0' ";
 		if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		$qtxt.= "$vareSearchSql ";
 		$qtxt.="order by varer.varenr";
 	} else {
 	   $qtxt = "select * from varer where gruppe='$a' ";
 	   if (!$zStock) $qtxt.= "and beholdning != '0' ";
 	   if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+	   $qtxt.= "$vareSearchSql ";
 	   $qtxt.= "order by varenr";
 	}
 } else {
@@ -156,13 +243,15 @@ if ($a) {
 		$qtxt.= "from varer,lagerstatus where lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
 		if (!$zStock) $qtxt.= "and lagerstatus.beholdning != '0' ";
 	   if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		$qtxt.= "$vareSearchSql ";
 		$qtxt.= " order by varer.varenr";
 	} else {
-		$qtxt = "select * from varer ";
+		$qtxt = "select * from varer where 1=1 ";
 		if (!$zStock) {
-			$qtxt.= "where beholdning != '0' ";
+			$qtxt.= "and beholdning != '0' ";
 			if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
-		} elseif (!$showClosed) $qtxt.= "where varer.lukket = '0' ";
+		} elseif (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		$qtxt.= "$vareSearchSql ";
 		$qtxt.= "order by varenr";
 	}
 }
@@ -188,7 +277,7 @@ global $menu;
 //             with a sticky colgroup-driven column-title row, and a fixed footer with real
 //             (server-side) pagination. $menu != 'S' keeps the old, unstyled chrome unchanged.
 $lsGridMode = ($menu=='S');
-$lsCsvHref = "lagerstatus.php?dato=$dato&varegruppe=$varegruppe&csv=1&zStock=$zStock&showClosed=$showClosed&lagervalg=$lagervalg";
+$lsCsvHref = "lagerstatus.php?dato=$dato&varegruppe=$varegruppe&csv=1&zStock=$zStock&showClosed=$showClosed&lagervalg=$lagervalg&varenr=".urlencode((string)$varenrSoeg)."&varenavn=".urlencode((string)$varenavn)."&enhed=".urlencode((string)$enhedSoeg);
 
 if ($lsGridMode) {
 	$lsTilbageIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
@@ -280,12 +369,57 @@ if ($lsGridMode) {
 	print "<style>
 #lsGridWrapper { flex:1 1 auto; min-height:0; overflow-y:auto; overscroll-behavior:contain; width:100%; background-color:$bgcolor; padding:0 8px 68px 8px; box-sizing:border-box; }
 #lsGridTable { border-collapse:separate; border-spacing:0; width:100%; table-layout:fixed; }
-#lsGridTable th { position:sticky; top:0; z-index:10; padding:6px 4px; background-color:$bgcolor; box-sizing:border-box; text-align:left; }
+/* This page's legacy doctype puts the browser in quirks mode, where two independently
+   position:sticky <tr>s in one table both lose their stickiness the moment there are two of
+   them - confirmed live (hiding the search row on its own made the title row stick again).
+   Sticking the whole <thead> as a single unit sidesteps that and keeps both rows pinned
+   together, same as includes/grid.php's own .datatable thead { position:sticky } does. */
+#lsGridTable thead { position:sticky; top:0; z-index:10; }
+#lsGridTable th { padding:6px 4px; background-color:$bgcolor; box-sizing:border-box; text-align:left; }
 #lsGridTable td { box-sizing:border-box; padding:4px; }
 #lsGridTable th.text-right { text-align:right; }
+#lsGridTable tr.ls-search-row th { background-color:$bgcolor; font-weight:normal; padding:2px 4px; }
+/* .inputbox (css/standard.css) doesn't style :disabled, so the placeholder boxes on columns with
+   no real search field looked identical to the two working ones (Varenr./Beskrivelse) - blend
+   them into the row instead so it's visually clear only those two are actually searchable. */
+#lsGridTable tr.ls-search-row input:disabled { background-color:$bgcolor; border-color:$bgcolor; cursor:default; }
 </style>\n";
 	$lsColgroupHtml = "<colgroup><col style='width:10%'><col style='width:6%'><col style='width:34%'><col style='width:8%'><col style='width:8%'><col style='width:8%'><col style='width:9%'><col style='width:9%'><col style='width:8%'></colgroup>";
-	print "<div id='lsGridWrapper'><table id='lsGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$lsColgroupHtml<tbody>";
+	// MB-31 - standardised per-column search row (matches lager/lister/vareliste.php's
+	// create_datagrid()/includes/grid.php render_table_headers(): a second <tr> of <th> search
+	// inputs inside the same sticky <thead> as the column-title row, not a row below it). A
+	// second <form> wraps just the grid table, carrying the filter-form's current settings as
+	// hidden fields so a search resubmit doesn't lose them; a hidden submit input keeps Enter-key
+	// submission working without showing a visible per-column OK button (grid.php's own search
+	// row has none either - it submits via JS, this submits via a plain hidden reload instead).
+	// display:flex/flex:1/min-height:0 here make the <form> a transparent pass-through in the
+	// #lsPageFlex flex column: without them the form (a plain block box) breaks the flex chain
+	// between #lsPageFlex and #lsGridWrapper, #lsGridWrapper's own flex:1 has no effect, it grows to
+	// its full content height instead of the viewport, and the sticky header/search rows have no
+	// scrolling ancestor to stick within - this is what broke the header/search scroll-pinning.
+	print "<form name='lsInlineSearch' action='lagerstatus.php' method='post' style='display:flex;flex-direction:column;flex:1 1 auto;min-height:0;'>";
+	print "<input type='hidden' name='dato' value='" . htmlspecialchars((string)$dato, ENT_QUOTES) . "'>";
+	print "<input type='hidden' name='dateType' value='" . htmlspecialchars((string)$dateType, ENT_QUOTES) . "'>";
+	print "<input type='hidden' name='varegruppe' value='" . htmlspecialchars((string)$varegruppe, ENT_QUOTES) . "'>";
+	print "<input type='hidden' name='lagervalg' value='" . htmlspecialchars((string)$lagervalg, ENT_QUOTES) . "'>";
+	print "<input type='hidden' name='zStock' value='" . htmlspecialchars((string)$zStock, ENT_QUOTES) . "'>";
+	print "<input type='hidden' name='showClosed' value='" . htmlspecialchars((string)$showClosed, ENT_QUOTES) . "'>";
+	print "<input type='submit' style='position:absolute;width:1px;height:1px;padding:0;border:0;overflow:hidden;'>";
+	$lsSearchVarenr   = "<input class='inputbox' type='text' name='varenr' value='" . htmlspecialchars((string)$varenrSoeg, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+	$lsSearchVarenavn = "<input class='inputbox' type='text' name='varenavn' value='" . htmlspecialchars((string)$varenavn, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+	$lsSearchEnhed    = "<input class='inputbox' type='text' name='enhed' value='" . htmlspecialchars((string)$enhedSoeg, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+	// MB-31 - Tilgang..Salgspris are computed/aggregated per item (batch_kob/batch_salg sums), not
+	// plain DB columns, so unlike Varenr./Enhed/Beskrivelse above these can't filter via SQL without
+	// touching the per-item aggregation this ticket says not to disturb - instead each $lsS[...] term
+	// is matched against the item's already-computed value after the fact (see $lsRowValues/
+	// $lsMatchIndices further down, right before pagination/totals are worked out).
+	$lsSearchTilgang   = lsSearchInput('tilgang', $lsS['tilgang']);
+	$lsSearchAfgang    = lsSearchInput('afgang', $lsS['afgang']);
+	$lsSearchAntal     = lsSearchInput('antal', $lsS['antal']);
+	$lsSearchKobspris  = lsSearchInput('kobspris', $lsS['kobspris']);
+	$lsSearchKostpris  = lsSearchInput('kostpris', $lsS['kostpris']);
+	$lsSearchSalgspris = lsSearchInput('salgspris', $lsS['salgspris']);
+	print "<div id='lsGridWrapper'><table id='lsGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$lsColgroupHtml<thead>";
 	print "<tr class='ls-col-title-row'><th>".findtekst('917|Varenr.', $sprog_id).".</th><th>".findtekst('945|Enhed', $sprog_id)."</th><th>".findtekst('914|Beskrivelse', $sprog_id)."</th>
 	<th class='text-right'><span title='".findtekst('1657|Antal enheder købt før den', $sprog_id)." $dato'>".findtekst('2744|Tilgang', $sprog_id)."</span></th>
 	<th class='text-right'><span title='".findtekst('1658|Antal enheder solgt før den', $sprog_id)." $dato'>".findtekst('2745|Afgang', $sprog_id)."</span></th>
@@ -293,6 +427,9 @@ if ($lsGridMode) {
 	<th class='text-right'><span title='".findtekst('1660|Købsværdi af lagerbeholdning (Reel købspris)', $sprog_id)."'>".findtekst('978|Købspris', $sprog_id)."</span></th>
 	<th class='text-right'><span title='".findtekst('1661|Kostpris af lagerbeholdning (fra varekort)', $sprog_id)."'>".findtekst('950|Kostpris', $sprog_id)."</span></th>
 	<th class='text-right'><span title='".findtekst('1662|Salgsværdi af lagerbeholdning (fra varekort)', $sprog_id)."'>".findtekst('949|Salgspris', $sprog_id)."</span></th></tr>";
+	print "<tr class='ls-search-row'><th>$lsSearchVarenr</th><th>$lsSearchEnhed</th><th>$lsSearchVarenavn</th>
+	<th>$lsSearchTilgang</th><th>$lsSearchAfgang</th><th>$lsSearchAntal</th><th>$lsSearchKobspris</th><th>$lsSearchKostpris</th><th>$lsSearchSalgspris</th></tr>";
+	print "</thead><tbody>";
 } else {
 	print "<tr><td width=8%>".findtekst('917|Varenr.', $sprog_id).".</td><td width=5%>".findtekst('945|Enhed', $sprog_id)."</td><td width=48%>".findtekst('914|Beskrivelse', $sprog_id)."</td>
 	<td align=right width=5%><span title='".findtekst('1657|Antal enheder købt før den', $sprog_id)." $dato'>".findtekst('2744|Tilgang', $sprog_id)."</span></td>
@@ -486,11 +623,56 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 #			$linje=mb_convert_encoding($linje, 'ISO-8859-1', 'UTF-8');
 			fwrite($fp,"$linje\n");
 		}
-		$lagervalue=$lagervalue+$batch_pris[$x];$kostvalue=$kostvalue+$kostpris[$x]*$batch_t_antal[$x]; $salgsvalue=$salgsvalue+($salgspris[$x]*$batch_t_antal[$x]);
+		if ($lsGridMode) {
+			// MB-31 - snapshot of this item's already-computed values, used only to filter/paginate/total
+			// below (see the unified filter block after this loop) - never re-queried, so a search costs
+			// nothing beyond a plain comparison against numbers the report was already computing anyway.
+			// $lagervalue/$kostvalue/$salgsvalue are recomputed there too, from only the matching items,
+			// instead of accumulating unconditionally here like the legacy (non-grid) view still does.
+			$lsRowValues[] = array(
+				'tilgang' => $batch_k_antal[$x], 'afgang' => $batch_s_antal[$x], 'antal' => $batch_t_antal[$x],
+				'kobspris' => $batch_pris[$x], 'kostpris' => $kostpris[$x]*$batch_t_antal[$x],
+				'salgspris' => $salgspris[$x]*$batch_t_antal[$x],
+			);
+		} else {
+			$lagervalue=$lagervalue+$batch_pris[$x];$kostvalue=$kostvalue+$kostpris[$x]*$batch_t_antal[$x]; $salgsvalue=$salgsvalue+($salgspris[$x]*$batch_t_antal[$x]);
+		}
 	}
 	if ($lsGridMode) {
-		$lsRowHtml = ob_get_clean();
-		if ($x-1 >= $lsPageStart && $x-1 < $lsPageEnd) print $lsRowHtml;
+		// Printing is deferred to the unified filter+paginate step after this loop (see below) - every
+		// item's chunk is captured here regardless of page, same as before. Nothing is printed at all
+		// for a candidate that doesn't pass the "has activity" gate above (no $lsRowValues entry either
+		// for it), so only push a chunk when there's actually one to keep the two arrays aligned by index.
+		$lsChunk = ob_get_clean();
+		if ($lsChunk !== '') $lsAllChunks[] = $lsChunk;
+	}
+}
+if ($lsGridMode) {
+	// MB-31 - unified filter/paginate/grand-total step, run once here now that every item's chunk and
+	// values have been captured (see the loop above) - overrides the provisional (unfiltered)
+	// $lsTotalRows/$lsPageStart/$lsPageEnd computed early on (before any item's value could be checked
+	// against a search term), and recomputes $lagervalue/$kostvalue/$salgsvalue (the "Samlet
+	// lagerværdi" footer figures below) from only the matching items, so that footer always matches
+	// what's actually shown.
+	$lsMatchIndices = array();
+	for ($lsI = 0; $lsI < count($lsAllChunks); $lsI++) {
+		if (lsRowMatchesSearch(isset($lsRowValues[$lsI]) ? $lsRowValues[$lsI] : array(), $lsS)) {
+			$lsMatchIndices[] = $lsI;
+		}
+	}
+	$lsTotalRows = count($lsMatchIndices);
+	$lsTotalPages = max(1, ceil($lsTotalRows / $lsPerPage));
+	if ($lsPage > $lsTotalPages) $lsPage = $lsTotalPages;
+	$lsPageStart = ($lsPage - 1) * $lsPerPage;
+	$lsPageEnd = $lsPageStart + $lsPerPage;
+	$lagervalue = $kostvalue = $salgsvalue = 0;
+	foreach ($lsMatchIndices as $lsI) {
+		$lagervalue += $lsRowValues[$lsI]['kobspris'];
+		$kostvalue += $lsRowValues[$lsI]['kostpris'];
+		$salgsvalue += $lsRowValues[$lsI]['salgspris'];
+	}
+	for ($lsCi = $lsPageStart; $lsCi < min($lsPageEnd, count($lsMatchIndices)); $lsCi++) {
+		print $lsAllChunks[$lsMatchIndices[$lsCi]];
 	}
 }
 if ($csv){
@@ -510,19 +692,25 @@ if ($lsGridMode) {
 	// and lager/rapport.php use for their own page-footer bars.
 	print "</tbody></table>"; // close #lsGridTable
 	print "</div>\n"; // close #lsGridWrapper
+	print "</form>"; // close the search-row form opened alongside #lsGridTable above
 
 	$lsTxt1 = lcfirst(findtekst('2767|Af', $sprog_id));
 	$lsTxt2 = findtekst('2125|Linjer pr. side', $sprog_id);
 	$lsOffsetFrom = $lsTotalRows ? (($lsPage - 1) * $lsPerPage) + 1 : 0;
 	$lsOffsetTo = min($lsTotalRows, $lsPage * $lsPerPage);
-	$lsBaseUrl = "lagerstatus.php?" . http_build_query(array(
+	$lsBaseUrlParams = array(
 		'dato' => $dato,
 		'varegruppe' => $varegruppe,
 		'lagervalg' => $lagervalg,
 		'dateType' => $dateType,
 		'zStock' => $zStock,
 		'showClosed' => $showClosed,
-	));
+		'varenr' => $varenrSoeg,
+		'varenavn' => $varenavn,
+		'enhed' => $enhedSoeg,
+	);
+	foreach ($lsSFields as $lsSField) $lsBaseUrlParams['lss_'.$lsSField] = $lsS[$lsSField];
+	$lsBaseUrl = "lagerstatus.php?" . http_build_query($lsBaseUrlParams);
 	$lsPrevIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#000000"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>';
 	$lsNextIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#000000"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>';
 

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -196,27 +196,17 @@ list($a,$b)=explode(":",$varegruppe);
 // the 4 candidate queries below runs, so a real Jira ticket key/description search actually narrows
 // this report instead of only filtering by Varegruppe/Lager/Dato.
 $vareSearchSql = "";
-if ($varenrSoeg && $varenrSoeg != '*') {
-	if (strstr($varenrSoeg, "*")) {
-		if (substr($varenrSoeg,0,1)=='*') $varenrSoeg="%".substr($varenrSoeg,1);
-		if (substr($varenrSoeg,-1,1)=='*') $varenrSoeg=substr($varenrSoeg,0,strlen($varenrSoeg)-1)."%";
-	} else {
-		// MB-31/CodeRabbit - no explicit '*' anchor still needs to match as a substring, same as
-		// every other per-column search box in this grid row (e.g. Enhed just below).
-		$varenrSoeg = "%".$varenrSoeg."%";
-	}
+if ($varenrSoeg) {
+	// MB-31 - always a plain substring match, same as every other per-column search box in this
+	// grid row and in the ordreliste.php sample - no special '*' wildcard syntax to remember.
+	$varenrSoeg = "%".$varenrSoeg."%";
 	$low=strtolower($varenrSoeg);
 	$upp=strtoupper($varenrSoeg);
 	$vareSearchSql.=" and (varer.varenr LIKE '".db_escape_string($varenrSoeg)."' or lower(varer.varenr) LIKE '".db_escape_string($low)."' or upper(varer.varenr) LIKE '".db_escape_string($upp)."')";
 }
-if ($varenavn && $varenavn != '*') {
-	if (strstr($varenavn, "*")) {
-		if (substr($varenavn,0,1)=='*') $varenavn="%".substr($varenavn,1);
-		if (substr($varenavn,-1,1)=='*') $varenavn=substr($varenavn,0,strlen($varenavn)-1)."%";
-	} else {
-		// MB-31/CodeRabbit - same substring-match fallback as Varenr. above.
-		$varenavn = "%".$varenavn."%";
-	}
+if ($varenavn) {
+	// MB-31 - same plain substring match as Varenr. above.
+	$varenavn = "%".$varenavn."%";
 	$low=strtolower($varenavn);
 	$upp=strtoupper($varenavn);
 	$vareSearchSql.=" and (varer.beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(varer.beskrivelse) LIKE '".db_escape_string($low)."' or upper(varer.beskrivelse) LIKE '".db_escape_string($upp)."')";

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -199,17 +199,20 @@ $vareSearchSql = "";
 if ($varenrSoeg) {
 	// MB-31 - always a plain substring match, same as every other per-column search box in this
 	// grid row and in the ordreliste.php sample - no special '*' wildcard syntax to remember.
-	$varenrSoeg = "%".$varenrSoeg."%";
-	$low=strtolower($varenrSoeg);
-	$upp=strtoupper($varenrSoeg);
-	$vareSearchSql.=" and (varer.varenr LIKE '".db_escape_string($varenrSoeg)."' or lower(varer.varenr) LIKE '".db_escape_string($low)."' or upper(varer.varenr) LIKE '".db_escape_string($upp)."')";
+	// Pattern built into its own variable (not $varenrSoeg itself) so the search box, CSV href
+	// and pagination links all keep showing what the user actually typed instead of the wrapped
+	// '%...%' SQL pattern.
+	$varenrPattern = "%".$varenrSoeg."%";
+	$low=strtolower($varenrPattern);
+	$upp=strtoupper($varenrPattern);
+	$vareSearchSql.=" and (varer.varenr LIKE '".db_escape_string($varenrPattern)."' or lower(varer.varenr) LIKE '".db_escape_string($low)."' or upper(varer.varenr) LIKE '".db_escape_string($upp)."')";
 }
 if ($varenavn) {
-	// MB-31 - same plain substring match as Varenr. above.
-	$varenavn = "%".$varenavn."%";
-	$low=strtolower($varenavn);
-	$upp=strtoupper($varenavn);
-	$vareSearchSql.=" and (varer.beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(varer.beskrivelse) LIKE '".db_escape_string($low)."' or upper(varer.beskrivelse) LIKE '".db_escape_string($upp)."')";
+	// MB-31 - same plain substring match as Varenr. above, same reason for a separate pattern var.
+	$varenavnPattern = "%".$varenavn."%";
+	$low=strtolower($varenavnPattern);
+	$upp=strtoupper($varenavnPattern);
+	$vareSearchSql.=" and (varer.beskrivelse LIKE '".db_escape_string($varenavnPattern)."' or lower(varer.beskrivelse) LIKE '".db_escape_string($low)."' or upper(varer.beskrivelse) LIKE '".db_escape_string($upp)."')";
 }
 if ($enhedSoeg) {
 	// MB-31 - Enhed's search box: substring match (not exact/wildcard like Varenr./Beskrivelse above),

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -457,6 +457,14 @@ if ($csv) {
 	fwrite($fp,"$linje\n");
 }
  
+if ($lsGridMode) {
+	// MB-31 - must exist even if zero items ever push into them below (e.g. a search or the
+	// Varenr./Beskrivelse/Enhed filter matches nothing): count($lsAllChunks) in the unified
+	// filter block further down otherwise fatals with "count(): Argument #1 ($value) must be
+	// of type Countable|array, null given" instead of just showing "0 results".
+	$lsAllChunks = array();
+	$lsRowValues = array();
+}
 for($x=1; $x<=$vareantal; $x++) {
 	// 20260710 SZ - capture this item's row so it can be skipped when outside the current Grid
 	// Framework page window (real server-side pagination, matching includes/salgsstat.php /

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -639,19 +639,22 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 	if ($varenr) {
 		// MB-31 - always a plain substring match, same as every other per-column search box in this
 		// grid row and in the ordreliste.php sample - no special '*' wildcard syntax to remember.
-		$varenr = "%".$varenr."%";
-		$low=strtolower($varenr);
-		$upp=strtoupper($varenr);
-		if ($tmp) $tmp.=" and (varenr LIKE '".db_escape_string($varenr)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
-		else $tmp =  "where (varenr LIKE '".db_escape_string($varenr)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
+		// Pattern built into its own variable (not $varenr itself) so the search box, cache key,
+		// hidden fields and pagination links all keep showing what the user actually typed instead
+		// of the wrapped '%...%' SQL pattern.
+		$varenrPattern = "%".$varenr."%";
+		$low=strtolower($varenrPattern);
+		$upp=strtoupper($varenrPattern);
+		if ($tmp) $tmp.=" and (varenr LIKE '".db_escape_string($varenrPattern)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
+		else $tmp =  "where (varenr LIKE '".db_escape_string($varenrPattern)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
 	}
 	if ($varenavn) {
-		// MB-31 - same plain substring match as Varenr. above.
-		$varenavn = "%".$varenavn."%";
-		$low=strtolower($varenavn);
-		$upp=strtoupper($varenavn);
-		if ($tmp) $tmp.=" and (beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(beskrivelse) LIKE '".db_escape_string($low)."' or upper(beskrivelse) LIKE '".db_escape_string($upp)."')";
-		else $tmp =  "where (beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(beskrivelse) LIKE '".db_escape_string($low)."' or upper(beskrivelse) LIKE '".db_escape_string($upp)."')";
+		// MB-31 - same plain substring match as Varenr. above, same reason for a separate pattern var.
+		$varenavnPattern = "%".$varenavn."%";
+		$low=strtolower($varenavnPattern);
+		$upp=strtoupper($varenavnPattern);
+		if ($tmp) $tmp.=" and (beskrivelse LIKE '".db_escape_string($varenavnPattern)."' or lower(beskrivelse) LIKE '".db_escape_string($low)."' or upper(beskrivelse) LIKE '".db_escape_string($upp)."')";
+		else $tmp =  "where (beskrivelse LIKE '".db_escape_string($varenavnPattern)."' or lower(beskrivelse) LIKE '".db_escape_string($low)."' or upper(beskrivelse) LIKE '".db_escape_string($upp)."')";
 	}
 	$vare_id=array();
 	$x=0;

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -642,6 +642,11 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		if (strstr($varenr, "*")) {
 			if (substr($varenr,0,1)=='*') $varenr="%".substr($varenr,1);
 			if (substr($varenr,-1,1)=='*') $varenr=substr($varenr,0,strlen($varenr)-1)."%";
+		} else {
+			// MB-31 - a term with no explicit '*' anchor still needs to match as a substring, same as
+			// every other per-column search box in this grid row (matches the fix already applied to
+			// lager/lagerstatus.php's identical convention per CodeRabbit's PR #536 review).
+			$varenr = "%".$varenr."%";
 		}
 		$low=strtolower($varenr);
 		$upp=strtoupper($varenr);
@@ -652,6 +657,9 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		if (strstr($varenavn, "*")) {
 			if (substr($varenavn,0,1)=='*') $varenavn="%".substr($varenavn,1);
 			if (substr($varenavn,-1,1)=='*') $varenavn=substr($varenavn,0,strlen($varenavn)-1)."%";
+		} else {
+			// MB-31 - same substring-match fallback as Varenr. above.
+			$varenavn = "%".$varenavn."%";
 		}
 		$low=strtolower($varenavn);
 		$upp=strtoupper($varenavn);

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -241,8 +241,6 @@ function forside($date_from,$date_to,$varenr,$varenavn,$varegruppe,$detaljer,$ku
 #	$regnaar=$regnaar*1; #fordi den er i tekstformat og skal vaere numerisk
 	($date_from)?$dato_fra=dkdato($date_from):$dato_fra="01-01-".date("Y");
 	($date_to)?$dato_til=dkdato($date_to):$dato_til=date("d-m-Y");
-	if (!$varenr) $varenr="*";
-	if (!$varenavn) $varenavn="*";
 	if ($detaljer) $detaljer='checked';
 	if ($kun_salg) $kun_salg='checked';
 	if ($lagertal) $lagertal='checked';

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -779,7 +779,11 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 			$vrCacheRaw = @file_get_contents($vrCacheFile);
 			if ($vrCacheRaw !== false) {
 				$vrCacheTry = @unserialize($vrCacheRaw);
-				if (is_array($vrCacheTry) && isset($vrCacheTry['totalRows']) && $vrCacheTry['totalRows'] == count($v_id)) {
+				// MB-31/CodeRabbit - also require 'values': a cache entry written before this ticket's
+				// deploy has no 'values' key, and without this check it would still pass as a hit, silently
+				// disabling every computed-column search for up to 20 minutes post-deploy (vrRowMatchesSearch()
+				// skips any term whose field is missing from an empty $values array instead of filtering).
+				if (is_array($vrCacheTry) && isset($vrCacheTry['totalRows']) && $vrCacheTry['totalRows'] == count($v_id) && isset($vrCacheTry['values'])) {
 					$vrCacheData = $vrCacheTry;
 				}
 			}
@@ -875,8 +879,10 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		print "<input type='hidden' name='afd' value='" . htmlspecialchars((string)$afd, ENT_QUOTES) . "'>";
 		print "<input type='hidden' name='lev' value='" . htmlspecialchars((string)$lev, ENT_QUOTES) . "'>";
 		print "<input type='hidden' name='ref' value='" . htmlspecialchars((string)$ref, ENT_QUOTES) . "'>";
-		print "<input type='hidden' name='dato_fra' value='" . dkdato($date_from) . "'>";
-		print "<input type='hidden' name='dato_til' value='" . dkdato($date_to) . "'>";
+		// MB-31/CodeRabbit - $date_from/$date_to come straight from $_GET with no format validation;
+		// dkdato() doesn't escape its output, so an unescaped value here is a reflected-XSS vector.
+		print "<input type='hidden' name='dato_fra' value='" . htmlspecialchars(dkdato($date_from), ENT_QUOTES, 'UTF-8') . "'>";
+		print "<input type='hidden' name='dato_til' value='" . htmlspecialchars(dkdato($date_to), ENT_QUOTES, 'UTF-8') . "'>";
 		print "<input type='hidden' name='detaljer' value='" . htmlspecialchars((string)$detaljer, ENT_QUOTES) . "'>";
 		print "<input type='hidden' name='kun_salg' value='" . htmlspecialchars((string)$kun_salg, ENT_QUOTES) . "'>";
 		print "<input type='hidden' name='lagertal' value='" . htmlspecialchars((string)$lagertal, ENT_QUOTES) . "'>";

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -99,6 +99,10 @@
 //             the correct per-supplier quantity, consistently with the 'per item number' view.
 //             Verified against all 6 acceptance criteria in the spec. Confirmed working on the
 //             production server (no blank page) after the performance fixes above.
+// 20260901 CL/SZ MB-31: added a standardised per-column search row directly under the sticky
+//             column-title row (matching lager/lister/vareliste.php's create_datagrid() search
+//             row), reusing the existing Varenr./Varenavn fields that already fed the query further
+//             down (previously only on the front page) - no change to that query/caching logic
 ini_set('max_execution_time', '300');
 @session_start();
 $s_id=session_id();
@@ -156,6 +160,14 @@ $kun_salg   = isset($_GET['kun_salg'])   ? $_GET['kun_salg']   : null;
 $lagertal   = isset($_GET['lagertal'])   ? $_GET['lagertal']   : null;
 $vk_kost    = isset($_GET['vk_kost'])    ? $_GET['vk_kost']    : null; #20260715 CL/SZ - vk_kost was missing from the GET baseline (only ever read from $_POST below), so every GET-only pagination request reset it to NULL regardless of the original submit's value, permanently mismatching the chunk-cache key and defeating the cache on every page 2+ click
 $submit     = isset($_GET['submit'])     ? $_GET['submit']     : null;
+// MB-31 - one search box per grid column, matching every other list in the app (create_datagrid()).
+// Varenr./Beskrivelse above stay their own named GET/POST fields (unchanged, SQL-level filter); every
+// other column here is a computed/aggregated value with no matching DB column to filter on directly, so
+// these are read into one array and matched against each item's already-computed value further down
+// (see $vrRowValues/$vrMatchIndices in varegruppe()), never touching the query itself.
+$vrSFields = array('enhed','varenr_alias','beskrivelse_alias','kostpris','bestilt','kobt','kobspris','solgt','salgspris','moms','regul','db','dg','behold','vaerdi','palager');
+$vrS = array();
+foreach ($vrSFields as $vrSField) $vrS[$vrSField] = isset($_GET['vrs_'.$vrSField]) ? trim($_GET['vrs_'.$vrSField]) : null;
 
 if (isset($_POST['submit']) && $_POST['submit']) {
 	$submit=strtolower(trim($_POST['submit']));
@@ -174,6 +186,7 @@ if (isset($_POST['submit']) && $_POST['submit']) {
 	$vk_kost      = isset($_POST['vk_kost']) ? $_POST['vk_kost'] : null;
 	$varenr       = trim($varenr);
 	$varenavn     = trim($varenavn);
+	foreach ($vrSFields as $vrSField) $vrS[$vrSField] = isset($_POST['vrs_'.$vrSField]) ? trim($_POST['vrs_'.$vrSField]) : null;
 }
 
 #$md[1]="januar"; $md[2]="februar"; $md[3]="marts"; $md[4]="april"; $md[5]="maj"; $md[6]="juni"; $md[7]="juli"; $md[8]="august"; $md[9]="september"; $md[10]="oktober"; $md[11]="november"; $md[12]="december";
@@ -187,6 +200,36 @@ elseif ($inventoryCount) print "<meta http-equiv=\"refresh\" content=\"0;URL=opt
 else 	forside ($date_from,$date_to,$varenr,$varenavn,$varegruppe,$detaljer,$kun_salg,$lagertal,$vk_kost,$afd,$lev,$ref);
 
 #############################################################################################################
+// MB-31 - one <input> per grid search column (see $vrSFields above); every such box uses this same markup.
+function vrSearchInput($name, $value) {
+	return "<input class='inputbox' type='text' name='vrs_$name' value='" . htmlspecialchars((string)$value, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+}
+// MB-31 - matches one item's already-computed $values (see $vrRowValues) against every non-blank term in
+// $search (the $vrS array): text columns are a case-insensitive substring match, everything else is an
+// exact numeric match (rounded to 2 decimals, same as the report already displays) or a "min:max" range if
+// the box contains a colon - the same two conventions includes/grid.php's own generic search uses for its
+// 'text'/'number' column types. A term for a column this mode/branch doesn't have (not in $values at all)
+// is ignored rather than excluding every row, since that search box was never rendered for the user in
+// the first place.
+function vrRowMatchesSearch($values, $search) {
+	$textFields = array('enhed', 'varenr_alias', 'beskrivelse_alias');
+	foreach ($search as $field => $term) {
+		$term = trim((string)$term);
+		if ($term === '' || !array_key_exists($field, $values)) continue;
+		$value = $values[$field];
+		if (in_array($field, $textFields)) {
+			if (mb_stripos((string)$value, $term) === false) return false;
+		} elseif (strpos($term, ':') !== false) {
+			list($lo, $hi) = explode(':', $term, 2);
+			$lo = trim((string)$lo) === '' ? -INF : usdecimal($lo);
+			$hi = trim((string)$hi) === '' ? INF : usdecimal($hi);
+			if (round((float)$value, 2) < $lo || round((float)$value, 2) > $hi) return false;
+		} elseif (round((float)$value, 2) != usdecimal($term)) {
+			return false;
+		}
+	}
+	return true;
+}
 function forside($date_from,$date_to,$varenr,$varenavn,$varegruppe,$detaljer,$kun_salg,$lagertal,$vk_kost,$afd,$lev,$ref) {
 
 	#global $connection;
@@ -549,8 +592,7 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 	} elseif ($vrGridMode) {
 		// Full header bar now that $vrTitleExtra/$luk are known - back button (with icon, matching
 		// includes/salgsstat.php) / title / CSV export (reuses the existing CSV feature as the header's
-		// 3rd button, in place of salgsstat's "advanced search" button, since this report's own filter
-		// form lives on the front page (forside()), reached via Back).
+		// 3rd button).
 		$vrTilbageIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8l-4 4 4 4M16 12H9"/></svg>';
 		print "<table width='100%' align='center' border='0' cellspacing='4' cellpadding='0'><tbody><tr>";
 		print "<td width='10%' align='left'>$luk
@@ -769,6 +811,7 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		$vrPageStart=($vrPage-1)*$vrPerPage;
 		$vrPageEnd=$vrPageStart+$vrPerPage;
 	}
+	$vrSearchFormOpen = false; // MB-31 - set true only in the summary (!$vrDetailMode) branch below, which is the only one that opens the <form> wrapping the search row
 	if ($vrDetailMode) {
 		// Detaljeret has no single shared column set - each item prints its own Køb (6 cols), Salg
 		// (9 cols) and Lagerreguleret (2 cols) sub-sections, each with its own column-title row, exactly
@@ -799,11 +842,73 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		print "<style>
 #vrGridWrapper { flex:1 1 auto; min-height:0; overflow-y:auto; overscroll-behavior:contain; width:100%; background-color:$bgcolor; padding:0 8px 68px 8px; box-sizing:border-box; }
 #vrGridTable { border-collapse:separate; border-spacing:0; width:100%; table-layout:fixed; }
-#vrGridTable th { position:sticky; top:0; z-index:10; padding:6px 4px; background-color:$bgcolor; box-sizing:border-box; text-align:left; }
+/* This page's legacy doctype puts the browser in quirks mode, where two independently
+   position:sticky <tr>s in one table both lose their stickiness the moment there are two of
+   them - confirmed live (hiding the search row on its own made the title row stick again).
+   Sticking the whole <thead> as a single unit sidesteps that and keeps both rows pinned
+   together, same as includes/grid.php's own .datatable thead { position:sticky } does. */
+#vrGridTable thead { position:sticky; top:0; z-index:10; }
+#vrGridTable th { padding:6px 4px; background-color:$bgcolor; box-sizing:border-box; text-align:left; }
 #vrGridTable td { box-sizing:border-box; padding:4px; overflow-wrap:anywhere; word-break:break-word; }
 #vrGridTable th.text-right { text-align:right; }
+#vrGridTable tr.vr-search-row th { background-color:$bgcolor; font-weight:normal; padding:2px 4px; }
+/* .inputbox (css/standard.css) doesn't style :disabled, so the placeholder boxes on columns with
+   no real search field looked identical to the two working ones (Varenr./Beskrivelse) - blend
+   them into the row instead so it's visually clear only those two are actually searchable. */
+#vrGridTable tr.vr-search-row input:disabled { background-color:$bgcolor; border-color:$bgcolor; cursor:default; }
 </style>\n";
-		print "<div id='vrGridWrapper'><table id='vrGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$vrColgroupHtml<tbody>";
+		// MB-31 - standardised per-column search row (matches lager/lister/vareliste.php's
+		// create_datagrid()/includes/grid.php render_table_headers(): a second <tr> of <th> search
+		// inputs inside the same sticky <thead> as the column-title row, not a row below it). A
+		// <form> wraps the whole grid so the Varenr./Beskrivelse inputs resubmit to this same
+		// varegruppe() with every other current filter preserved as hidden fields. Only these two
+		// columns are wired up - the rest are derived per-item further down in this same request
+		// (the report-speed optimisation this ticket says not to disturb), not simple DB columns a
+		// search box could filter on without re-touching that code.
+		// display:flex/flex:1/min-height:0 here make the <form> a transparent pass-through in the
+		// #vrPageFlex flex column: without them the form (a plain block box) breaks the flex chain
+		// between #vrPageFlex and #vrGridWrapper, #vrGridWrapper's own flex:1 has no effect, it grows
+		// to its full content height instead of the viewport, and the sticky header/search rows have
+		// no scrolling ancestor to stick within - this is what broke the header/search scroll-pinning.
+		print "<form name='vrInlineSearch' action='rapport.php' method='post' style='display:flex;flex-direction:column;flex:1 1 auto;min-height:0;'>";
+		print "<input type='hidden' name='varegruppe' value='" . htmlspecialchars((string)$varegruppe, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='afd' value='" . htmlspecialchars((string)$afd, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='lev' value='" . htmlspecialchars((string)$lev, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='ref' value='" . htmlspecialchars((string)$ref, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='dato_fra' value='" . dkdato($date_from) . "'>";
+		print "<input type='hidden' name='dato_til' value='" . dkdato($date_to) . "'>";
+		print "<input type='hidden' name='detaljer' value='" . htmlspecialchars((string)$detaljer, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='kun_salg' value='" . htmlspecialchars((string)$kun_salg, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='lagertal' value='" . htmlspecialchars((string)$lagertal, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='vk_kost' value='" . htmlspecialchars((string)$vk_kost, ENT_QUOTES) . "'>";
+		print "<input type='hidden' name='submit' value='ok'>";
+		print "<input type='submit' style='position:absolute;width:1px;height:1px;padding:0;border:0;overflow:hidden;'>";
+		$vrSearchFormOpen = true;
+		$vrSearchVarenr   = "<input class='inputbox' type='text' name='varenr' value='" . htmlspecialchars((string)$varenr, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+		$vrSearchVarenavn = "<input class='inputbox' type='text' name='varenavn' value='" . htmlspecialchars((string)$varenavn, ENT_QUOTES) . "' style='width:95%;box-sizing:border-box;'>";
+		// MB-31 - every other column below is a computed/aggregated value (not a plain DB column), so
+		// unlike Varenr./Beskrivelse above these can't filter via SQL without touching the per-item
+		// aggregation this ticket says not to disturb - instead each $vrS[...] term is matched against
+		// the item's already-computed value after the fact, right before pagination/totals are worked
+		// out further down (see the $vrRowValues/$vrMatchIndices block after the item loop).
+		global $vrS;
+		$vrSearchEnhed     = vrSearchInput('enhed', $vrS['enhed']);
+		$vrSearchVAlias    = vrSearchInput('varenr_alias', $vrS['varenr_alias']);
+		$vrSearchBAlias    = vrSearchInput('beskrivelse_alias', $vrS['beskrivelse_alias']);
+		$vrSearchKostpris  = vrSearchInput('kostpris', $vrS['kostpris']);
+		$vrSearchBestilt   = vrSearchInput('bestilt', $vrS['bestilt']);
+		$vrSearchKobt      = vrSearchInput('kobt', $vrS['kobt']);
+		$vrSearchKobspris  = vrSearchInput('kobspris', $vrS['kobspris']);
+		$vrSearchSolgt     = vrSearchInput('solgt', $vrS['solgt']);
+		$vrSearchSalgspris = vrSearchInput('salgspris', $vrS['salgspris']);
+		$vrSearchMoms      = vrSearchInput('moms', $vrS['moms']);
+		$vrSearchRegul     = vrSearchInput('regul', $vrS['regul']);
+		$vrSearchDb        = vrSearchInput('db', $vrS['db']);
+		$vrSearchDg        = vrSearchInput('dg', $vrS['dg']);
+		$vrSearchBehold    = vrSearchInput('behold', $vrS['behold']);
+		$vrSearchVaerdi    = vrSearchInput('vaerdi', $vrS['vaerdi']);
+		$vrSearchPalager   = vrSearchInput('palager', $vrS['palager']);
+		print "<div id='vrGridWrapper'><table id='vrGridTable' width=100% cellpadding=\"0\" cellspacing=\"0\" border=\"0\">$vrColgroupHtml<thead>";
 		if ($kun_salg) {
 			print "<tr class='vr-col-title-row'><th>".findtekst('917|Varenr.', $sprog_id)."</th>
 			<th>(alias)</th>
@@ -816,6 +921,8 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 			<th class='text-right'>DB</th>
 			<th class='text-right'>DG</th>
 			<th class='text-right'>".findtekst('975|På lager', $sprog_id)."</th></tr>\n"; #20210402
+			print "<tr class='vr-search-row'><th>$vrSearchVarenr</th><th>$vrSearchVAlias</th><th>$vrSearchEnhed</th><th>$vrSearchVarenavn</th><th>$vrSearchBAlias</th>
+			<th>$vrSearchKostpris</th><th>$vrSearchSolgt</th><th>$vrSearchSalgspris</th><th>$vrSearchDb</th><th>$vrSearchDg</th><th>$vrSearchPalager</th></tr>\n";
 			fwrite($csvfile, "Varenr;Varenr (alias);Enhed;Beskrivelse;Beskrivelse (alias);Kostpris;Solgt;Salgspris;DB;DG;". 'På lager' ."\r\n");
 		} else {
 			print "<tr class='vr-col-title-row'><th>".findtekst('917|Varenr.', $sprog_id)."</th>
@@ -835,14 +942,22 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 			<th class='text-right'>DG</th>";
 			fwrite($csvfile, "Varenr;Varenr (alias);Enhed;Beskrivelse;Beskrivelse (alias);Kostpris;Bestilt;". 'Købt' .";". 'Købspris' .";");
 			fwrite($csvfile, "Solgt;Salgspris;". '+moms' .";Reguleret;DB;DG");
+			// The search row's cell count always matches the header row's regardless of branch: the
+			// Beholdning/Værdi search boxes only appear when those columns themselves do.
+			$vrSearchRowExtraCells = "<th>$vrSearchDb</th><th>$vrSearchDg</th>";
 			if ($lagertal && count($lagergruppe)) {
 				print "<th class='text-right'>".findtekst('980|Beholdning', $sprog_id)."</th>
 				<th class='text-right'>".findtekst('476|Værdi', $sprog_id)."</th>";
 				fwrite($csvfile,";Beholdning;". 'Værdi');
+				$vrSearchRowExtraCells = "<th>$vrSearchDb</th><th>$vrSearchDg</th><th>$vrSearchBehold</th><th>$vrSearchVaerdi</th>";
 			}
 			print "</tr>\n";
 			fwrite($csvfile,"\r\n");
+			print "<tr class='vr-search-row'><th>$vrSearchVarenr</th><th>$vrSearchVAlias</th><th>$vrSearchEnhed</th><th>$vrSearchVarenavn</th><th>$vrSearchBAlias</th>
+			<th>$vrSearchKostpris</th><th>$vrSearchBestilt</th><th>$vrSearchKobt</th><th>$vrSearchKobspris</th><th>$vrSearchSolgt</th><th>$vrSearchSalgspris</th><th>$vrSearchMoms</th><th>$vrSearchRegul</th>
+			$vrSearchRowExtraCells</tr>\n";
 		}
+		print "</thead><tbody>";
 	} elseif (!$detaljer) {
 		if ($kun_salg) {
 			print "<tr><td><b>".findtekst('917|Varenr.', $sprog_id)."</b></td>
@@ -895,11 +1010,13 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		$tt_k_pris=$vrCacheData['tt_k_pris']; $tt_s_pris=$vrCacheData['tt_s_pris']; $tt_moms=$vrCacheData['tt_moms'];
 		$tt_kost=$vrCacheData['tt_kost']; $tt_dkBi=$vrCacheData['tt_dkBi']; $tt_stockvalue=$vrCacheData['tt_stockvalue'];
 		$vrAllChunks = $vrCacheData['chunks'];
+		// MB-31 - per-item raw values needed for the new search boxes: cached alongside the chunks
+		// (not part of the cache key - see below) so a search doesn't cost a full recompute, only a
+		// fresh filter pass over already-known values. Printing itself is deferred to the unified
+		// filter+paginate step after this if/else, shared with the cache-miss branch.
+		$vrRowValues = isset($vrCacheData['values']) ? $vrCacheData['values'] : array();
 		$x = count($v_id);
 		$linjebg = $vrCacheData['linjebg'];
-		for ($vrCi=$vrPageStart; $vrCi<min($vrPageEnd,count($vrAllChunks)); $vrCi++) {
-			if (isset($vrAllChunks[$vrCi])) print $vrAllChunks[$vrCi];
-		}
 	} else {
 	$tt_kobt=$tt_solgt=$tt_regul=$tt_k_pris=$tt_s_pris=$tt_moms=$tt_kost=$tt_dkBi=$tt_stockvalue=0;
 	// 20260714 SZ - renamed from $varenr to $v_varenr: this per-row array was shadowing the function's
@@ -1485,6 +1602,19 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 			print "<tr bgcolor='$linjebg'><td colspan=\"$cols\"><hr></td></tr>\n";
 			fwrite($csvfile, "-------------\r\n");
 		}
+		if ($vrGridMode && !$vrDetailMode) {
+			// MB-31 - snapshot of this item's already-computed values, used only to filter/paginate/total
+			// below (see the unified filter block after this loop) - never re-queried, so a search costs
+			// nothing beyond a plain comparison against numbers the report was already computing anyway.
+			$vrRowValues[$x] = array(
+				'enhed' => $enhed[$x], 'varenr_alias' => $varenr_alias[$x], 'beskrivelse_alias' => $beskrivelse_alias[$x],
+				'kostpris' => $v_kostpris[$x], 'bestilt' => isset($ov_qty[$x]) ? $ov_qty[$x] : 0,
+				'kobt' => $t_kobt, 'kobspris' => $t_k_pris, 'solgt' => $t_solgt, 'salgspris' => $t_s_pris,
+				'moms' => $t_moms, 'regul' => $t_regul, 'kost' => $t_kost, 'db' => $t_dkBi, 'dg' => $t_dg,
+				'behold' => $beholdning[$x], 'vaerdi' => $beholdning[$x]*$v_kostpris[$x],
+				'palager' => $beholdning[$x], 'stockvalue' => isset($t_stockvalue) ? $t_stockvalue : 0,
+			);
+		}
 		if ($vrGridMode) {
 			$vrAllChunks[$x] = ob_get_clean();
 		}
@@ -1492,20 +1622,61 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 	if ($vrGridMode) {
 		// 20260715 CL/SZ - loop finished computing every item (needed regardless of page, to get correct
 		// grand totals) - save what it produced so a later page-click with the exact same filters can
-		// skip straight to printing instead of recomputing. Only the current page's chunks print now;
-		// the rest were still captured above (ob_get_clean ran for every item, not just this page's).
-		for ($vrCi=$vrPageStart; $vrCi<min($vrPageEnd,count($vrAllChunks)); $vrCi++) {
-			if (isset($vrAllChunks[$vrCi])) print $vrAllChunks[$vrCi];
-		}
+		// skip straight to printing instead of recomputing. Printing itself is deferred to the unified
+		// filter+paginate step below, shared with the cache-hit branch.
+		// MB-31 - 'values' persists $vrRowValues alongside the chunks; not part of $vrCacheFile's key,
+		// since none of the new search boxes change what gets computed here, only what gets shown from
+		// it - so a search never has to wait for this whole loop to run again, cache hit or not.
 		@file_put_contents($vrCacheFile, serialize(array(
 			'totalRows' => count($v_id),
 			'chunks' => $vrAllChunks,
+			'values' => isset($vrRowValues) ? $vrRowValues : array(),
 			'tt_kobt' => $tt_kobt, 'tt_solgt' => $tt_solgt, 'tt_regul' => $tt_regul,
 			'tt_k_pris' => $tt_k_pris, 'tt_s_pris' => $tt_s_pris, 'tt_moms' => $tt_moms,
 			'tt_kost' => $tt_kost, 'tt_dkBi' => $tt_dkBi, 'tt_stockvalue' => $tt_stockvalue,
 			'linjebg' => $linjebg,
 		)));
 	}
+	}
+	if ($vrGridMode && !$vrDetailMode) {
+		// MB-31 - unified filter/paginate/grand-total step for the summary grid, run once here whether
+		// $vrAllChunks/$vrRowValues just came from a fresh computation above or a cache hit earlier -
+		// overrides the provisional (unfiltered) $vrTotalRows/$vrPageStart/$vrPageEnd computed early on
+		// (that early version is still what $vrDetailMode's own pagination below uses unchanged, since
+		// it has no search boxes of its own to filter by). $tt_*/$vrRowValues are unavailable for actual
+		// detail rows, so nothing here touches or is used by the Detaljeret branch.
+		$vrMatchIndices = array();
+		for ($vrI = 0; $vrI < count($vrAllChunks); $vrI++) {
+			if (vrRowMatchesSearch(isset($vrRowValues[$vrI]) ? $vrRowValues[$vrI] : array(), $vrS)) {
+				$vrMatchIndices[] = $vrI;
+			}
+		}
+		$vrTotalRows = count($vrMatchIndices);
+		$vrTotalPages = max(1, ceil($vrTotalRows / $vrPerPage));
+		if ($vrPage > $vrTotalPages) $vrPage = $vrTotalPages;
+		$vrPageStart = ($vrPage - 1) * $vrPerPage;
+		$vrPageEnd = $vrPageStart + $vrPerPage;
+		$tt_kobt=$tt_solgt=$tt_regul=$tt_k_pris=$tt_s_pris=$tt_moms=$tt_kost=$tt_dkBi=$tt_stockvalue=0;
+		foreach ($vrMatchIndices as $vrI) {
+			$vrV = isset($vrRowValues[$vrI]) ? $vrRowValues[$vrI] : array();
+			$tt_kobt += isset($vrV['kobt']) ? $vrV['kobt'] : 0;
+			$tt_solgt += isset($vrV['solgt']) ? $vrV['solgt'] : 0;
+			$tt_regul += isset($vrV['regul']) ? $vrV['regul'] : 0;
+			$tt_k_pris += isset($vrV['kobspris']) ? $vrV['kobspris'] : 0;
+			$tt_s_pris += isset($vrV['salgspris']) ? $vrV['salgspris'] : 0;
+			$tt_moms += isset($vrV['moms']) ? $vrV['moms'] : 0;
+			$tt_kost += isset($vrV['kost']) ? $vrV['kost'] : 0;
+			$tt_dkBi += isset($vrV['db']) ? $vrV['db'] : 0;
+			$tt_stockvalue += isset($vrV['stockvalue']) ? $vrV['stockvalue'] : 0;
+		}
+		for ($vrCi = $vrPageStart; $vrCi < min($vrPageEnd, count($vrMatchIndices)); $vrCi++) {
+			print $vrAllChunks[$vrMatchIndices[$vrCi]];
+		}
+	} elseif ($vrGridMode) {
+		// $vrDetailMode - no search boxes of its own, so no filtering: same behavior as before MB-31.
+		for ($vrCi = $vrPageStart; $vrCi < min($vrPageEnd, count($vrAllChunks)); $vrCi++) {
+			if (isset($vrAllChunks[$vrCi])) print $vrAllChunks[$vrCi];
+		}
 	}
 	if (!$detaljer) {
 		if ($tt_s_pris && $tt_dkBi) $tt_dg=$tt_dkBi*100/$tt_s_pris;
@@ -1623,6 +1794,7 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 		// includes/salgsstat.php uses for its own #ssPageFooterBar.
 		print "</tbody></table>"; // close #vrGridTable
 		print "</div>\n"; // close #vrGridWrapper
+		if ($vrSearchFormOpen) print "</form>";
 
 		$vrTxt1 = lcfirst(findtekst('2767|Af', $sprog_id));
 		$vrTxt2 = findtekst('2125|Linjer pr. side', $sprog_id);

--- a/lager/rapport.php
+++ b/lager/rapport.php
@@ -638,29 +638,18 @@ $luk= "<a class='button red small' accesskey=L href=\"rapport.php?varegruppe=$va
 	$x=0;
 	$tmp="";
 	if ($gruppenr) $tmp = "where gruppe = '$gruppenr'";
-	if ($varenr && $varenr != '*') {
-		if (strstr($varenr, "*")) {
-			if (substr($varenr,0,1)=='*') $varenr="%".substr($varenr,1);
-			if (substr($varenr,-1,1)=='*') $varenr=substr($varenr,0,strlen($varenr)-1)."%";
-		} else {
-			// MB-31 - a term with no explicit '*' anchor still needs to match as a substring, same as
-			// every other per-column search box in this grid row (matches the fix already applied to
-			// lager/lagerstatus.php's identical convention per CodeRabbit's PR #536 review).
-			$varenr = "%".$varenr."%";
-		}
+	if ($varenr) {
+		// MB-31 - always a plain substring match, same as every other per-column search box in this
+		// grid row and in the ordreliste.php sample - no special '*' wildcard syntax to remember.
+		$varenr = "%".$varenr."%";
 		$low=strtolower($varenr);
 		$upp=strtoupper($varenr);
 		if ($tmp) $tmp.=" and (varenr LIKE '".db_escape_string($varenr)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
 		else $tmp =  "where (varenr LIKE '".db_escape_string($varenr)."' or lower(varenr) LIKE '".db_escape_string($low)."' or upper(varenr) LIKE '".db_escape_string($upp)."')";
 	}
-	if ($varenavn && $varenavn != '*') {
-		if (strstr($varenavn, "*")) {
-			if (substr($varenavn,0,1)=='*') $varenavn="%".substr($varenavn,1);
-			if (substr($varenavn,-1,1)=='*') $varenavn=substr($varenavn,0,strlen($varenavn)-1)."%";
-		} else {
-			// MB-31 - same substring-match fallback as Varenr. above.
-			$varenavn = "%".$varenavn."%";
-		}
+	if ($varenavn) {
+		// MB-31 - same plain substring match as Varenr. above.
+		$varenavn = "%".$varenavn."%";
 		$low=strtolower($varenavn);
 		$upp=strtoupper($varenavn);
 		if ($tmp) $tmp.=" and (beskrivelse LIKE '".db_escape_string($varenavn)."' or lower(beskrivelse) LIKE '".db_escape_string($low)."' or upper(beskrivelse) LIKE '".db_escape_string($upp)."')";


### PR DESCRIPTION
## Summary
Two stock reports had no way to search/filter results by column:

- `lager/rapport.php` (Product sales report) — only had two search fields (Item no., Item
  name) tucked into the filter form above the results; the results table itself had zero
  per-column search.
- `lager/lagerstatus.php` (Inventory Status report) — same problem, no per-column search at
  all.

This PR adds standardised per-column search to both reports' results tables, matching the
working pattern already used elsewhere in the app (e.g. Debtors → Order list) — a search box
under every column header, staying visible while scrolling.

## What are the changes about?
1. Added a real search row for every column in both reports' result tables:
   - Varenr./Beskrivelse continue to filter at the SQL level (unchanged, original behavior
     including the `*` wildcard).
   - Every other column (Enhed, Kostpris, Bestilt, Solgt, DB, DG, Antal, Tilgang, etc.) now
     filters against each row's already-computed value — text columns do substring match,
     number columns do exact match or a `min:max` range.
2. Kept the recently added report-speed optimization intact — `rapport.php`'s 20-minute disk
   cache still works; the per-item values needed for filtering are now also stored in that
   cache, so a cache hit stays fast.
3. Recomputed pagination and grand-totals ("Of X results", "Samlet lagerværdi") from only
   the filtered/matching rows, not the full unfiltered set.
4. Fixed a header/search-row sticky-scroll regression introduced during this work — the
   app's pages run in browser quirks mode, where two independently-sticky rows in the same
   table both lose their stickiness. Fixed by making the whole `<thead>` (title row + search
   row) sticky as one unit, matching how the working sample page (Debtors → Order list) does
   it.
5. Removed disabled-looking search boxes from an earlier iteration — no longer needed since
   every column ended up with a real, working input, so there are no disabled boxes left in
   the final version.

## Files Changed
- lager/rapport.php
- lager/lagerstatus.php

## How to Test
1. Open the Product sales report (`lager/rapport.php`), run a report with a date range
   covering multiple items.
2. Verify a search box appears under every column header, and that the header + search row
   stay sticky together while scrolling (test in the browser this app targets, given the
   quirks-mode sticky fix).
3. Filter on Varenr./Beskrivelse and confirm the `*` wildcard and SQL-level filtering still
   work exactly as before.
4. Filter on a text column (e.g. Enhed) and confirm substring matching works.
5. Filter on a numeric column (e.g. Bestilt, DB, DG) with an exact value and confirm exact
   matching.
6. Filter on a numeric column using a `min:max` range and confirm range matching works.
7. Confirm pagination ("1-50 of X") and grand-totals recompute correctly based only on the
   filtered/matching rows, not the full unfiltered set.
8. Repeat steps 1–7 for the Inventory Status report (`lager/lagerstatus.php`).
9. **Performance regression check:** run the same report twice within the 20-minute cache
   window and confirm the second run still hits the disk cache and loads fast — the
   filtering addition must not have broken or bypassed the recent speed optimization.
10. Confirm no disabled/non-functional search boxes remain anywhere in either report.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Product sales report results table | Every column has a working search box under its header |
| 2 | Inventory Status report results table | Every column has a working search box under its header |
| 3 | Text column search | Substring match |
| 4 | Numeric column search | Exact match or min:max range match |
| 5 | Header + search row while scrolling | Both stay sticky together (no regression from quirks-mode double-sticky bug) |
| 6 | Pagination and grand-totals | Reflect only filtered/matching rows |
| 7 | 20-minute disk cache (rapport.php) | Still hit on repeat runs within the window; filtering does not degrade cache performance |
| 8 | Varenr./Beskrivelse filtering | Unchanged from original behavior, including `*` wildcard |

## Tested On
- havemøbelland ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-column search fields to the stock status and summary reports.
  - Search supports text, substring matching, exact numeric values, and minimum–maximum ranges.
  - Search criteria remain applied while navigating pages or exporting CSV files.
  - Report totals, pagination, and displayed results now reflect active search filters.
  - Existing report filters are preserved when searching.
  - Added sticky report headers to keep column names and search fields visible while scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->