### PR TITLE
MB-31 fixes: bypass stock/discontinued filters and activity gate when…

### DIFF
--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -202,7 +202,10 @@ list($a,$b)=explode(":",$varegruppe);
 // the 4 candidate queries below runs, so a real Jira ticket key/description search actually narrows
 // this report instead of only filtering by Varegruppe/Lager/Dato.
 $vareSearchSql = "";
-if ($varenrSoeg) {
+// CodeRabbit - a plain truthy check treats the string "0" as false (PHP's "0" == false), so searching
+// Varenr./Beskrivelse/Enhed for exactly "0" silently built no SQL filter at all - explicit "not null and
+// not empty string" checks below instead, so "0" is treated as a real search term like any other.
+if ($varenrSoeg !== null && $varenrSoeg !== '') {
 	// MB-31 - always a plain substring match, same as every other per-column search box in this
 	// grid row and in the ordreliste.php sample - no special '*' wildcard syntax to remember.
 	// Pattern built into its own variable (not $varenrSoeg itself) so the search box, CSV href
@@ -213,14 +216,14 @@ if ($varenrSoeg) {
 	$upp=strtoupper($varenrPattern);
 	$vareSearchSql.=" and (varer.varenr LIKE '".db_escape_string($varenrPattern)."' or lower(varer.varenr) LIKE '".db_escape_string($low)."' or upper(varer.varenr) LIKE '".db_escape_string($upp)."')";
 }
-if ($varenavn) {
+if ($varenavn !== null && $varenavn !== '') {
 	// MB-31 - same plain substring match as Varenr. above, same reason for a separate pattern var.
 	$varenavnPattern = "%".$varenavn."%";
 	$low=strtolower($varenavnPattern);
 	$upp=strtoupper($varenavnPattern);
 	$vareSearchSql.=" and (varer.beskrivelse LIKE '".db_escape_string($varenavnPattern)."' or lower(varer.beskrivelse) LIKE '".db_escape_string($low)."' or upper(varer.beskrivelse) LIKE '".db_escape_string($upp)."')";
 }
-if ($enhedSoeg) {
+if ($enhedSoeg !== null && $enhedSoeg !== '') {
 	// MB-31 - Enhed's search box: substring match (not exact/wildcard like Varenr./Beskrivelse above),
 	// same convention includes/grid.php's own DEFAULT_GENERATE_SEARCH() uses for its 'text' columns.
 	$vareSearchSql.=" and varer.enhed ILIKE '%".db_escape_string($enhedSoeg)."%'";
@@ -234,14 +237,25 @@ if ($enhedSoeg) {
 // only, not $lsS (the numeric per-column boxes) - those have no SQL-level filter of their own to bypass,
 // and bypassing zStock for a numeric-only search would run the expensive per-item loop over the whole
 // catalog instead of a search-narrowed candidate list.
-$lsHasTextSearch = ($varenrSoeg || $varenavn || $enhedSoeg);
+// CodeRabbit - same "0" truthy pitfall as $vareSearchSql above: || on the raw strings would treat an
+// exact "0" search as no search at all, leaving the very filters this flag exists to bypass still in
+// effect for that value - explicit not-null/not-empty checks instead.
+$lsHasTextSearch = ($varenrSoeg !== null && $varenrSoeg !== '')
+	|| ($varenavn !== null && $varenavn !== '')
+	|| ($enhedSoeg !== null && $enhedSoeg !== '');
 
 if ($a) {
 	if ($lagervalg) {
 		$qtxt = "select varer.id,varer.varenr,varer.enhed,varer.beskrivelse,varer.salgspris,varer.kostpris,varer.varianter,varer.gruppe,";
 		$qtxt.= "lagerstatus.beholdning ";
-		$qtxt.= "from varer,lagerstatus where varer.gruppe='$a' and lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
-		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and lagerstatus.beholdning != '0' ";
+		// CodeRabbit - LEFT JOIN (was an inner join): a product that has never had any stock movement in
+		// THIS specific warehouse has no lagerstatus row for it at all, so an inner join dropped it before
+		// $lsHasTextSearch below ever got a chance to matter - a text search still couldn't find it even
+		// with the zStock/showClosed bypass. coalesce() below treats "no row" the same as "0 stock"
+		// everywhere beholdning is filtered; the loop that reads $r2['beholdning'] further down does the
+		// same for display.
+		$qtxt.= "from varer left join lagerstatus on lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' where varer.gruppe='$a' ";
+		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and coalesce(lagerstatus.beholdning,0) != '0' ";
 		if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 		$qtxt.= "$vareSearchSql ";
 		$qtxt.="order by varer.varenr";
@@ -256,8 +270,9 @@ if ($a) {
 	if ($lagervalg) {
 		$qtxt =" select varer.id,varer.varenr,varer.enhed,varer.beskrivelse,varer.salgspris,varer.kostpris,varer.varianter,varer.gruppe,";
 		$qtxt.= "lagerstatus.beholdning ";
-		$qtxt.= "from varer,lagerstatus where lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
-		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and lagerstatus.beholdning != '0' ";
+		// CodeRabbit - LEFT JOIN, same reason as the gruppe+lagervalg branch above.
+		$qtxt.= "from varer left join lagerstatus on lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' where 1=1 ";
+		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and coalesce(lagerstatus.beholdning,0) != '0' ";
 	   if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 		$qtxt.= "$vareSearchSql ";
 		$qtxt.= " order by varer.varenr";
@@ -276,7 +291,11 @@ while ($r2=db_fetch_array($q2)){
 		$vare_id[$x]=$r2['id'];
 		$varenr[$x]=stripslashes($r2['varenr']);
 		$enhed[$x]=stripslashes($r2['enhed']);
-		$beholdning[$x]=$r2['beholdning'];
+		// CodeRabbit - the lagervalg branches above now LEFT JOIN lagerstatus, so a product with no
+		// stock row at all for the selected warehouse comes back with beholdning=NULL rather than a
+		// missing row; treat that the same as 0 here so downstream arithmetic (afrund/dkdecimal/etc.)
+		// never operates on NULL.
+		$beholdning[$x]=$r2['beholdning'] !== null ? $r2['beholdning'] : 0;
 		$varianter[$x]=$r2['varianter']; #20180204
 		$beskrivelse[$x]=stripslashes($r2['beskrivelse']);
 		$salgspris[$x]=$r2['salgspris'];

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -47,6 +47,12 @@
 //             $varenrSoeg, not $varenr, to avoid clobbering the existing per-item $varenr[$x] array
 //             further down (caught live against a real tenant - first version silently turned every
 //             result row's item-number display into "Array" and broke pagination links)
+// 20260903 SZ MB-31 follow-up: the search added above couldn't find an item that had never been
+//             bought/sold, nor one that was out of stock or discontinued (reported by Peter, tenant
+//             test_31, item K7048TE12) - the zStock/showClosed SQL filters and the "has any activity"
+//             gate further down excluded it regardless of a matching search term. Added
+//             $lsHasTextSearch to bypass both once Varenr./Beskrivelse/Enhed is searched - see its
+//             own comment further down. Live-verified against the local chartest tenant.
 
 // MB-31 - one <input> per grid search column (see $lsSFields further down); every such box uses this
 // same markup.
@@ -220,19 +226,29 @@ if ($enhedSoeg) {
 	$vareSearchSql.=" and varer.enhed ILIKE '%".db_escape_string($enhedSoeg)."%'";
 }
 
+// MB-31 follow-up (Peter, test_31, 20260903) - a Varenr./Beskrivelse/Enhed search must find a matching
+// item regardless of the zStock ("0 lager")/showClosed ("Udgåede") checkboxes and regardless of whether
+// it's ever been bought or sold: those two checkboxes are for browsing the full list, but a deliberate
+// text search already narrows $vareSearchSql to matching items, so it's safe (and expected) to bypass
+// both filters below plus the "has activity" gate further down in that case. Scoped to the text fields
+// only, not $lsS (the numeric per-column boxes) - those have no SQL-level filter of their own to bypass,
+// and bypassing zStock for a numeric-only search would run the expensive per-item loop over the whole
+// catalog instead of a search-narrowed candidate list.
+$lsHasTextSearch = ($varenrSoeg || $varenavn || $enhedSoeg);
+
 if ($a) {
 	if ($lagervalg) {
 		$qtxt = "select varer.id,varer.varenr,varer.enhed,varer.beskrivelse,varer.salgspris,varer.kostpris,varer.varianter,varer.gruppe,";
 		$qtxt.= "lagerstatus.beholdning ";
 		$qtxt.= "from varer,lagerstatus where varer.gruppe='$a' and lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
-		if (!$zStock) $qtxt.= "and lagerstatus.beholdning != '0' ";
-		if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and lagerstatus.beholdning != '0' ";
+		if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 		$qtxt.= "$vareSearchSql ";
 		$qtxt.="order by varer.varenr";
 	} else {
 	   $qtxt = "select * from varer where gruppe='$a' ";
-	   if (!$zStock) $qtxt.= "and beholdning != '0' ";
-	   if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+	   if (!$zStock && !$lsHasTextSearch) $qtxt.= "and beholdning != '0' ";
+	   if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 	   $qtxt.= "$vareSearchSql ";
 	   $qtxt.= "order by varenr";
 	}
@@ -241,16 +257,14 @@ if ($a) {
 		$qtxt =" select varer.id,varer.varenr,varer.enhed,varer.beskrivelse,varer.salgspris,varer.kostpris,varer.varianter,varer.gruppe,";
 		$qtxt.= "lagerstatus.beholdning ";
 		$qtxt.= "from varer,lagerstatus where lagerstatus.vare_id=varer.id and lagerstatus.lager='$lagervalg' ";
-		if (!$zStock) $qtxt.= "and lagerstatus.beholdning != '0' ";
-	   if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and lagerstatus.beholdning != '0' ";
+	   if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 		$qtxt.= "$vareSearchSql ";
 		$qtxt.= " order by varer.varenr";
 	} else {
 		$qtxt = "select * from varer where 1=1 ";
-		if (!$zStock) {
-			$qtxt.= "and beholdning != '0' ";
-			if (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
-		} elseif (!$showClosed) $qtxt.= "and varer.lukket = '0' ";
+		if (!$zStock && !$lsHasTextSearch) $qtxt.= "and beholdning != '0' ";
+		if (!$showClosed && !$lsHasTextSearch) $qtxt.= "and varer.lukket = '0' ";
 		$qtxt.= "$vareSearchSql ";
 		$qtxt.= "order by varenr";
 	}
@@ -577,7 +591,12 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 			db_modify("insert into lagerstatus(vare_id,beholdning,lager) values ('$vare_id[$x]','$diff','$tmp')",__FILE__ . " linje " . __LINE__);
 		}
 	}
-	if ($batch_k_antal[$x]||$batch_s_antal[$x]||$beholdning[$x]||$handlet[$x]) {
+	// MB-31 follow-up - $lsHasTextSearch bypasses this "has any activity" gate too: a text search
+	// already narrowed the candidate query above ($vareSearchSql), so every $x reaching here already
+	// matches the search term and must be shown even if it's never been bought/sold and has 0 stock
+	// (K7048TE12, Peter's test_31 report) - previously such an item silently vanished here even though
+	// it matched the query.
+	if ($batch_k_antal[$x]||$batch_s_antal[$x]||$beholdning[$x]||$handlet[$x]||$lsHasTextSearch) {
 		if ($linjebg!=$bgcolor5){$linjebg=$bgcolor5; $color='#000000';}
 		else {$linjebg=$bgcolor; $color='#000000';}
 		print "<tr bgcolor=\"$linjebg\">";


### PR DESCRIPTION
## Summary
MB-31 added per-column search (Varenr./Beskrivelse/Enhed) to `lager/lagerstatus.php` (Stock
Status report). Peter (QA), testing on tenant `test_31`, found the search didn't actually
work for the items you'd most want to find with it:

- Searching Varenr. for an item that had never been bought or sold (e.g. `K7048TE12`)
  returned nothing.
- Items that were out of stock or discontinued weren't found by search either, even with the
  exact Varenr. typed in.

## Root Cause
Two filters that predate the search feature, neither aware a search could be active:

1. **SQL query filters** — the candidate query only includes `beholdning != '0'` (stock
   present) unless "0 lager" is checked, and only `lukket = '0'` (not discontinued) unless
   "Udgåede" is checked. These run before the search term is even considered, so a
   correctly-typed Varenr. could be filtered out at the database level, before it ever
   reached comparison.
2. **"Has any activity" gate** — even a row that survived the SQL query was dropped from the
   output entirely if it had zero purchase/sale/stock history
   (`$batch_k_antal||$batch_s_antal||$beholdning[$x]||$handlet[$x]`). This is specifically
   what hid `K7048TE12`.


## What are the changes about?
In `lager/lagerstatus.php`: added `$lsHasTextSearch` (true whenever Varenr./Beskrivelse/
Enhed has a search term) and used it to bypass both the zStock/showClosed SQL filters and
the activity gate.

**Why this is safe:** a non-empty search term already narrows the SQL `WHERE` clause itself
(matching on Varenr./Beskrivelse/Enhed), so bypassing the other two filters only lets through
rows that already matched the search — never anything extra. The zStock/showClosed and
activity-history filters were only ever meant to hide irrelevant items from *unfiltered
browsing*, not to hide items the user explicitly searched for by name.

**Deliberately not applied** to the numeric per-column boxes (Tilgang/Afgang/Antal/
Kobspris/Kostpris/Salgspris): bypassing zStock there would make the per-item aggregation
loop scan the whole catalog instead of a search-narrowed set — a real perf risk given MB-31's
own ticket explicitly requires not undoing the recent report-speed work. Numeric-column
filtering therefore continues to operate only on rows that already passed the existing SQL
filters, same as before this fix.

## Files Changed
- lager/lagerstatus.php (~24 insertions / 11 deletions, plus a changelog line)

## How to Test
1. On a test tenant (e.g. `test_31` or `chartest`), create an item that has never been bought
   or sold (no purchase/sale/stock history).
2. Search for it by exact Varenr. in the Stock Status report — verify it is now found and
   displayed.
3. Confirm the same item does **not** appear when browsing without a search term (i.e. it's
   still correctly hidden from default/unfiltered browsing — this fix only affects
   search-active behavior).
4. Create/identify a discontinued item ("Udgåede") and an out-of-stock item — search for each
   by exact Varenr. and confirm both are now found.
5. Confirm the same discontinued/out-of-stock items are correctly hidden from default
   browsing when "Udgåede"/"0 lager" are unchecked and no search term is active.
6. Search using Beskrivelse and Enhed (not just Varenr.) and confirm the same bypass applies
   correctly for both.
7. Filter using a numeric per-column box (e.g. Antal, Kostpris) with no text search active —
   confirm behavior and performance are unchanged from before this fix (zStock/showClosed
   filters still apply as before).
8. Combine a text search with a numeric column filter and confirm both apply correctly
   together.
9. **Performance regression check:** run a report with an empty/no search term on a large
   catalog and confirm load time is unchanged from before this fix — the bypass should only
   ever trigger when `$lsHasTextSearch` is true.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Search by exact Varenr. for a never-transacted item | Item is found and displayed |
| 2 | Search by exact Varenr. for a discontinued item | Item is found and displayed |
| 3 | Search by exact Varenr. for an out-of-stock item | Item is found and displayed |
| 4 | Same items with no search term active | Remain correctly hidden per existing zStock/showClosed/activity rules |
| 5 | Numeric per-column search (Tilgang/Afgang/Antal/Kobspris/Kostpris/Salgspris) | Continues to operate only on rows passing existing SQL filters — no perf regression |
| 6 | Report load time with no search term | Unchanged from pre-fix baseline |

## Verification
Verified live by creating a never-transacted item and a discontinued item through the real
app UI on the local `chartest` tenant — both correctly stay hidden from default browsing and
are now found by search.

## Tested On
- d-lop ✅

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Text searches for item number, description, or unit now return matching items even when they are out of stock, discontinued, or have no recorded purchase or sales activity.
  - Search results are no longer limited by stock-status and activity filters when a text search term is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->