### PR TITLE
MB-35: unify Indkøbsforslag reorder formula across both calculation b…

### DIFF
--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -75,6 +75,9 @@
 //                 deleted account's number is never reused; kontonr above 8 digits (EAN-like
 //                 outliers) are ignored when finding the highest, and if the 8-digit range is
 //                 capped by an outlier the first number free in both series is used (SST-753)
+// 20260905 SZ Added genbestil_nettobeholdning()/beregn_genbestil() next to find_beholdning() -
+//             lager/varer.php's reorder-suggestion formula had two branches that disagreed on
+//             whether existing purchase proposals/orders were subtracted (MB-35)
 
 include(__DIR__ . '/stdFunc/dkDecimal.php');
 include(__DIR__ . '/stdFunc/nrCast.php');
@@ -1675,6 +1678,24 @@ if (!function_exists('find_beholdning')) {
 		return $beholdning;
 	}
 } #endfunc find_beholdning()
+
+// MB-35 - lager/varer.php's reorder-suggestion code had two branches computing this differently:
+// one subtracted existing purchase proposals/orders ($i_forslag/$bestilt, from find_beholdning()
+// above) from both the trigger and the suggested quantity, the other used neither anywhere, so an
+// item already covered by a pending purchase order still got flagged and suggested for the full
+// gap up to max - doubling the order once the pending one also arrives. Both branches now share
+// these two functions so they can't drift apart again.
+if (!function_exists('genbestil_nettobeholdning')) {
+	function genbestil_nettobeholdning($beholdning, $i_ordre, $i_forslag, $bestilt) {
+		return $beholdning - $i_ordre + $i_forslag + $bestilt;
+	}
+}
+if (!function_exists('beregn_genbestil')) {
+	function beregn_genbestil($max_lager, $beholdning, $i_ordre, $i_forslag, $bestilt) {
+		$genbestil = $max_lager - genbestil_nettobeholdning($beholdning, $i_ordre, $i_forslag, $bestilt);
+		return $genbestil < 0 ? 0 : $genbestil;
+	}
+}
 
 if (!function_exists('hent_shop_ordrer')) {
 	function hent_shop_ordrer($shop_ordre_id, $from_date)

--- a/lager/varer.php
+++ b/lager/varer.php
@@ -57,7 +57,12 @@
 // 2021.04.01 LOE - Translated these texts to English 20210401
 // 2023.04.14 LOE - Minor modifications
 // 2023.06.03 PHR - php8
-// 2023.09.05	PHR - cookie for saldiProductListStart & saldiProductListLines 
+// 2023.09.05	PHR - cookie for saldiProductListStart & saldiProductListLines
+// 20260905 SZ MB-35: udskriv()'s two genbestil branches disagreed on whether existing purchase
+//             proposals/orders (i_forslag/bestilt) were subtracted from the reorder suggestion -
+//             one branch used neither, so an item already covered by a pending purchase order got
+//             suggested for the full gap to max again. Extracted genbestil_nettobeholdning()/
+//             beregn_genbestil() and routed both branches through them.
 
 @session_start();
 $s_id=session_id();
@@ -904,11 +909,13 @@ for ($v=0;$v<count($varenr);$v++) {
 					print "<td align=right>".dkdecimal($beholdning[$v],2)."</td>";
 				}
 				if ($makeSuggestion){
-					$tmp=$beholdning[$v]-$i_ordre[$z];
+					// MB-35 - was $beholdning[$v]-$i_ordre[$z] and $max_lager[$v]-$beholdning[$v]+$i_ordre[$z]
+					// below, ignoring $i_forslag[$z]/$bestilt[$z] (already fetched above) - see
+					// genbestil_nettobeholdning()/beregn_genbestil() in includes/std_func.php.
+					$tmp=genbestil_nettobeholdning($beholdning[$v],$i_ordre[$z],$i_forslag[$z],$bestilt[$z]);
 					if ($min_lager[$v]*1>$tmp || $alle_varer) {
 						$gb=$gb+1;
-						$genbestil[$z]=$max_lager[$v]-$beholdning[$v]+$i_ordre[$z];
-						if ($genbestil[$z] < 0) $genbestil[$z]=0;	
+						$genbestil[$z]=beregn_genbestil($max_lager[$v],$beholdning[$v],$i_ordre[$z],$i_forslag[$z],$bestilt[$z]);
 						print "<td align=right><input class=\"inputbox\" type=\"text\" style=\"text-align:right;width:60px\" name=\"gb_antal_$gb\" value=\"$genbestil[$z]\"></td>";
 						print "<input type=\"hidden\" name=\"gb_id_$gb\" value=\"$id[$v]\">";
 						print "<input type=\"hidden\" name=\"genbestil_ant\" value=\"$gb\">";
@@ -998,9 +1005,12 @@ for ($v=0;$v<count($varenr);$v++) {
 			}
 			if (!$min_lager[$v])  $min_lager[$v]  = 0;
 			if (!$beholdning[$v]) $beholdning[$v] = 0;
-			if ($min_lager[$v]*1>($beholdning[$v]-$i_ordre[$z]+$i_forslag[$z]+$bestilt[$z])) {
-			
-				$genbestil[$z]=$max_lager[$v]-$beholdning[$v]+$i_ordre[$z]-($i_forslag[$z]+$bestilt[$z]);
+			// MB-35 - routed through the same genbestil_nettobeholdning()/beregn_genbestil() helpers
+			// as the other branch above (line ~906), so the two can't drift apart again - this
+			// branch's own formula was already correct, the other one was missing the
+			// i_forslag/bestilt subtraction.
+			if ($min_lager[$v]*1>genbestil_nettobeholdning($beholdning[$v],$i_ordre[$z],$i_forslag[$z],$bestilt[$z])) {
+				$genbestil[$z]=beregn_genbestil($max_lager[$v],$beholdning[$v],$i_ordre[$z],$i_forslag[$z],$bestilt[$z]);
 				if ($makeSuggestion) {
 					$forslag[$v]=$id[$v];
 				}
@@ -1019,6 +1029,10 @@ return($z);
 }
 }# endfunc udskriv
 ##############################################
+
+// MB-35 - genbestil_nettobeholdning()/beregn_genbestil(), used by both branches above, now live in
+// includes/std_func.php next to find_beholdning() (whose $i_ordre/$i_forslag/$bestilt values they
+// consume), so they're plain testable functions rather than tied up in this page's top-level script.
 
 function genbestil($vare_id, $antal) {
 	global $brugernavn,$db,$regnaar;

--- a/tests/characterization/includes/genbestil/GenbestilCharacterizationTest.test.php
+++ b/tests/characterization/includes/genbestil/GenbestilCharacterizationTest.test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CHARACTERIZATION suite for genbestil_nettobeholdning()/beregn_genbestil()
+ * (includes/std_func.php), pinning the MB-35 fix.
+ *
+ * lager/varer.php's reorder-suggestion code (function udskriv()) had two
+ * branches computing the same thing differently: one subtracted existing
+ * purchase proposals/orders ($i_forslag/$bestilt) from both the "does this
+ * item need reordering" check and the suggested quantity, the other used
+ * neither anywhere. An item already covered by a pending purchase order
+ * still got flagged and suggested for the full gap up to max - doubling the
+ * order once the pending one also arrives. Both branches now call these two
+ * shared functions instead of repeating the formula inline.
+ */
+final class GenbestilCharacterizationTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ob_start();
+        require_once dirname(__DIR__, 4) . '/includes/std_func.php';
+        ob_end_clean();
+        self::assertTrue(function_exists('genbestil_nettobeholdning'), 'genbestil_nettobeholdning() not defined after include');
+        self::assertTrue(function_exists('beregn_genbestil'), 'beregn_genbestil() not defined after include');
+    }
+
+    /**
+     * @return array<string, array{float, float, float, float, float, float}>
+     *   [beholdning, i_ordre, i_forslag, bestilt, expectedNetto, expectedGenbestil]
+     */
+    public static function scenarios(): array
+    {
+        return [
+            // MB-35 ticket's own worked example: stock 9, min 5, max 10, one open sales
+            // order of 8, no existing purchase proposals/orders. Netto = 9-8 = 1, which is
+            // below min (5), so a reorder of max(10) - netto(1) = 9 is suggested.
+            'ticket worked example (9/5/10/8 -> 9)' => [9, 8, 0, 0, 1, 9],
+
+            // Same stock/order as above, but 8 units are already on an open purchase
+            // order (bestilt=8): netto = 9-8+0+8 = 9, so only 1 more is actually needed
+            // (max 10 - netto 9). The old naive branch ignored $bestilt entirely and would
+            // still have suggested 9 here, silently doubling the pending purchase.
+            'existing purchase order already covers the gap' => [9, 8, 0, 8, 9, 1],
+
+            // Same again, but the 8 units are an unconfirmed purchase proposal
+            // (i_forslag=8) rather than a placed order - same effect, must net out the
+            // same way since the formula treats i_forslag and bestilt identically.
+            'existing purchase proposal already covers the gap' => [9, 8, 8, 0, 9, 1],
+
+            // No open sales order and stock already at max: netto = max, so max - netto = 0.
+            'no deficit suggests nothing' => [10, 0, 0, 0, 10, 0],
+
+            // Netto exceeds max (e.g. a large incoming purchase order on top of healthy
+            // stock): the raw formula would go negative, must clamp to 0, never a negative
+            // reorder quantity.
+            'netto above max clamps to zero, not negative' => [10, 0, 0, 5, 15, 0],
+        ];
+    }
+
+    #[DataProvider('scenarios')]
+    public function testNettobeholdning(float $beholdning, float $iOrdre, float $iForslag, float $bestilt, float $expectedNetto, float $expectedGenbestil): void
+    {
+        self::assertEquals($expectedNetto, genbestil_nettobeholdning($beholdning, $iOrdre, $iForslag, $bestilt));
+    }
+
+    #[DataProvider('scenarios')]
+    public function testBeregnGenbestil(float $beholdning, float $iOrdre, float $iForslag, float $bestilt, float $expectedNetto, float $expectedGenbestil): void
+    {
+        $maxLager = 10;
+        self::assertEquals($expectedGenbestil, beregn_genbestil($maxLager, $beholdning, $iOrdre, $iForslag, $bestilt));
+    }
+}


### PR DESCRIPTION
## Summary
`lager/varer.php`'s "Indkøbsforslag" (reorder suggestion) feature computes, for each item,
how much to reorder. Its `udskriv()` function had two separate code branches computing this
differently:

- One branch (decides *whether* an item needs reordering) correctly subtracted existing
  purchase proposals and open purchase orders (`i_forslag`/`bestilt`) already covering part
  of the gap.
- The other branch (renders the actual editable quantity shown to the user) used a simpler
  formula that ignored `i_forslag`/`bestilt` entirely.

So an item already covered by a pending purchase order could still be suggested for the full
gap up to max — effectively proposing a duplicate order on top of one already in flight.

## ⚠️ Reproduction caveat — read before treating this as confirmed root cause of the reported "17"
The ticket reports a specific observed value (genbestillingsforslag 17 where the expected
value is 9, for stock 9 / min 5 / max 10 / open sales order 8). **This exact "17" figure was
not reproducible with clean data on any code path in this investigation.** What *was*
confirmed and fixed is a real, deterministic inconsistency between the two branches
described above — this is a genuine bug and this PR fixes it. But it should not be assumed
this PR explains the specific "17" the QC reviewer observed; that may have a different or
additional cause (the ticket itself raises two competing hypotheses: a `varer.beholdning`
desync, or order-line double-counting in `find_beholdning()`). Neither of those was confirmed
or ruled out here — see "Not Investigated" below.

**Recommendation:** verify with whoever filed the original ticket whether the underlying
`ssl3` dev-mappen scenario can still be reproduced post-fix, or whether the desync/
double-counting hypotheses need separate follow-up.

## Note on file location
The ticket assignment message pointed at `lager/minmaxstock.php` for this formula — that
file does not contain this logic at all. The actual code is in `lager/varer.php`, matching
the ticket description's own line references (line 910 / 1001-1003). Flagging this in case
it indicates stale documentation/tribal knowledge about where this logic lives.

## What are the changes about?
- Extracted two small shared functions — `genbestil_nettobeholdning()` and
  `beregn_genbestil()` — into `includes/std_func.php`, next to `find_beholdning()` (whose
  values they consume).
- Routed both branches in `lager/varer.php` through these shared functions instead of each
  repeating the formula inline, so they can no longer drift apart.
- Added a PHPUnit test suite with the ticket's worked example (stock 9, min 5, max 10, open
  sales order 8 → expected 9), plus cases that specifically exercise the branch
  inconsistency this fix resolves, and a zero-clamp case (reorder suggestion should never go
  negative).

## Files Changed
- lager/varer.php
- includes/std_func.php
- tests/characterization/includes/genbestil/GenbestilCharacterizationTest.test.php (new)

## Not Investigated (flagged, not ruled out)
Per the ticket's own two hypotheses for the specific "17" figure:
1. `varer.beholdning` desync from `sum(lagerstatus.beholdning)` — not confirmed or ruled out.
2. Order-line double-counting in `find_beholdning()` (`includes/std_func.php:1598`) — not
   confirmed or ruled out.

Neither was reproducible with clean test data. If the original "17" is still observed
post-fix in the real `ssl3` scenario, one of these is the more likely remaining cause and
should be investigated as a follow-up.

## How to Test
1. Run the worked example from the ticket: item with stock 9, min lager 5, max lager 10, one
   open (undelivered) sales order for 8 units. Verify the Indkøbsforslag now shows 9, not 17.
2. Create an item with an existing open purchase order or purchase proposal already covering
   part of the reorder gap. Verify the visible suggested quantity now correctly subtracts
   that pending order/proposal, matching the "needs reordering" branch's calculation.
3. Confirm both branches (the reorder-needed decision and the visible suggested quantity)
   now agree for the same item in all test cases.
4. Verify the zero-clamp case: an item that doesn't actually need reordering (net position
   already at or above max) shows a suggested quantity of 0, not a negative number.
