### PR TITLE
Self-heal adresser.stripe_fravalg where the debtor card writes it (L4 master-data-customer DEVY-1)

### DIFF
--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -116,6 +116,11 @@ $css = "../css/standard.css";
 include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
+// 20260902 CL/LH  L4 finding master-data-customer DEVY-1 / concurrent-editing DEVY-1: the debtor
+// INSERT/UPDATE below reference adresser.stripe_fravalg unconditionally, but the column is only
+// added by includes/betweenUpdates.php (aaben_regnskab.php). Self-heal here so a tenant that
+// skipped that path does not lose every debtor save to "column does not exist".
+ensure_column('adresser', 'stripe_fravalg', 'varchar(2)');
 include("../includes/topline_settings.php");
 include("../includes/grid.php");
 include_once("../includes/emballage_schema.php");

--- a/debitor/debkort_save.php
+++ b/debitor/debkort_save.php
@@ -178,6 +178,10 @@ if ($_POST['id'] || $_POST['firmanavn']) { #20140505
 			 include("../includes/online.php");
 			}
 		}
+		// 20260902 CL/LH  L4 finding master-data-customer DEVY-1: the INSERT/UPDATE below write
+		// adresser.stripe_fravalg unconditionally; self-heal the column for tenants that never
+		// ran includes/betweenUpdates.php (only reached via aaben_regnskab.php / POS).
+		ensure_column('adresser', 'stripe_fravalg', 'varchar(2)');
 		######### Kategorier
 
 		for ($x=0;$x<$cat_antal;$x++) {

--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -479,10 +479,10 @@ if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 // 20260819 CL/LH Per-debtor opt-out for kortbetaling ("Ingen kortbetaling" on the
 // debitorkort): overrides templates and catalog - the link helper renders '' and
 // subscribe.php parks. Does NOT touch already-running subscriptions.
-$qtxt = "SELECT column_name FROM information_schema.columns WHERE table_name='adresser' AND column_name='stripe_fravalg'";
-if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-	db_modify("ALTER TABLE adresser ADD stripe_fravalg varchar(2)", __FILE__ . " linje " . __LINE__);
-}
+// 20260902 CL/LH  Same guard as debitor/debitorkort.php + debkort_save.php now call themselves
+// (L4 finding: tenants that never came through aaben_regnskab.php lacked the column and every
+// debtor save failed). Kept here so the migration path stays the canonical one.
+ensure_column('adresser', 'stripe_fravalg', 'varchar(2)');
 
 
 $qtxt = "SELECT data_type FROM information_schema.columns WHERE table_name = 'ansatte' and column_name = 'mobile'";

--- a/includes/stdFunc/ensureColumn.php
+++ b/includes/stdFunc/ensureColumn.php
@@ -1,0 +1,58 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- includes/stdFunc/ensureColumn.php --- lap 5.0.0 --- 2026-09-02 ---
+// LICENS
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY. See
+// GNU General Public License for more details.
+//
+// Copyright (c) 2003-2026 saldi.dk aps
+// ----------------------------------------------------------------------
+// 20260902 CL/LH  Self-healing column guard. includes/betweenUpdates.php only runs when a
+//                 regnskab is opened through admin/aaben_regnskab.php (or the POS), so a page
+//                 that writes a recently added column can meet a tenant that never ran the
+//                 migration. Call this at the top of such pages - it is idempotent and cheap
+//                 (one information_schema lookup per table/column per request).
+
+if (!function_exists('ensure_column')) {
+	/**
+	 * Add $column to $table if it does not exist yet.
+	 *
+	 * @param string $table       table name (letters, digits, underscore)
+	 * @param string $column      column name (letters, digits, underscore)
+	 * @param string $definition  column type/definition, e.g. "varchar(2)" or "text default ''"
+	 * @return bool               true when the column exists after the call
+	 */
+	function ensure_column($table, $column, $definition) {
+		static $known = array();
+		$table  = preg_replace('/[^a-z0-9_]/i', '', (string)$table);
+		$column = preg_replace('/[^a-z0-9_]/i', '', (string)$column);
+		if ($table === '' || $column === '') return false;
+		$key = "$table.$column";
+		if (isset($known[$key])) return true;
+
+		$qtxt = "SELECT 1 FROM information_schema.columns WHERE table_name='$table' AND column_name='$column' LIMIT 1";
+		if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+			// IF NOT EXISTS: two concurrent requests can both pass the check above.
+			db_modify("ALTER TABLE $table ADD COLUMN IF NOT EXISTS $column $definition", __FILE__ . " linje " . __LINE__);
+			if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) return false;
+		}
+		$known[$key] = true;
+		return true;
+	}
+}
+?>

--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -80,6 +80,7 @@ include(__DIR__ . '/stdFunc/dkDecimal.php');
 include(__DIR__ . '/stdFunc/nrCast.php');
 include(__DIR__ . '/stdFunc/strStartsWith.php');
 include(__DIR__ . '/stdFunc/usDecimal.php');
+include(__DIR__ . '/stdFunc/ensureColumn.php');
 include(__DIR__ . '/stdFunc/navStack.php');
 include(__DIR__ . '/stdFunc/fefo.php');
 include(__DIR__ . '/stdFunc/shopApiRequest.php');


### PR DESCRIPTION
## What

L4 gate 2026-09-02, **master-data-customer DEVY-1** and **concurrent-editing DEVY-1** (no SD ticket yet): every debtor save/create failed with `column "stripe_fravalg" of relation "adresser" does not exist` and a blank page. Whole customer master-data was dead on those tenants.

The migration exists in `includes/betweenUpdates.php`, but that file only runs when a regnskab is opened through `admin/aaben_regnskab.php` (or the POS). A tenant reached any other way never gets the column, while `debitorkort.php` / `debkort_save.php` write it unconditionally. Same lesson as F-014 (`global_id`) and SD-646 (`moms_periode_luk`).

## How

- `includes/stdFunc/ensureColumn.php` (new): `ensure_column($table, $column, $definition)` — one `information_schema` lookup per request, `ADD COLUMN IF NOT EXISTS` (two concurrent logins can both pass the check, same reason as the `ansatte.mobile` guard).
- Called from `debitor/debitorkort.php` and `debitor/debkort_save.php` before the writers.
- `betweenUpdates.php` now uses the same helper, so the migration path stays canonical and there is one implementation.

## Review focus

Deploy-checklist item as well: a scripted pre-cutover schema-parity assertion (`stripe_fravalg`, `moms_periode_luk`, `global_id`) would catch this class before customers do.

## Verification

- `php -l` clean on all five files (via the `saldi-web` image).
- Not yet exercised in the test lab. Acceptance: fresh clone that has *not* been through `aaben_regnskab.php` — open a debtor card and save; row persists and the column exists afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGPZkSoY2Li3KuckJu6N7C
