### PR TITLE
Kreditor order: keep typed Ordredato/Levdato when the supplier is chosen (L4 master-data-supplier DEVY-1)

### DIFF
--- a/includes/kreditorOrderFuncIncludes/accountLookup.php
+++ b/includes/kreditorOrderFuncIncludes/accountLookup.php
@@ -2,6 +2,9 @@
 // ../includes/kreditorOrderFuncIncludes/accountLookup.php
 // 20260304 LOE Converted to use grid framework (same as debitor/order account lookup)
 // 20260506 sawaneh Added create-new-supplier overlay when looked-up kontonr/firmanavn has no match
+// 20260902 CL/LH  Carry already-typed order/delivery dates along so the new order header
+//                 keeps them (kreditor/ordre.php reads ordredato/levdato from GET before insertAccount()).
+
 function kontoopslag($sort, $fokus, $id, $find){
 
 	global $bgcolor, $bgcolor5;
@@ -278,8 +281,7 @@ TOGGLESCRIPT;
 	echo <<<HTML
 	<script>
 	function selectAccount{$id}(fokus, konto_id) {
-		// 20260902 CL/LH  Carry already-typed order/delivery dates along so the new order header
-		// keeps them (kreditor/ordre.php reads ordredato/levdato from GET before insertAccount()).
+		// 20260902
 		var url = "ordre.php?id=$id&fokus=" + fokus + "&konto_id=" + konto_id;
 		var dateFields = ["ordredato", "levdato"];
 		for (var i = 0; i < dateFields.length; i++) {

--- a/includes/kreditorOrderFuncIncludes/accountLookup.php
+++ b/includes/kreditorOrderFuncIncludes/accountLookup.php
@@ -278,7 +278,15 @@ TOGGLESCRIPT;
 	echo <<<HTML
 	<script>
 	function selectAccount{$id}(fokus, konto_id) {
-		window.location.href = "ordre.php?id=$id&fokus=" + fokus + "&konto_id=" + konto_id;
+		// 20260902 CL/LH  Carry already-typed order/delivery dates along so the new order header
+		// keeps them (kreditor/ordre.php reads ordredato/levdato from GET before insertAccount()).
+		var url = "ordre.php?id=$id&fokus=" + fokus + "&konto_id=" + konto_id;
+		var dateFields = ["ordredato", "levdato"];
+		for (var i = 0; i < dateFields.length; i++) {
+			var el = document.getElementsByName(dateFields[i]);
+			if (el.length && el[0].value) url += "&" + dateFields[i] + "=" + encodeURIComponent(el[0].value);
+		}
+		window.location.href = url;
 	}
 	</script>
 HTML;

--- a/kreditor/orderIncludes/insertAccount.php
+++ b/kreditor/orderIncludes/insertAccount.php
@@ -30,6 +30,7 @@
 // 20270226 PHR $art set to 'KO' if empty
 // 20260710 MJ Preserve ref: use global $ref (from form) or look up employee naam, not raw brugernavn.
 // 20260713 MJ Fix structural bug: orphaned if(!$afd){ caused all main logic to be skipped when afd was set. Also restore afd lookup from ansatte.
+// 20260902 CL/LH  L4 finding master-data-supplier DEVY-1: selecting the supplier used to stamp today's date over an Ordredato the operator had already typed, and never stored Levdato. Keep the dates from the form (kreditor/ordre.php passes them along) and only fall back to today when nothing was entered.
 
 if (!function_exists('insertAccount')) {
 function insertAccount($id, $konto_id) {

--- a/kreditor/orderIncludes/insertAccount.php
+++ b/kreditor/orderIncludes/insertAccount.php
@@ -44,6 +44,7 @@ function insertAccount($id, $konto_id) {
 	global $status,$sum;
 	global $valuta,$omlev,$afd;
 	global $ref;
+	global $ordredate,$levdate;
 	$tidspkt=date("U");
 
 	if (!$konto_id) {
@@ -121,16 +122,23 @@ function insertAccount($id, $konto_id) {
 	$momssats=(float)usdecimal($momssats);
 	if ((!$id)&&($firmanavn)) {
 		transaktion('begin');
-		$ordredate=date("Y-m-d");
+		// 20260902 CL/LH  L4 finding master-data-supplier DEVY-1: selecting the supplier used to
+		// stamp today's date over an Ordredato the operator had already typed, and never stored
+		// Levdato. Keep the dates from the form (kreditor/ordre.php passes them along) and only
+		// fall back to today when nothing was entered.
+		$ordredate = trim((string)$ordredate);
+		if (strlen($ordredate) < 6) $ordredate = date("Y-m-d");
+		$levdate = trim((string)$levdate);
+		$levdate_sql = (strlen($levdate) >= 6) ? "'" . db_escape_string($levdate) . "'" : "NULL";
 		$ordrenr = get_next_order_number('KO');
 		$qtxt = "insert into ordrer ";
 		$qtxt.= "(ordrenr,konto_id,kontonr,firmanavn,addr1,addr2,postnr,bynavn,land,kontakt,lev_navn,lev_addr1,";
-		$qtxt.= "lev_addr2,lev_postnr,lev_bynavn,lev_kontakt,betalingsdage,betalingsbet,cvrnr,notes,art,ordredate,";
+		$qtxt.= "lev_addr2,lev_postnr,lev_bynavn,lev_kontakt,betalingsdage,betalingsbet,cvrnr,notes,art,ordredate,levdate,";
 		$qtxt.= "email,momssats,status,ref,afd,lager,sum,hvem,tidspkt,valuta,kred_ord_id,omvbet)";
 		$qtxt.= " values ";
 		$qtxt.= "($ordrenr,$konto_id,'$kontonr','$firmanavn','$addr1','$addr2','$postnr','$bynavn',";
 		$qtxt.= "'$land','$kontakt','$lev_navn','$lev_addr1','$lev_addr2','$lev_postnr','$lev_bynavn','$lev_kontakt',";
-		$qtxt.= "'$betalingsdage','$betalingsbet','$cvrnr','$notes','$art','$ordredate','$email','$momssats',$status,";
+		$qtxt.= "'$betalingsdage','$betalingsbet','$cvrnr','$notes','$art','" . db_escape_string($ordredate) . "',$levdate_sql,'$email','$momssats',$status,";
 		$qtxt.="'$insert_ref','$afd','$lager','$sum','$brugernavn','$tidspkt','$valuta','$kred_ord_id','$omlev')";
 /*		
 		$qtxt = "insert into ordrer ";

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -172,6 +172,11 @@ $lager = if_isset($_GET, NULL, 'lager');
 $konto_id = if_isset($_GET, NULL, 'konto_id');
 
 if ((!$id || $id === 'null') && $konto_id) {
+	// 20260902 CL/LH  Carry the dates the operator typed before choosing a supplier (the lookup
+	// navigates here by GET, see accountLookup.php selectAccount) into the new order header.
+	// usdate('') returns today, so only convert values that were actually supplied.
+	$ordredate = trim(if_isset($_GET, '', 'ordredato')) !== '' ? usdate(trim($_GET['ordredato'])) : '';
+	$levdate   = trim(if_isset($_GET, '', 'levdato'))   !== '' ? usdate(trim($_GET['levdato']))   : '';
 	include_once('orderIncludes/insertAccount.php');
 	$id = insertAccount(0, $konto_id);
 	if ($id) {

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -65,6 +65,8 @@
 // 20260827 Sawaneh create supplier: before insert the kontonr is re-checked across all arts, and a
 //                 number taken meanwhile (stale prefill or a debtor holding it) is replaced with a
 //                 fresh one from get_next_number, so no cross-art duplicate can be created (SST-753)
+// 20260902 CL/LH  Carry the dates the operator typed before choosing a supplier (the lookup navigates here by GET, see accountLookup.php selectAccount) into the new order header. 
+//                 usdate('') returns today, so only convert values that were actually supplied.
 
 @session_start();
 $s_id=session_id();


### PR DESCRIPTION
## What

L4 gate 2026-09-02, **master-data-supplier DEVY-1** (no SD ticket yet): on a new purchase, entering Ordredato/Levdato and *then* selecting the supplier created the header with Ordredato = today (outside the open fiscal year in the lab) and a cleared Levdato.

Cause: the lookup's `selectAccount()` navigates to `ordre.php?konto_id=…` by GET, and `insertAccount()` hard-coded `$ordredate = date("Y-m-d")` and never included `levdate` in the INSERT.

## How

- `includes/kreditorOrderFuncIncludes/accountLookup.php` `selectAccount()`: append `ordredato`/`levdato` from the form when filled.
- `kreditor/ordre.php`: read them from GET before `insertAccount()` — only converting supplied values, because `usdate('')` returns today.
- `kreditor/orderIncludes/insertAccount.php`: use the dates when present, fall back to today for `ordredate` only, escape both, and include `levdate` in the INSERT.

## Verification

- `php -l` clean on all three files (via the `saldi-web` image).
- Not yet exercised in the test lab. Acceptance: repeat master-data-supplier — after selecting supplier 99014 the header must show Ordredato/Levdato `15-09-2025` as typed; selecting a supplier with empty date fields must still give today's Ordredato and an empty Levdato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGPZkSoY2Li3KuckJu6N7C
