### PR TITLE
Bound outbound HTTP calls: EasyUBL/locator cURL handles and login locator (L4 integration-flows DEVY-1/3, F-010)

### DIFF
--- a/debitor/api.php
+++ b/debitor/api.php
@@ -169,6 +169,9 @@
 
         // Send update request to EasyUBL with the actual company ID
         $ch = curl_init();
+        // 20260902 CL/LH  L4 finding integration-flows DEVY-1/3: bound the call so a hung EasyUBL/locator endpoint cannot wedge the request
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_URL, "https://easyubl.net/api/Company/Update/$companyId");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json", "Authorization: ".$apiKey));
@@ -223,6 +226,9 @@
             $guid = "00000000-0000-0000-0000-000000000000";
             $data = createCompany($apiKey);
             $ch = curl_init();
+            // 20260902 CL/LH  L4 finding integration-flows DEVY-1/3: bound the call so a hung EasyUBL/locator endpoint cannot wedge the request
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 30);
             curl_setopt($ch, CURLOPT_URL, "https://easyubl.net/api/Company/Update/$guid");
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json", "Authorization: ".$apiKey));
@@ -264,6 +270,9 @@
 
                 // Send the company id to ssl2.saldi.dk for storage
                 $ch = curl_init();
+                // 20260902 CL/LH  L4 finding integration-flows DEVY-1/3: bound the call so a hung EasyUBL/locator endpoint cannot wedge the request
+                curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 30);
                 curl_setopt($ch, CURLOPT_URL, "https://saldi.dk/locator/locator.php?action=insertCompanyId&companyId=$companyId&globalId=$globalid");
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json"));
@@ -427,6 +436,9 @@
         file_put_contents("../temp/$db/xml-$fileId.xml", $xml);
         curl_close($ch);
         $ch = curl_init();
+        // 20260902 CL/LH  L4 finding integration-flows DEVY-1/3: bound the call so a hung EasyUBL/locator endpoint cannot wedge the request
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         $data = [
             "language" => "",
             "base64EncodedDocumentXml" => $result["base64EncodedDocumentXml"]

--- a/index/login.php
+++ b/index/login.php
@@ -833,8 +833,12 @@ if(!isset($afbryd)){
 			$url = "https://saldi.dk/locator/locator.php?action=getDBlocation&globalId=$globalId&dbName=$db&dbMail=$mainMail";
 			$url.= "&dbAlias=". urlencode($regnskab) ."&dbLocation=$dbLocation&userId=$userId&userName=". urlencode($brugernavn);
 			$url.= "&usermail=". urlencode($usermail);;
-			$result = file_get_contents($url);
-			$a = explode(',',json_decode($result, true));
+			// 20260902 CL/LH  F-010: the locator call is synchronous on every login. Bound it so an
+			// unreachable saldi.dk cannot hang the login page, and tolerate a failed call.
+			$locatorCtx = stream_context_create(array('http' => array('timeout' => 5)));
+			$result = @file_get_contents($url, false, $locatorCtx);
+			if ($result === false) $result = '';
+			$a = explode(',', (string)json_decode($result, true));
 			if ($a[0] && (!$globalId || (!$dbMail && $mainMail))) {
 				$globalId = $a[0];
 				include("../includes/connect.php");


### PR DESCRIPTION
## What

Hardening from the L4 gate 2026-09-02:

- **integration-flows DEVY-1/3** (related: SD-653): four cURL handles in `debitor/api.php` (Company/Update ×2, locator `insertCompanyId`, HumanReadable) had no `CONNECTTIMEOUT`/`TIMEOUT`, so a hung EasyUBL or saldi.dk endpoint wedged the request and the send popup with it. They now get the same 10 s / 30 s bounds the send handle already has.
- **F-010** (findings ledger): `index/login.php` does a synchronous `file_get_contents()` to the saldi.dk locator on every login with no timeout. It now uses a 5 s stream context and tolerates a failed call instead of passing `false` into `json_decode()`/`explode()`.

Behavioural scope is deliberately small: no retry logic, no async — just bounds and a null-safe path. The EasyUBL idempotency/status-transition work stays in SD-653.

## Verification

- `php -l` clean on both files (via the `saldi-web` image).
- Not yet exercised in the test lab. Acceptance: EasyUBL mock in `timeout` mode must return control to the UI within ~30 s; login with the locator host blackholed must complete within ~5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGPZkSoY2Li3KuckJu6N7C
