### PR TITLE
MB-39: fix lagerstatus purchase-price valuation ignoring negative bat…

### DIFF
--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -47,6 +47,13 @@
 //             $varenrSoeg, not $varenr, to avoid clobbering the existing per-item $varenr[$x] array
 //             further down (caught live against a real tenant - first version silently turned every
 //             result row's item-number display into "Array" and broke pagination links)
+// 20260904 SZ MB-39: Kobspris valued stock at the wrong price - the batch_kob value walk's
+//             "and antal >= 1" dropped negative (credit note) lines, so a credited purchase never
+//             cancelled the batch it credited, and its "order by kobsdate desc" had no tie-break,
+//             so the result could change between runs when batches shared a date. Included
+//             negative lines, added an id-based tie-break, stopped the walk once remaining stock
+//             is covered, and guarded on positive remaining stock so already-zero/negative-stock
+//             items still value at 0. Verified against IBON's real saldi_821 dump (SST-764).
 
 // MB-31 - one <input> per grid search column (see $lsSFields further down); every such box uses this
 // same markup.

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -539,14 +539,24 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 		if ($tmp*$batch_t_antal[$x]!=0) $batch_pris[$x]=$batch_pris[$x]/$tmp*$batch_t_antal[$x];
 		else $batch_pris[$x]=0;
 */	