5. Run the new PHPUnit suite and confirm all cases pass, including the ticket's worked
   example.
6. Attempt to reproduce the original ticket's exact "17" scenario against the `ssl3`
   dev-mappen demo account, if still available, and note whether it's resolved or whether a
   different root cause is still present.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Worked example: stock 9, min 5, max 10, open sales order 8 | Genbestillingsforslag = 9 |
| 2 | Item with existing open purchase order/proposal covering part of the gap | Visible suggested quantity correctly subtracts it — no duplicate-order suggestion |
| 3 | Both calculation branches for the same item | Consistent with each other |
| 4 | Item not needing reorder | Suggested quantity is 0, never negative |

## Verification
- The worked example now correctly computes 9 (not 17) both in the unit test and live,
  against a test scenario in the local `chartest` tenant.
- **Not verified:** the literal "17" from the ticket was not reproducible with clean data on
  any code path — see caveat above.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reorder suggestions now calculate net stock using current inventory, pending purchase proposals, and existing purchase orders.
  - Suggested reorder quantities are calculated against the configured maximum stock level.

- **Bug Fixes**
  - Reorder suggestions now consistently account for pending purchasing activity across all supported workflows.
  - Negative reorder quantities are prevented, ensuring suggestions never recommend less than zero items.
  - Reorder calculations now provide consistent results regardless of the workflow used to generate them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->