### PR TITLE
Add local OIOUBL and Peppol invoice extraction

### DIFF
--- a/includes/docsIncludes/docPool.php
+++ b/includes/docsIncludes/docPool.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// --- includes/docsIncludes/docPool.php --- ver 5.0.0 --- 2026-05-15 --- 
+// --- includes/docsIncludes/docPool.php --- ver 5.0.0 --- 2026-08-31 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -20,7 +20,7 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
 // See GNU General Public License for more details.
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft ApS
 // ----------------------------------------------------------------------
 // 20250510 PHR Added 'w' to $legalChars
 // 20250519 PHR '&' replaced by '_' in filenames 
@@ -43,6 +43,7 @@
 //                 which the very next INSERT/UPDATE in each of those code paths already
 //                 references - a brand-new tenant's first pool file would fail with
 //                 "column norm_amount does not exist". Added the column to both.
+// 20260831 CDX/PHR Enabled OIOUBL/Peppol XML uploads for local extraction
 include_once(__DIR__ . "/poolAmountNormalizer.php");
 /**
  * Log message to a file in temp/$db/docPool.log
@@ -3836,7 +3837,7 @@ JS;
 	print "<div style='padding: 12px;'>";
 	
 	// Unified upload zone (click to select or drag and drop)
-	print "<input id='fileUploadInput' type='file' name='uploadedFile[]' accept='.pdf,.jpg,.jpeg,.png' multiple style='display:none'>";
+	print "<input id='fileUploadInput' type='file' name='uploadedFile[]' accept='.pdf,.jpg,.jpeg,.png,.xml' multiple style='display:none'>";
 	print "<div id='dropZone' ondrop='handleDrop(event)' ondragover='handleDragOver(event)' onclick='document.getElementById(\"fileUploadInput\").click()' style='width: 100%; border: 2px dashed #bbb; border-radius: 10px; padding: 90px 16px; background-color: #f8f8f8; cursor: pointer; transition: all 0.3s ease; box-sizing: border-box; display: flex; align-items: center; justify-content: center; margin-bottom: 12px;'>";
 	print "<div id='dropText' style='display: flex; flex-direction: column; align-items: center; gap: 8px; pointer-events: none; text-align: center;'>";
 	print "<svg viewBox='0 0 24 24' fill='none' stroke='#7ab3d4' stroke-width='1.5' width='44' height='44'><path d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/><polyline points='14 2 14 8 20 8'/><line x1='16' y1='13' x2='8' y2='13'/><line x1='16' y1='17' x2='8' y2='17'/></svg>";
@@ -3874,7 +3875,7 @@ JS;
 	}
 
 	function uploadFiles(files) {
-		var allowedExtensions = ['.pdf', '.jpg', '.jpeg', '.png'];
+		var allowedExtensions = ['.pdf', '.jpg', '.jpeg', '.png', '.xml'];
 		var validFiles = [];
 		for (var i = 0; i < files.length; i++) {
 			var fileName = files[i].name.toLowerCase();

--- a/includes/docsIncludes/invoiceExtractionApi.php
+++ b/includes/docsIncludes/invoiceExtractionApi.php
@@ -1,6 +1,25 @@
 <?php
-// --- includes/docsIncludes/invoiceExtractionApi.php -----
+// --- includes/docsIncludes/invoiceExtractionApi.php --- patch 5.0.0 --- 2026-08-31 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Danosoft ApS
+// ----------------------------------------------------------------------
 // Helper functions for invoice extraction API integration
+// 20260831 CX/PHR Added local OIOUBL/Peppol XML invoice extraction
 
 function invoiceExtractionApiResolveApiKey() {
 	if (!function_exists('db_select') || !function_exists('db_fetch_array')) {
@@ -53,13 +72,113 @@ function invoiceExtractionApiDependencies() {
 }
 
 /**
- * Extract invoice data from a PDF or image file using the external API.
+ * Extract standard invoice fields from an OIOUBL or Peppol UBL XML document.
  *
- * @param string $filePath Full path to the PDF or image file (jpg, jpeg, png)
+ * @param string $filePath Full path to the XML document.
+ * @return array{
+ *   amount: string|null,
+ *   date: string|null,
+ *   vendor: string|null,
+ *   invoiceNumber: string|null,
+ *   description: string|null,
+ *   currency: string|null
+ * }|null SALDI invoice fields, or null when the XML is not a supported UBL invoice.
+ */
+function extractUblInvoiceData($filePath) {
+	$xmlContent = file_get_contents($filePath);
+	if ($xmlContent === false || trim($xmlContent) === '') {
+		error_log("UBL invoice XML is empty or unreadable: $filePath");
+		return null;
+	}
+	if (stripos($xmlContent, '<!DOCTYPE') !== false || stripos($xmlContent, '<!ENTITY') !== false) {
+		error_log("UBL invoice XML contains a prohibited document type or entity declaration: $filePath");
+		return null;
+	}
+
+	$previousUseInternalErrors = libxml_use_internal_errors(true);
+	$document = new DOMDocument();
+	$loaded = $document->loadXML($xmlContent, LIBXML_NONET | LIBXML_NOBLANKS | LIBXML_COMPACT);
+	libxml_clear_errors();
+	libxml_use_internal_errors($previousUseInternalErrors);
+	if (!$loaded || !$document->documentElement) {
+		error_log("Failed to parse UBL invoice XML: $filePath");
+		return null;
+	}
+
+	$documentType = $document->documentElement->localName;
+	if (!in_array($documentType, array('Invoice', 'CreditNote'), true)) {
+		error_log("Unsupported UBL XML document type: $documentType (file: $filePath)");
+		return null;
+	}
+
+	$xpath = new DOMXPath($document);
+	$getValue = function ($expression) use ($xpath) {
+		$nodes = $xpath->query($expression);
+		if (!$nodes || $nodes->length === 0) return null;
+		$value = trim($nodes->item(0)->textContent);
+		return $value !== '' ? $value : null;
+	};
+
+	$invoiceNumber = $getValue('/*[local-name()="Invoice" or local-name()="CreditNote"]/*[local-name()="ID"][1]');
+	$date = $getValue('/*[local-name()="Invoice" or local-name()="CreditNote"]/*[local-name()="IssueDate"][1]');
+	$vendor = $getValue('/*/*[local-name()="AccountingSupplierParty"]//*[local-name()="PartyName"]/*[local-name()="Name"][1]');
+	if ($vendor === null) {
+		$vendor = $getValue('/*/*[local-name()="AccountingSupplierParty"]//*[local-name()="PartyLegalEntity"]/*[local-name()="RegistrationName"][1]');
+	}
+
+	$amountNodes = $xpath->query('/*/*[local-name()="LegalMonetaryTotal"]/*[local-name()="PayableAmount"][1]');
+	$amount = null;
+	$currency = null;
+	if ($amountNodes && $amountNodes->length > 0) {
+		$amountNode = $amountNodes->item(0);
+		$amount = trim($amountNode->textContent);
+		if ($amount === '') $amount = null;
+		$currency = trim($amountNode->getAttribute('currencyID'));
+		if ($currency === '') $currency = null;
+	}
+	if ($currency === null) {
+		$currency = $getValue('/*/*[local-name()="DocumentCurrencyCode"][1]');
+	}
+
+	$descriptionValues = array();
+	$descriptionNodes = $xpath->query('/*/*[local-name()="InvoiceLine" or local-name()="CreditNoteLine"]/*[local-name()="Item"]/*[local-name()="Name" or local-name()="Description"]');
+	if ($descriptionNodes) {
+		foreach ($descriptionNodes as $descriptionNode) {
+			$value = trim($descriptionNode->textContent);
+			if ($value !== '' && !in_array($value, $descriptionValues, true)) $descriptionValues[] = $value;
+		}
+	}
+	if (empty($descriptionValues)) {
+		$note = $getValue('/*/*[local-name()="Note"][1]');
+		if ($note !== null) $descriptionValues[] = $note;
+	}
+	$description = !empty($descriptionValues) ? implode('; ', $descriptionValues) : null;
+
+	if ($amount === null && $date === null && $vendor === null && $invoiceNumber === null && $description === null && $currency === null) {
+		return null;
+	}
+
+	return array(
+		'amount' => $amount,
+		'date' => $date,
+		'vendor' => $vendor,
+		'invoiceNumber' => $invoiceNumber,
+		'description' => $description,
+		'currency' => $currency
+	);
+}
+
+/**
+ * Extract invoice data locally from UBL XML or through the external API for PDF/images.
+ *
+ * @param string $filePath Full path to an XML, PDF, or image file (jpg, jpeg, png).
  * @param string $invoiceId Unique ID for the invoice (e.g., "invoice-001")
  * @return array|null Returns SALDI invoice fields on success, null on failure
  */
 function extractInvoiceData($filePath, $invoiceId = null) {
+	$fileExt = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+	if ($fileExt === 'xml') return extractUblInvoiceData($filePath);
+
 	$dependencies = invoiceExtractionApiDependencies();
 	$keyResolver = isset($dependencies['key_resolver']) && is_callable($dependencies['key_resolver'])
 		? $dependencies['key_resolver']
@@ -73,7 +192,6 @@ function extractInvoiceData($filePath, $invoiceId = null) {
 		return null;
 	}
 
-	$fileExt = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
 	$allowedTypes = array('pdf', 'jpg', 'jpeg', 'png');
 	if (!in_array($fileExt, $allowedTypes)) {
 		error_log("Unsupported file type for invoice extraction: $fileExt (file: $filePath)");

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -1,6 +1,6 @@
 <!doctype html>
 <?php
-// --- includes/documents.php --- patch 5.0.0 --- 2026-06-03 ---
+// --- includes/documents.php --- patch 5.0.0 --- 2026-08-31 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -17,7 +17,7 @@
 // See GNU General Public License for more details.
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2026 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft ApS
 // ----------------------------------------------------------------------
 //20230622 - LOE Updated file path and some related modifications.
 //20240412 - PHR Various modifications
@@ -27,6 +27,7 @@
 //20260304 PHR Someone removed the convertOldDoc section.
 //20260603 CL/PHR debitorOrdrer tilføjet som moderne kilde (modernSources, isModernLayout,
 //                  docFolder-fallback, header-logik og openPool-default)
+// 20260831 CX/PHR Added local OIOUBL/Peppol XML upload and extraction support
 
 @session_start();
 $s_id=session_id();
@@ -130,7 +131,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 	}
 	
 	if ($isAjax || $openPool) {
-		$allowedTypes = array('jpg','jpeg','pdf','png');
+		$allowedTypes = array('jpg','jpeg','pdf','png','xml');
 		$fileName = basename($_FILES['uploadedFile']['name']);
 		
 		// Get file type from MIME type
@@ -162,7 +163,8 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 			// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 			$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 			$baseName = sanitize_filename($baseName);
-			$targetFile = "$poolDir/$baseName.pdf";
+			$storedExt = $ext === 'xml' ? 'xml' : 'pdf';
+			$targetFile = "$poolDir/$baseName.$storedExt";
 			
 			// Try to extract invoice data via API
 			$extractedData = null;
@@ -196,11 +198,11 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 					}
 				}
 			} else {
-				// For PDF files, move directly
+				// PDF and XML files are preserved unchanged.
 				move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile);
