### PR TITLE
MB-32: fix false 'account number must be integer' alert on blank acco…

### DIFF
--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -101,6 +101,9 @@
 // 20260727 NTR Added a if statement around $an_id as if there was no ansatte with that id, it would throw an error and set an_id to 0 instead of unset.
 // 20260820 Sawaneh Save no longer rewrites kontakt_emails/adresser.email when the POST lacks the
 //                kontakt_email fields, so partial or stale submits cannot wipe stored email addresses
+// 20260905 SZ MB-32: blank Customer no. popped a false "must be integers" alert under PHP 8 - (float)''
+//             compared to '' is now a string comparison ("0" != ""), true, where PHP 7 compared both as
+//             0. Skip the check when the field is blank, matching debitor/debkort_save.php's SD-513 fix
 @session_start();
 $s_id = session_id();
 
@@ -495,7 +498,7 @@ if (!$is_grid_submission && (isset($_POST['id']) || isset($_POST['firmanavn'])))
 			$tmp2 = $tmp2 . $y;
 		}
 		$tmp2 = (float)$tmp2;
-		if ($tmp2 != $ny_kontonr) {
+		if ($ny_kontonr !== '' && $tmp2 != $ny_kontonr) {	# MB-32 - an empty field is not an error, the number is assigned automatically further down (same fix as debitor/debkort_save.php, SD-513)
 			$alerttekst = findtekst('345|Kontonummer må kun bestå af heltal uden mellemrum', $sprog_id);
 			print "<BODY onLoad=\"javascript:alert('$alerttekst')\"><!--tekst 345-->";
 		}

--- a/includes/kreditorkort.php
+++ b/includes/kreditorkort.php
@@ -27,6 +27,10 @@
 // 20220722 MSC - Implementing new top design
 // 20251125 LOE Datagrid used to handle the main tables.
 // 20260501 PHR fidscal_year
+// 20260905 SZ MB-32: blank account no. popped a false "must be integers" alert under PHP 8 -
+//             (int)'' compared to '' is now a string comparison ("0" != ""), true, where PHP 7
+//             compared both as 0. Skip the check when the field is blank, same fix as
+//             debitor/debkort_save.php (SD-513)
 
 @session_start();
 $s_id = session_id();
@@ -121,7 +125,7 @@ if ($_POST) {
 			$tmp2 = $tmp2 . $y;
 		}
 		$tmp2 = (int)$tmp2;
-		if ($tmp2 != $ny_kontonr) {
+		if ($ny_kontonr !== '' && $tmp2 != $ny_kontonr) {	# MB-32 - an empty field is not an error, the number is assigned automatically further down (same fix as debitor/debkort_save.php, SD-513)
 			print "<BODY onLoad=\"javascript:alert('" . findtekst('345|Kontonummer må kun bestå af heltal uden mellemrum', $sprog_id) . "')\">\n";
 		}
 		$ny_kontonr = $tmp2;

--- a/kreditor/kreditorkort.php
+++ b/kreditor/kreditorkort.php
@@ -28,6 +28,10 @@
 // 20251125 LOE Datagrid used to handle the main tables.
 // 20260501 PHR fidscal_year
 // 20260604 Sawaneh  redesign kreditor account card
+// 20260905 SZ MB-32: blank account no. popped a false "must be integers" alert under PHP 8 -
+//             (int)'' compared to '' is now a string comparison ("0" != ""), true, where PHP 7
+//             compared both as 0. Skip the check when the field is blank, same fix as
+//             debitor/debkort_save.php (SD-513)
 
 
 @session_start();
@@ -123,7 +127,7 @@ if ($_POST) {
 			$tmp2 = $tmp2 . $y;
 		}
 		$tmp2 = (int)$tmp2;
-		if ($tmp2 != $ny_kontonr) {
+		if ($ny_kontonr !== '' && $tmp2 != $ny_kontonr) {	# MB-32 - an empty field is not an error, the number is assigned automatically further down (same fix as debitor/debkort_save.php, SD-513)
 			print "<BODY onLoad=\"javascript:alert('" . findtekst('345|Kontonummer må kun bestå af heltal uden mellemrum', $sprog_id) . "')\">\n";
 		}
 		$ny_kontonr = $tmp2;


### PR DESCRIPTION
## Summary
Saving a new customer or creditor with a blank account number falsely triggered the alert
"Kontonummer må kun bestå af heltal uden mellemrum" ("account number may only consist of
whole numbers without spaces") — even though a blank number is valid and the system
auto-assigns one right afterward anyway. The alert appeared over a blank grey intermediate
page, reading like a crash to the user, before the save completed normally regardless.

## Root Cause
The validation casts the typed value to a number (`(float)$tmp2` or `(int)$tmp2`) and
compares it to the original string with `!=`.

- On PHP 7, this comparison converted the string to a number first, so `0 != ''` was really
  `0 != 0` → false → no alert.
- PHP 8 changed the comparison rule: it now converts the number to a string instead, so it
  becomes `"0" != ""` → true → the false alert fires on every blank field.

The exact same bug had already been fixed once, in `debitor/debkort_save.php` (commit
`36405e2f`, SD-513) — three copy-pasted duplicates of that same check were missed at the
time and are fixed here.

## What are the changes about?
Same pattern as the existing SD-513 fix — skip the check entirely when the field is blank:

```php
if ($ny_kontonr !== '' && $tmp2 != $ny_kontonr) {
```

Applied to three copy-pasted duplicates of the same check:
1. `debitor/debitorkort.php` — customer card (`(float)` cast)
2. `kreditor/kreditorkort.php` — creditor card (`(int)` cast)
3. `includes/kreditorkort.php` — duplicate copy (`(int)` cast)

Changelog entries added to all three; all three pass `php -l`.

## Files Changed
- debitor/debitorkort.php
- kreditor/kreditorkort.php
- includes/kreditorkort.php

## How to Test
1. Debtor → Accounts → New customer. Fill first name, last name, address, email; leave
   Customer no. blank. Click Save/update.
2. Verify no "account number may only consist of integers" alert appears, and the customer
   saves silently with an auto-assigned account number (as before the fix, minus the false
   alert).
3. Repeat the same flow under Creditor → New creditor, leaving the account number blank —
   verify no false alert and a correctly auto-assigned number.
4. As a regression check, enter an actually invalid account number (containing letters or
   spaces) on both the customer and creditor cards, and confirm the real validation alert
   still fires correctly — this fix must only skip the check when the field is genuinely
   blank, not weaken the check itself.
5. Confirm all three changed files still pass `php -l`.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | New customer, account number left blank | No false alert; saves with auto-assigned number |
| 2 | New creditor, account number left blank | No false alert; saves with auto-assigned number |
| 3 | Invalid account number entered (letters/spaces) on either card | Real validation alert still fires correctly |
| 4 | All three touched files | Pass php -l |

## Verification
All three files are now confirmed fixed end-to-end against the real running app
(`saldi_chartest`), not just by code-pattern inspection:

- `debitor/debitorkort.php` and `kreditor/kreditorkort.php`: live-verified — false alert
  reproduced pre-fix, confirmed gone post-fix.
- `includes/kreditorkort.php`: also live-verified, to the same standard as the other two.
  - Pre-fix (stashed the change): submitted a blank account number → got the exact false
    alert "Kontonummer må kun bestå af heltal uden mellemrum", then still auto-assigned
    "Kontonummer 1001 tildelt automatisk" — same bug, reproduced live.
  - Post-fix (restored): identical submission → only "Kontonummer 1000 tildelt automatisk",
    no false alert.
- All test rows cleaned up from `saldi_chartest` afterward.

## Note — unrelated finding, flagged separately, out of scope for MB-32
While verifying `includes/kreditorkort.php`, confirmed it is not dead code: nothing in the
codebase links to it, but Apache serves any `.php` file directly regardless of includer
status, so `http://.../includes/kreditorkort.php` renders a real, older-design
"Leverandørkort" page on its own. This means there's a live, unlinked duplicate of the
creditor-card page sitting in the app, reachable by direct URL. This is worth flagging to
the team separately — it's out of scope for MB-32 itself and not touched by this PR.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed false “must be integers” alerts when customer account numbers are left blank.
  - Fixed the same issue for supplier account numbers.
  - Blank account-number fields can now proceed to automatic account-number assignment as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->