-	if ($batch_k_antal[$x]) {
+	// MB-39 - "and antal >= 1" used to drop negative batch_kob lines (purchase credit notes) from
+	// this walk, so a credit note never cancelled the erroneous batch it credited, plus it dropped
+	// legitimate fractional purchase lines (0 < antal < 1, e.g. produce sold by weight). Now that
+	// negative lines are included, the walk must only run when there's positive remaining stock to
+	// value ($batch_t_antal[$x] > 0): for a fully sold-out or oversold/misposted item, a negative
+	// line alone can satisfy the "<=" check below and leave $antal non-zero without ever reaching
+	// real stock, producing a bogus non-zero price for an item that should value at 0 - the old
+	// antal>=1 filter prevented this too, as a side effect of keeping negative lines out entirely.
+	if ($batch_k_antal[$x] && $batch_t_antal[$x] > 0) {
 		$pris=0;
 		$antal=0;
-		$qtxt="select antal,pris from batch_kob where vare_id=$vare_id[$x] and antal >= 1"; #20140128
+		// Tie-break on id keeps same-day batches in a deterministic order - previously relied on
+		// undefined physical row order, so the result could change between runs on tied dates.
+		$qtxt="select antal,pris from batch_kob where vare_id=$vare_id[$x]";
 		if ($lagervalg) $qtxt.=" and lager='$lagervalg'";
 		($dateType == 'levdate')?$dt = 'kobsdate':$dt = $dateType;
 		if ($date!=$dd) $qtxt.=" and $dt <= '$date'";
-		$qtxt.=" order by kobsdate desc";
+		$qtxt.=" order by kobsdate desc, id desc";
 		$q1=db_select($qtxt,__FILE__ . " linje " . __LINE__);
 		while($r1=db_fetch_array($q1)) {
 			if ($antal+$r1['antal'] <= $batch_t_antal[$x]) {
@@ -556,6 +566,11 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 				$pris+=$r1['pris']*($batch_t_antal[$x]-$antal);
 				$antal=$batch_t_antal[$x];
 			}
+			// Once the walk has accounted for all remaining stock, stop - otherwise an older
+			// credit note (now included above) could still get pulled in here, since a negative
+			// antal always satisfies the "<=" check above regardless of how much of the target is
+			// already covered.
+			if ($antal>=$batch_t_antal[$x]) break;
 		}
 		($antal)?$batch_pris[$x]=$pris:$batch_pris[$x]=0;
 	}

--- a/lager/lagerstatus.php
+++ b/lager/lagerstatus.php
@@ -54,6 +54,7 @@
 //             negative lines, added an id-based tie-break, stopped the walk once remaining stock
 //             is covered, and guarded on positive remaining stock so already-zero/negative-stock
 //             items still value at 0. Verified against IBON's real saldi_821 dump (SST-764).
+// 20260908 CDX/LH Cancel linked purchase credits before selecting the remaining stock value.
 
 // MB-31 - one <input> per grid search column (see $lsSFields further down); every such box uses this
 // same markup.
@@ -96,6 +97,7 @@ include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
 include("../includes/topline_settings.php");
+include_once(__DIR__ . "/lagerstatusValue.php");
 
 db_modify("update varer set lukket = '0' where lukket is NULL or lukket = ''",__FILE__ . " linje " . __LINE__);
 
@@ -546,41 +548,17 @@ if ($vare_id[$x]==454) #cho "BP $batch_pris[$x]<br>";
 		if ($tmp*$batch_t_antal[$x]!=0) $batch_pris[$x]=$batch_pris[$x]/$tmp*$batch_t_antal[$x];
 		else $batch_pris[$x]=0;
 */	
-	// MB-39 - "and antal >= 1" used to drop negative batch_kob lines (purchase credit notes) from
-	// this walk, so a credit note never cancelled the erroneous batch it credited, plus it dropped
-	// legitimate fractional purchase lines (0 < antal < 1, e.g. produce sold by weight). Now that
-	// negative lines are included, the walk must only run when there's positive remaining stock to
-	// value ($batch_t_antal[$x] > 0): for a fully sold-out or oversold/misposted item, a negative
-	// line alone can satisfy the "<=" check below and leave $antal non-zero without ever reaching
-	// real stock, producing a bogus non-zero price for an item that should value at 0 - the old
-	// antal>=1 filter prevented this too, as a side effect of keeping negative lines out entirely.
-	if ($batch_k_antal[$x] && $batch_t_antal[$x] > 0) {
-		$pris=0;
-		$antal=0;
-		// Tie-break on id keeps same-day batches in a deterministic order - previously relied on
-		// undefined physical row order, so the result could change between runs on tied dates.
-		$qtxt="select antal,pris from batch_kob where vare_id=$vare_id[$x]";
-		if ($lagervalg) $qtxt.=" and lager='$lagervalg'";
-		($dateType == 'levdate')?$dt = 'kobsdate':$dt = $dateType;
-		if ($date!=$dd) $qtxt.=" and $dt <= '$date'";
-		$qtxt.=" order by kobsdate desc, id desc";
-		$q1=db_select($qtxt,__FILE__ . " linje " . __LINE__);
-		while($r1=db_fetch_array($q1)) {
-			if ($antal+$r1['antal'] <= $batch_t_antal[$x]) {
-				$antal+=$r1['antal'];
-				$pris+=$r1['antal']*$r1['pris'];
-			} elseif ($antal < $batch_t_antal[$x] && $antal+$r1['antal'] > $batch_t_antal[$x]) {
-				$pris+=$r1['pris']*($batch_t_antal[$x]-$antal);
-				$antal=$batch_t_antal[$x];
+		// Keep fractional receipts and unresolved credit rows in the signed history. Linked
+		// credits cancel their original receipts before the newest-first quantity cutoff.
+		if ($batch_k_antal[$x] && $batch_t_antal[$x] > 0) {
+			$qtxt = lagerstatusPurchaseValueSql($vare_id[$x], $lagervalg, $dateType, $date != $dd ? $date : null);
+			$q1 = db_select($qtxt, __FILE__ . " linje " . __LINE__);
+			$purchaseBatches = array();
+			while ($r1 = db_fetch_array($q1)) {
+				$purchaseBatches[] = $r1;
 			}
-			// Once the walk has accounted for all remaining stock, stop - otherwise an older
-			// credit note (now included above) could still get pulled in here, since a negative
-			// antal always satisfies the "<=" check above regardless of how much of the target is
-			// already covered.
-			if ($antal>=$batch_t_antal[$x]) break;
+			$batch_pris[$x] = lagerstatusPurchaseValue($purchaseBatches, $batch_t_antal[$x]);
 		}
-		($antal)?$batch_pris[$x]=$pris:$batch_pris[$x]=0;
-	}
 	}
 	if (isset($_GET['ajour']) && $_GET['ajour']==1 && $batch_t_antal[$x] != $beholdning[$x]) {
 		$diff=$batch_t_antal[$x];

--- a/lager/lagerstatusValue.php
+++ b/lager/lagerstatusValue.php
@@ -1,0 +1,99 @@
+<?php
+// --- lager/lagerstatusValue.php --- patch 5.0.0 --- 2026-09-08 ---
+// 20260908 CDX/LH Cancel linked purchase credits before valuing the remaining stock.
+
+/**
+ * Build the purchase history query using the report's item, warehouse and date scope.
+ * A null cutoff preserves the report's current-date inclusion of future deliveries.
+ *
+ * @param int $itemId
+ * @param int $warehouse Zero selects all warehouses.
+ * @param string $dateType Report date selection: levdate or fakturadate.
+ * @param string|null $cutoffDate ISO date, or null for the current report date.
+ * @return string
+ */
+function lagerstatusPurchaseValueSql($itemId, $warehouse, $dateType, $cutoffDate)
+{
+	$itemId = (int)$itemId;
+	$warehouse = (int)$warehouse;
+	$sql = "select bk.id,bk.linje_id,bk.antal,bk.pris,ol.kred_linje_id from batch_kob bk ";
+	$sql .= "left join ordrelinjer ol on ol.id=bk.linje_id where bk.vare_id=$itemId";
+	if ($warehouse) {
+		$sql .= " and bk.lager=$warehouse";
+	}
+	if ($cutoffDate !== null) {
+		// The page supplies usdate() output. Cast its components before SQL interpolation.
+		if (!preg_match('/\A[0-9]{4}-[0-9]{2}-[0-9]{2}\z/', $cutoffDate)) {
+			throw new InvalidArgumentException('Stock valuation cutoff must be an ISO date.');
+		}
+		list($year, $month, $day) = array_map('intval', explode('-', $cutoffDate));
+		$cutoffDate = sprintf('%04d-%02d-%02d', $year, $month, $day);
+		$column = $dateType === 'fakturadate' ? 'fakturadate' : 'kobsdate';
+		$sql .= " and bk.$column <= '$cutoffDate'";
+	}
+	return $sql . " order by bk.kobsdate desc, bk.id desc";
+}
+
+/**
+ * Value stock from purchase batches already ordered newest first and scoped by the report.
+ * Linked negative quantities first cancel receipts on their original order line, including
+ * split deliveries, so a partial stock valuation cannot retain half a cancelled purchase.
+ * Positive copied lines may also have kred_linje_id; they are receipts, not credits.
+ *
+ * Unlinked credits, missing original receipts and any excess credited quantity retain the
+ * existing signed-walk behavior. There is no reliable original purchase to cancel in those
+ * cases; this function deliberately does not infer a match from price or chronology.
+ *
+ * @param array<int, array{id: int|string, linje_id: int|string|null, antal: float|string|null,
+ *     pris: float|string|null, kred_linje_id: int|string|null}> $batches
+ * @param float $remainingStock
+ * @return float Purchase value before the report's display rounding.
+ */
+function lagerstatusPurchaseValue($batches, $remainingStock)
+{
+	if ($remainingStock <= 0) {
+		return 0.0;
+	}
+
+	$receiptsByLine = array();
+	foreach ($batches as $index => $batch) {
+		$batches[$index]['antal'] = (float)$batch['antal'];
+		$lineId = (int)$batch['linje_id'];
+		if ($batch['antal'] > 0 && $lineId > 0) {
+			$receiptsByLine[$lineId][] = $index;
+		}
+	}
+	foreach ($batches as $creditIndex => $credit) {
+		$originalLine = (int)$credit['kred_linje_id'];
+		if ($credit['antal'] >= 0 || !isset($receiptsByLine[$originalLine])) {
+			continue;
+		}
+		$quantity = -$credit['antal'];
+		foreach ($receiptsByLine[$originalLine] as $receiptIndex) {
+			$cancelled = min($quantity, $batches[$receiptIndex]['antal']);
+			// batch_kob quantities are numeric(15,3); avoid fractional subtraction residue.
+			$batches[$receiptIndex]['antal'] = round($batches[$receiptIndex]['antal'] - $cancelled, 3);
+			$quantity = round($quantity - $cancelled, 3);
+			if ($quantity <= 0) {
+				break;
+			}
+		}
+		$batches[$creditIndex]['antal'] = -$quantity;
+	}
+
+	$quantity = 0.0;
+	$value = 0.0;
+	foreach ($batches as $batch) {
+		if ($quantity + $batch['antal'] <= $remainingStock) {
+			$quantity += $batch['antal'];
+			$value += $batch['antal'] * (float)$batch['pris'];
+		} elseif ($quantity < $remainingStock) {
+			$value += ($remainingStock - $quantity) * (float)$batch['pris'];
+			$quantity = $remainingStock;
+		}
+		if ($quantity >= $remainingStock) {
+			break;
+		}
+	}
+	return $quantity ? $value : 0.0;
+}

--- a/tests/characterization/lager/LagerstatusPurchaseValueTest.test.php
+++ b/tests/characterization/lager/LagerstatusPurchaseValueTest.test.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../lager/lagerstatusValue.php';
+
+final class LagerstatusPurchaseValueTest extends TestCase
+{
+    /**
+     * @return array{id: int, linje_id: int, antal: string, pris: string, kred_linje_id: int}
+     */
+    private static function batch(int $id, int $line, float $quantity, float $price, int $original = 0): array
+    {
+        return ['id' => $id, 'linje_id' => $line, 'antal' => (string)$quantity,
+            'pris' => (string)$price, 'kred_linje_id' => $original];
+    }
+
+    /**
+     * @return array<string, array{array<int, array>, float, float}>
+     */
+    public static function valuationCases(): array
+    {
+        $old = self::batch(1, 101, 10, 1000);
+        $replacement = self::batch(2, 102, 10, 20);
+        $credit = self::batch(3, 103, -10, 1000, 101);
+        return [
+            'ordinary newest receipts' => [[$replacement, $old], 5, 100],
+            'credit after replacement, five sold' => [[$credit, $replacement, $old], 5, 100],
+            'replacement after credit, five sold' => [[$replacement, $credit, $old], 5, 100],
+            'credit after replacement, no sales' => [[$credit, $replacement, $old], 10, 200],
+            'split original deliveries' => [[$credit, $replacement,
+                self::batch(8, 101, 6, 1000), self::batch(7, 101, 4, 1000)], 5, 100],
+            'partial credit and partial sales' => [[self::batch(3, 103, -4, 1000, 101),
+                self::batch(2, 102, 4, 20), $old], 8, 4080],
+            'several credits on original line' => [[self::batch(5, 105, -3, 1000, 101),
+                self::batch(4, 104, -2, 1000, 101), self::batch(2, 102, 5, 20), $old], 7, 2100],
+            'copied positive line is a receipt' => [[$credit, self::batch(2, 102, 10, 20, 101), $old], 5, 100],
+            'fractional split receipts cancel exactly' => [[self::batch(5, 103, -.3, 1000, 101),
+                self::batch(4, 102, .3, 20), self::batch(2, 101, .2, 1000),
+                self::batch(1, 101, .1, 1000)], .15, 3],
+            'positive fractions without credits' => [[self::batch(1, 101, .25, 20)], .125, 2.5],
+            'zero stock' => [[$credit, $replacement, $old], 0, 0],
+            'negative stock' => [[$credit, $replacement, $old], -5, 0],
+            'no purchase history' => [[], 5, 0],
+            // These preserve the existing fallback, including its known limitations; no
+            // original purchase can be inferred safely from price or position alone.
+            'unlinked credit retains signed fallback' => [[self::batch(3, 103, -10, 1000), $replacement, $old], 5, -4800],
+            'missing original retains signed fallback' => [[self::batch(3, 103, -10, 1000, 999), $replacement, $old], 5, -4800],
+            'excess credit retains unmatched remainder' => [[self::batch(3, 103, -12, 1000, 101),
+                self::batch(2, 102, 20, 20), $old], 13, -1700],
+        ];
+    }
+
+    #[DataProvider('valuationCases')]
+    public function testStockValuation(array $batches, float $stock, float $expected): void
+    {
+        $original = $batches;
+        self::assertEqualsWithDelta($expected, lagerstatusPurchaseValue($batches, $stock), .000001);
+        self::assertSame($original, $batches, 'Valuation must not mutate the caller\'s batch history.');
+    }
+
+    public function testQueryKeepsWarehouseDateAndItemScope(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite is required for the isolated query fixture.');
+        }
+        $db = new PDO('sqlite::memory:');
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db->exec('CREATE TABLE batch_kob (id INTEGER, linje_id INTEGER, vare_id INTEGER, antal NUMERIC,
+            pris NUMERIC, lager INTEGER, kobsdate TEXT, fakturadate TEXT)');
+        $db->exec('CREATE TABLE ordrelinjer (id INTEGER PRIMARY KEY, kred_linje_id INTEGER)');
+        $db->exec('INSERT INTO ordrelinjer VALUES (101,0),(102,101),(103,101),(104,0),(105,0),(106,0)');
+        $db->exec("INSERT INTO batch_kob VALUES
+            (1,101,1,10,1000,1,'2026-09-01','2026-09-01'),
+            (2,102,1,10,20,1,'2026-09-02','2026-09-04'),
+            (3,103,1,-10,1000,1,'2026-09-03','2026-09-03'),
+            (4,104,1,10,30,2,'2026-09-02','2026-09-02'),
+            (5,105,2,999,999,1,'2026-09-04','2026-09-04'),
+            (6,106,1,1,40,1,'2026-09-09','2026-09-09')");
+
+        $read = static function ($warehouse, $type, $cutoff) use ($db) {
+            return $db->query(lagerstatusPurchaseValueSql(1, $warehouse, $type, $cutoff))->fetchAll(PDO::FETCH_ASSOC);
+        };
+        $batches = $read(1, 'levdate', '2026-09-03');
+        self::assertSame([3, 2, 1], array_column($batches, 'id'));
+        self::assertEqualsWithDelta(100, lagerstatusPurchaseValue($batches, 5), .000001);
+
+        // The credit is outside this delivery-date cutoff, so the old receipt is still valid.
+        $batches = $read(1, 'levdate', '2026-09-02');
+        self::assertSame([2, 1], array_column($batches, 'id'));
+        self::assertEqualsWithDelta(5200, lagerstatusPurchaseValue($batches, 15), .000001);
+
+        // Invoice-date selection excludes the uninvoiced replacement at this cutoff.
+        $batches = $read(1, 'fakturadate', '2026-09-03');
+        self::assertSame([3, 1], array_column($batches, 'id'));
+        self::assertSame(0.0, lagerstatusPurchaseValue($batches, 0));
+
+        self::assertSame([4], array_column($read(2, 'levdate', '2026-09-03'), 'id'));
+        $batches = $read(0, 'levdate', '2026-09-03');
+        self::assertSame([3, 4, 2, 1], array_column($batches, 'id'));
+        self::assertEqualsWithDelta(400, lagerstatusPurchaseValue($batches, 15), .000001);
+
+        // Null represents the report's current date: preserve its existing future-date inclusion.
+        self::assertSame([6, 3, 2, 1], array_column($read(1, 'levdate', null), 'id'));
+    }
+
+    public function testQueryCastsIdentifiersAndRejectsAnUnsafeCutoff(): void
+    {
+        self::assertStringContainsString('bk.vare_id=1 and bk.lager=2',
+            lagerstatusPurchaseValueSql('1 OR 1=1', '2 OR 1=1', 'levdate', null));
+        $this->expectException(InvalidArgumentException::class);
+        lagerstatusPurchaseValueSql(1, 0, 'levdate', "2026-09-03' OR 1=1");
+    }
+}


### PR DESCRIPTION
## What are the changes about?

[MB-39 / SST-764](https://saldi-team.atlassian.net/browse/SST-764): Lagerstatus could retain an incorrect purchase price after that purchase was credited and replaced. The old `antal >= 1` filter excluded credits and fractional receipts, and purchase batches sharing a date had no deterministic order.

The report now includes signed/fractional history, orders batches by purchase date and ID, and cancels linked negative quantities against receipts on their original `ordrelinjer.kred_linje_id` before selecting the newest remaining stock. This avoids a further defect in a simple signed walk: purchase 10 at 1,000, replace 10 at 20, credit the original 10, then sell 5 must value the remaining stock at **100**, rather than **-4,800**.

Split receipts, partial/repeated credits and three-decimal quantities are handled. Positive copied lines remain purchases even if they retain an original-line reference. Zero and negative stock retain a zero purchase value. Existing report item, warehouse and date filters are preserved.

Changed files: `lager/lagerstatus.php`, new `lager/lagerstatusValue.php`, and `tests/characterization/lager/LagerstatusPurchaseValueTest.test.php`.

## Validation

- PHP syntax and diff checks passed. Committed PHPUnit coverage: **18 tests, 44 assertions** on PHP 8.2/8.3, including generated SQL against SQLite fixtures.
- Independent review found no blocking issues; **96 additional cancellation invariants** passed with warnings treated as failures.
- Full authenticated report validation passed on a disposable PostgreSQL 16 tenant: replacement-before-credit with partial sale (5 units / 100.00), split original receipts with partial credit and sale (8 / 4,080.00), and warehouse-specific receipts/credits (4 / 120.00). Current total: 4,300.00.
- Delivery-date and invoice-date cutoffs before/after credits and sales matched expected quantities and values. Exported delivery-date CSV values matched the displayed report.
- Read-only comparison against IBON's **2026-09-04** backup: 1,169 current nonzero-stock product candidates; prior PR total **9,562,883.61**, corrected total **9,562,575.89**. Three products changed by a combined **-307.72**; no negative values were introduced. Including zero-stock products (1,726 candidates) gave the same totals.

## Limits and remaining customer verification

Unlinked credits, absent original receipts and excess credited quantities retain the signed-history fallback. No original purchase is inferred from matching prices or chronology. Those histories can still contain valuation defects and are explicitly covered as unchanged limitations.

The historical ticket total is **not reconciled** by the newer backup comparison. On the Sept 4 snapshot, item 2009 has 14,635 units valued at **296,822.35**: 14,400 at 20.26 plus 235 at 21.61. The former expectation of 296,505.10 priced every unit at 20.26 and does not match the preserved purchase-layer calculation. Confirm the intended customer report date/warehouse and accounting expectation before closing SST-764.

The existing CSV link selects delivery dates even after an invoice-date report; that separate navigation behavior is unchanged. Related latest-purchase lookups in `includes/ordrefunc.php` and `includes/opdat_kostpriser.php` are outside this correction.

## Manual regression before customer deployment

1. Receive the incorrect purchase, its replacement and linked credit in both credit/replacement orders; sell part of the stock and verify quantity and purchase value. Repeat with split receipts and partial credits.
2. Compare each warehouse and delivery/invoice cutoffs before and after those events. Check zero/negative and fractional stock plus an ordinary product without credit history.
3. Compare report and CSV values for the same supported filter selection, repeat the report for deterministic totals, and check report load time on the intended customer dataset.
4. Reconcile the expected historical total separately and verify the deployed customer installation before resolving the support ticket.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that I am not linking to new external resources that could compromise stability
- [x] I have read and understood the developer guidelines