-				// Extract data from PDF
+				// Extract data through AI for PDF or locally for UBL XML.
 				if ($autoExtract && file_exists($targetFile)) {
-					error_log("documents.php (AJAX): Calling extractInvoiceData for PDF: $targetFile");
+					error_log("documents.php (AJAX): Calling extractInvoiceData for document: $targetFile");
 					$invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
 					$extractedData = extractInvoiceData($targetFile, $invoiceId);
 					if ($extractedData) {
@@ -246,7 +248,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				
 				// Rename file if we have a new name
 				if ($newBaseName !== $baseName) {
-					$newTargetFile = "$poolDir/$newBaseName.pdf";
+					$newTargetFile = "$poolDir/$newBaseName.$storedExt";
 					
 					// Check if file already exists and append number if needed
 					$counter = 1;
@@ -260,9 +262,9 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 					if (rename($targetFile, $newTargetFile)) {
 						$targetFile = $newTargetFile;
 						$baseName = $newBaseName;
-						error_log("documents.php (AJAX): Renamed file to: $newBaseName.pdf");
+						error_log("documents.php (AJAX): Renamed file to: $newBaseName.$storedExt");
 					} else {
-						error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.pdf");
+						error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.$storedExt");
 					}
 				}
 			}
@@ -339,7 +341,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				
 				// Save extracted currency directly to pool_files (currency not stored in .info files)
 				if ($extractedData !== null && !empty($extractedData['currency'])) {
-					$uploadFilename = $baseName . '.pdf';
+					$uploadFilename = $baseName . '.' . $storedExt;
 					$uploadCurrency = $extractedData['currency'];
 					$qtxt = "SELECT id FROM pool_files WHERE filename = '" . db_escape_string($uploadFilename) . "'";
 					$existingRow = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
@@ -354,7 +356,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				echo json_encode([
 					'success' => true,
 					'message' => 'File uploaded successfully',
-					'filename' => $baseName . '.pdf',
+					'filename' => $baseName . '.' . $storedExt,
 					'extracted' => $extractedData
 				]);
 				exit;
@@ -545,10 +547,11 @@ if (!$isModernLayout) {
 // Handle file uploads for pool view
 // Allow uploads when sourceId is set OR when openPool is set (for new pool uploads)
 if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $openPool)) {
-	$fileTypes = array('jpg','jpeg','pdf','png');
+	$fileTypes = array('jpg','jpeg','pdf','png','xml');
 	$fileName = basename($_FILES['uploadedFile']['name']);
 	list($tmp,$fileType) = explode("/",$_FILES['uploadedFile']['type']);
-	if (in_array(strtolower($fileType),$fileTypes)) {
+	$fileExt = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+	if (in_array(strtolower($fileType),$fileTypes) || in_array($fileExt, $fileTypes)) {
 		$poolDir = "$docFolder/$db/pulje";
 		if (!is_dir($poolDir)) {
 			mkdir($poolDir, 0755, true);
@@ -559,7 +562,8 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 		// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 		$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 		$baseName = sanitize_filename($baseName);
-		$targetFile = "$poolDir/$baseName.pdf";
+		$storedExt = $ext === 'xml' ? 'xml' : 'pdf';
+		$targetFile = "$poolDir/$baseName.$storedExt";
 		
 		// Try to extract invoice data BEFORE converting to PDF (API works better with original images)
 		$extractedData = null;
@@ -593,11 +597,11 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 				}
 			}
 		} else {
-			// For PDF files, move directly
+			// PDF and XML files are preserved unchanged.
 			move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile);
-			// Extract data from PDF
+			// Extract data through AI for PDF or locally for UBL XML.
 			if ($autoExtract && file_exists($targetFile)) {
-				error_log("documents.php (block2): Calling extractInvoiceData for PDF: $targetFile");
+				error_log("documents.php (block2): Calling extractInvoiceData for document: $targetFile");
 				$invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
 				$extractedData = extractInvoiceData($targetFile, $invoiceId);
 				if ($extractedData) {
@@ -686,7 +690,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 				"kladde_id=$kladde_id"."&".
 				"bilag=$bilag"."&".
 				"fokus=$fokus"."&".
-				"poolFile=$baseName.pdf"."&".
+				"poolFile=$baseName.$storedExt"."&".
 				"docFolder=$docFolder"."&".
 				"sourceId=$sourceId"."&".
 				"source=$source";

--- a/tests/test_invoice_extraction_api.php
+++ b/tests/test_invoice_extraction_api.php
@@ -35,6 +35,18 @@ mkdir($tempDir);
 $pdfPath = $tempDir . '/invoice.pdf';
 $pdfBytes = "%PDF-1.7\npage-one\fpage-two\n%%EOF";
 file_put_contents($pdfPath, $pdfBytes);
+$xmlPath = $tempDir . '/invoice.xml';
+$xmlBytes = '<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017</cbc:CustomizationID>
+  <cbc:ID>INV-42</cbc:ID>
+  <cbc:IssueDate>2026-07-23</cbc:IssueDate>
+  <cbc:DocumentCurrencyCode>DKK</cbc:DocumentCurrencyCode>
+  <cac:AccountingSupplierParty><cac:Party><cac:PartyName><cbc:Name>Leverandør ApS</cbc:Name></cac:PartyName></cac:Party></cac:AccountingSupplierParty>
+  <cac:LegalMonetaryTotal><cbc:PayableAmount currencyID="DKK">1250.00</cbc:PayableAmount></cac:LegalMonetaryTotal>
+  <cac:InvoiceLine><cac:Item><cbc:Name>Konsulentydelse</cbc:Name></cac:Item></cac:InvoiceLine>
+</Invoice>';
+file_put_contents($xmlPath, $xmlBytes);
 
 $dbSelectCalls = array();
 $dbSelectResult = array('var_value' => 'global-key');
@@ -66,6 +78,19 @@ $invoiceExtractionApiDependencies = array(
 	'key_resolver' => function () { return null; },
 	'transport' => function () use (&$transportCalls) { $transportCalls++; return array(); }
 );
+$xmlResult = extractInvoiceData($xmlPath, 'xml-test');
+check($xmlResult === array('amount' => '1250.00', 'date' => '2026-07-23', 'vendor' => 'Leverandør ApS', 'invoiceNumber' => 'INV-42', 'description' => 'Konsulentydelse', 'currency' => 'DKK'), 'extracts standard OIOUBL/Peppol fields locally');
+check($transportCalls === 0, 'does not call the AI transport for XML invoices');
+
+$unsafeXmlPath = $tempDir . '/unsafe.xml';
+file_put_contents($unsafeXmlPath, '<!DOCTYPE Invoice [<!ENTITY secret SYSTEM "file:///etc/passwd">]><Invoice>&secret;</Invoice>');
+check(extractInvoiceData($unsafeXmlPath, 'unsafe-xml') === null, 'rejects XML document type and entity declarations');
+
+$transportCalls = 0;
+$invoiceExtractionApiDependencies = array(
+	'key_resolver' => function () { return null; },
+	'transport' => function () use (&$transportCalls) { $transportCalls++; return array(); }
+);
 check(extractInvoiceData($pdfPath, 'missing-key') === null && $transportCalls === 0, 'does not call transport without an API key');
 
 foreach (array(
@@ -82,6 +107,8 @@ foreach (array(
 
 unset($invoiceExtractionApiDependencies);
 unlink($pdfPath);
+unlink($xmlPath);
+unlink($unsafeXmlPath);
 rmdir($tempDir);
 
 echo "\nResults: $passed passed, $failed failed\n";


### PR DESCRIPTION
## Summary

- accept XML files in the document-pool upload flow and preserve their `.xml` extension
- parse OIOUBL/Peppol Invoice and CreditNote documents locally without an AI request
- populate amount, date, supplier, invoice number, description, and currency through the existing metadata flow
- reject XML documents containing DOCTYPE or entity declarations

## Validation

- `php -l includes/documents.php`
- `php -l includes/docsIncludes/docPool.php`
- `php -l includes/docsIncludes/invoiceExtractionApi.php`
- `php tests/test_invoice_extraction_api.php` — 16 passed
- `php tests/test_doc_pool_upload_exactly_once.php` — 11 passed
- `git diff --check`

## Manual testing

- upload an OIOUBL invoice and confirm date, amount, supplier, invoice number, and currency
- upload a Peppol BIS 3 invoice and confirm the same metadata
- scan an existing XML pool file using the extraction button
- test a UBL CreditNote
- upload PDF/JPG/PNG and confirm they still use the existing AI extraction flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading OIOUBL/Peppol XML invoices alongside PDF and image files.
  * XML invoices are validated and processed locally, extracting key invoice details such as number, date, vendor, amount, currency, and description.
  * Added protection against unsafe XML declarations during invoice processing.

* **Bug Fixes**
  * Improved file handling so uploaded documents retain the appropriate file extension and processing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->