### PR TITLE
MB-33: zero out price multipliers when Automatisk prisberegning is un…

### DIFF
--- a/lager/varekort.php
+++ b/lager/varekort.php
@@ -111,6 +111,12 @@
 // 20260902 Sawaneh Udløbsdato (showExpirySettings) moved out of the Diverse
 //                  cell into its own section box row, like the other sections,
 //                  so it separates and toggles independently.
+// 20260905 SZ MB-33: "Automatisk prisberegning" checkbox had no column of its own -
+//             show_advanced_price_calc is read from POST but never saved, so the
+//             checkbox was always redrawn from salgspris/tier/retail_price_multiplier
+//             > 0, and unchecking it did nothing since those fields kept their old
+//             values. Now zero the multipliers when the box is unchecked so "off"
+//             actually persists and stops updateProductPrice.php's auto-overwrite too.
 ob_start(); //Starts output buffering
 
 @session_start();
@@ -415,6 +421,9 @@ if ($saveItem || $submit = trim($submit)) {
     $retail_price_method = if_isset($_POST['retail_price_method']);
     $retail_price_rounding = if_isset($_POST['retail_price_rounding']);
     $show_advanced_price_calc = if_isset($_POST['show_advanced_price_calc']);
+    if (!$show_advanced_price_calc) {	# MB-33 - the checkbox has no column of its own; zero the multipliers so unchecking actually turns automatic price calc off (it's gated on these being >0, both here and in updateProductPrice.php)
+        $tier_price_multiplier = $salgspris_multiplier = $retail_price_multiplier = 0;
+    }
 
     if (!$kat_id)
         $kat_id = array();


### PR DESCRIPTION
## Summary
On the item card, the "Automatisk prisberegning" (automatic price calculation) checkbox
couldn't be turned off. Unchecking it and saving had no effect — reloading the card showed
it checked again, and the sales price / B2B sales price kept getting silently overwritten
whenever the cost price changed.

## Root Cause
The checkbox's own on/off state is never saved to the database — there is no column for it
at all. Both the checkbox's display and the actual auto-price-overwrite logic are driven
purely by whether `salgspris_multiplier` / `tier_price_multiplier` / `retail_price_multiplier`
are greater than 0:

- The checkbox is drawn "checked" in `lager/productCardIncludes/showPrices.php` whenever any
  of those multipliers is `>0`, regardless of what the user just submitted.
- The real automatic price recalculation, in
  `lager/productsIncludes/updateProductPrice.php` (triggered on every item save with a cost
  price, and also when a supplier invoice is posted), reads those same multiplier fields
  from the database and recalculates whenever they're `>0` — it never checks the checkbox at
  all.

So unchecking the box did nothing, because the multiplier fields that actually control the
behavior kept their old nonzero values.

## What are the changes about?
In `lager/varekort.php`, when the checkbox comes back unchecked on save, zero out
`salgspris_multiplier`, `tier_price_multiplier`, and `retail_price_multiplier` before they're
written to the database.

No schema change needed — since both the display and the automation are already gated on
these fields, zeroing them makes "off" actually take effect.

## Files Changed
- lager/varekort.php (9 lines added: the fix plus a changelog entry)

## ⚠️ Pre-flight check before opening/merging
The ticket explicitly notes PR #545 (Sulayman) changed `lager/varekort.php` this same week,
and instructs branching off current master. Confirm this branch was created from
post-#545 master, and re-check the diff for conflicts/overlap with that PR's changes before
merging — this wasn't independently re-verified as part of this write-up.

## How to Test
1. Open an item card (e.g. test item 271094) with "Automatisk prisberegning" checked and
   Salgspris DG > 0 (e.g. 50%).
2. Uncheck "Automatisk prisberegning" and save.
3. Reload the item card — verify the checkbox stays unchecked (not re-checked).
4. Change the cost price and save — verify the sales price and B2B sales price are **not**
   automatically overwritten anymore.
5. Post a supplier invoice affecting this item's cost price — verify the same: no automatic
   price recalculation occurs while the checkbox is off.
6. Re-check "Automatisk prisberegning", set a DG percentage, and save — verify the automatic
   calculation resumes correctly (no regression on the "on" path).
7. Confirm no schema/migration changes were introduced — this fix should be pure logic,
   reusing existing multiplier columns.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Uncheck "Automatisk prisberegning", save, reload | Checkbox remains unchecked |
| 2 | Cost price changed while checkbox is off | Sales price / B2B sales price not overwritten |
| 3 | Supplier invoice posted while checkbox is off | No automatic price recalculation |
| 4 | Checkbox re-checked with a DG percentage set | Automatic calculation resumes correctly |

## Verification
Verified live end-to-end against the real running app: checkbox persistence, salgspris no
longer overwritten, and B2B/tier_price no longer overwritten — all three confirmed via
before/after tests.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabling automatic price calculation now preserves manually entered prices by preventing subsequent automatic price updates.
  - Price multipliers are reset when automatic calculation is disabled, ensuring the setting is saved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->