### PR TITLE
Embed chaty_V2 support chatbot in the main shell

### DIFF
--- a/index/main.php
+++ b/index/main.php
@@ -30,6 +30,7 @@
 // 20260716 MJ      Tilfoejede Momsperioder-link i Finans-sidebar.
 // 20260730 NTR - Added translation to momsperioder.
 // 20260730 MJ Fjernede Momsperioder-link fra Finans-sidebaren; linket er nu en knap i regnskabsaar.php
+// 20260902 CL/LH Indlejrede chaty_V2 support-chatbot (wuweiworkai.com/chaty-v2) i skallen
 @session_start();
 $s_id = session_id();
 
@@ -664,5 +665,17 @@ function brightenColor($color, $amount = 0.2) {
     }
   }
 </style>
+
+<?php
+// Chat-widget serveres lokalt fra chaty_V2's docker-compose ved udvikling paa localhost
+$chatyBase = (strpos($_SERVER['HTTP_HOST'], 'localhost') === 0 || strpos($_SERVER['HTTP_HOST'], '127.0.0.1') === 0)
+	? 'http://localhost:3000' : 'https://wuweiworkai.com/chaty-v2';
+?>
+<script async
+  src="<?php print $chatyBase; ?>/widget.js"
+  data-widget-id="saldi-erp"
+  data-brand="SALDI.dk"
+  data-lang="<?php print ($sprog_id == 2) ? 'en' : 'da'; ?>"
+  data-theme-color="#2872fa"></script>
 
 </html>

--- a/index/main.php
+++ b/index/main.php
@@ -668,8 +668,8 @@ function brightenColor($color, $amount = 0.2) {
 
 <?php
 // Chat-widget serveres lokalt fra chaty_V2's docker-compose ved udvikling paa localhost
-$chatyBase = (strpos($_SERVER['HTTP_HOST'], 'localhost') === 0 || strpos($_SERVER['HTTP_HOST'], '127.0.0.1') === 0)
-	? 'http://localhost:3000' : 'https://wuweiworkai.com/chaty-v2';
+$chatyHost = strtolower((string) parse_url('http://' . ($_SERVER['HTTP_HOST'] ?? ''), PHP_URL_HOST));  
+$chatyBase = in_array($chatyHost, ['localhost', '127.0.0.1'], true)	? 'http://localhost:3000' : 'https://wuweiworkai.com/chaty-v2';
 ?>
 <script async
   src="<?php print $chatyBase; ?>/widget.js"


### PR DESCRIPTION
## What

Adds the SALDI.dk RAG support chatbot (chaty_V2, deployed at `https://wuweiworkai.com/chaty-v2/`) as a floating chat widget in the ERP. One file changed: `index/main.php`.

- The embed script is injected in the outer iframe shell, just before `</html>`, so the widget loads once per session, floats above the content iframe, and the conversation survives all in-app navigation.
- `data-widget-id="saldi-erp"` separates ERP traffic from the marketing-site install in chatbot analytics.
- `data-lang` follows the user's language: `en` when `$sprog_id == 2`, otherwise `da` (the widget supports da/en).
- On `localhost`/`127.0.0.1` the widget is served from chaty_V2's local docker-compose (`http://localhost:3000`) so it can be developed and tested locally; every other host uses the production URL.

## Out of scope (later phase)

- Wiring the Hjælp button to open the chat (`window.SALDI_CHAT.open()` is exposed by the widget for this).
- Disabling the step-by-step tutorial.
- Pages that bypass the shell (POS, popups, debitoripad, print views).

## Prerequisites

The production origin must be allowed by chaty_V2's `EMBED_ALLOWED_ORIGINS` on the VPS — `https://saldi.dk` and `https://*.saldi.dk` are already on the allowlist, so no server change is needed for production.

## Test scenarios

Affected file: `index/main.php` (shell only — no business logic touched).

1. Log in, confirm the round chat bubble appears bottom-right and stays put while navigating Finans → Debitor → Lager.
2. Confirm no overlap with bottom-anchored UI (kassekladde, the loading bar at the bottom edge).
3. Click the bubble: the chat panel opens; ask a question in Danish and get an answer (verified locally against a local chaty_V2 instance; production answers require a `*.saldi.dk` origin).
4. Switch a user to English (`sprog_id = 2`) and confirm the widget renders in English.
5. Non-shell pages (POS, popups) are unchanged — no widget there by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the Chaty widget to the application.
  - The widget uses the local service for exact `localhost` and `127.0.0.1` addresses, and the production service for other hosts.
  - Configured SALDI branding, language, widget identification, and theme color for a consistent embedded experience.

- **Documentation**
  - Added a changelog entry documenting the embedded Chaty integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->