### PR TITLE
POS Z-report: read hidden numeric fields as floats, not Danish decimals (L4 pos-day-close DEVY-5, Visa persisted 10x)

### DIFF
--- a/debitor/pos_ordre_includes/boxCountMethods/printBoxCount.php
+++ b/debitor/pos_ordre_includes/boxCountMethods/printBoxCount.php
@@ -157,23 +157,30 @@ function setPrintTxt($fp, $log, $FromCharset, $ToCharset, $ore_50, $kr_1, $kr_2,
 		db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 		$qtxt2 = "('$dd','cashCount','$cashCountTxt[fromBox] $kasse $cashCountTxt[currency]','0','$udtages','$reportNumber')";
 		db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
+		// 20260902 CL/LH  L4 finding pos-day-close DEVY-5 (Visa persisted 10x): kortsum, kontosum and the
+		// Valuta* values arrive from hidden fields that pos_ordre.php prints as raw PHP floats ("7906.1"),
+		// so they must be read with (float). Feeding them to usdecimal() strips the "." as a Danish
+		// thousands separator and stores 79061. Only operator-typed fields (ny_kortsum, optval,
+		// ValutaUdtages, udtages) are Danish-formatted and keep usdecimal().
 		for ($x=0;$x<count($valuta);$x++) {
 			$qtxt2 = "('$dd','cashCount','Morgenbeholdning $valuta[$x]:','0','". $ValutaByttePenge[$x] ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
-			$qtxt2 = "('$dd','cashCount','Dagens tilgang $valuta[$x]:','0','". usdecimal($ValutaTilgang[$x],2) ."','$reportNumber')";
+			$qtxt2 = "('$dd','cashCount','Dagens tilgang $valuta[$x]:','0','". (float)$ValutaTilgang[$x] ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
-			$tmp=usdecimal($ValutaByttePenge[$x],2)+usdecimal($ValutaTilgang[$x],2);
+			$tmp=(float)$ValutaByttePenge[$x]+(float)$ValutaTilgang[$x];
 			$qtxt2 = "('$dd','cashCount','Forventet beholdning $valuta[$x]:','0','$tmp','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 			$qtxt2 = "('$dd','cashCount','Optalt beholdning $valuta[$x]:','0','". usdecimal($optval[$x],2) ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
-			$qtxt2 = "('$dd','cashCount','Difference $valuta[$x]:','0','". usdecimal($ValutaKasseDiff[$x],2) ."','$reportNumber')";
+			$qtxt2 = "('$dd','cashCount','Difference $valuta[$x]:','0','". (float)$ValutaKasseDiff[$x] ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 			$qtxt2 = "('$dd','cashCount','Udtaget fra kasse $kasse  $valuta[$x]:','0','". usdecimal($ValutaUdtages[$x],2) ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 		}
 		if ($kontosum) {
-			$qtxt2 = "('$dd','cashCount','Salg på konto','0','". usdecimal($kontosum,2) .#','$reportNumber')";
+			// The stray '#' that used to sit here turned the rest of the line into a comment, so
+			// db_modify() was concatenated into $qtxt2 and ran with the previous loop's row.
+			$qtxt2 = "('$dd','cashCount','Salg på konto','0','". (float)$kontosum ."','$reportNumber')";
 			db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 		}
 		for ($x=0;$x<count($kortnavn);$x++) {
@@ -181,7 +188,7 @@ function setPrintTxt($fp, $log, $FromCharset, $ToCharset, $ore_50, $kr_1, $kr_2,
 			if ($changeCardValue) {
 				$txt1.="(". dkdecimal($kortsum[$x],2) .")";
 				$txt2=usdecimal($ny_kortsum[$x],2);
-			} else $txt2=usdecimal($kortsum[$x],2);
+			} else $txt2=(float)$kortsum[$x];
 			$qtxt2 = "('$dd','cashCount','$txt1','0','$txt2','$reportNumber')";
 				if ($txt1) db_modify($qtxt.$qtxt2,__FILE__ . " linje " . __LINE__); 
 		}


### PR DESCRIPTION
## What

L4 gate 2026-09-02, **pos-day-close DEVY-5** (no SD ticket yet): approving the Z-report persisted Visa **79.061,00** for a UI value of 7.906,10 while MasterCard 3.877,00 and Amex 120,00 were correct.

Root cause: `pos_ordre.php` prints `kortsum[]`, `kontosum` and the `Valuta*` amounts into hidden fields as raw PHP floats (`7906.1`), and `printBoxCount.php` fed them to `usdecimal()`, which strips the `.` as a Danish thousands separator → `79061`. Integer totals have no dot and survived — which is exactly the pattern the run observed.

## How

`debitor/pos_ordre_includes/boxCountMethods/printBoxCount.php`: read machine-formatted hidden values with `(float)`; keep `usdecimal()` for operator-typed fields (`ny_kortsum`, `optval`, `ValutaUdtages`, `udtages`).

Also fixes a stray `#` in the *Salg på konto* line that commented out the rest of the statement, so `db_modify()` ran concatenated into the string with the **previous** loop iteration's row.

## Review focus (money path — senior review, @sirrolin)

Which fields are machine-formatted vs operator-typed — see the comment block at the top of the changed loop. `ny_kortsum` is printed with `dkdecimal()` in `boxCount.php:296`, so it stays Danish.

## Verification

- `php -l` clean (via the `saldi-web` image).
- Not yet exercised in the test lab. Acceptance: repeat pos-day-close — `report` row for Visa must equal the on-screen 7.906,10 to the øre; foreign-currency count rows (Dagens tilgang / Difference) must match the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGPZkSoY2Li3KuckJu6N7C
