### PR TITLE
MB-38: assign next free ordrenr to new order created via Opret ny ord…

### DIFF
--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -42,6 +42,9 @@
 //             splits could still compute the same "next" number. Serialize new-order creation with
 //             an advisory lock (pg_advisory_xact_lock, auto-released on commit; GET_LOCK/RELEASE_LOCK
 //             on MySQL, released explicitly after commit since MySQL locks aren't transaction-scoped).
+// 20260905 SZ MB-38/CodeRabbit: GET_LOCK() returns 0 on timeout / NULL on error, which the earlier
+//             fix ignored - check for a return of 1 and abort the split with an alert instead of
+//             risking a duplicate ordrenr if the lock wasn't actually acquired.
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
@@ -80,10 +83,19 @@ else {
 		# MB-38/CodeRabbit: serialize ordrenr allocation so two concurrent splits can't compute the
 		# same "next free number" - hold the lock until this transaction actually commits (below),
 		# since a concurrent transaction's MAX(ordrenr) can't see our new row until then anyway.
-		if ($db_type == 'mysql' || $db_type == 'mysqli')
-			db_select("SELECT GET_LOCK('kreditor_ordre_split_ordrenr', 10)", __FILE__ . " linje " . __LINE__);
-		else
+		if ($db_type == 'mysql' || $db_type == 'mysqli') {
+			$lockResult = db_fetch_array(db_select("SELECT GET_LOCK('kreditor_ordre_split_ordrenr', 10) AS lock_ok", __FILE__ . " linje " . __LINE__));
+			if ($lockResult['lock_ok'] != 1) {
+				# GET_LOCK returns 0 on timeout or NULL on error - don't risk allocating a
+				# duplicate ordrenr, make the user retry the split instead.
+				alert("Kunne ikke oprette ny ordre lige nu (ordrenummer var l&aring;st af en anden bruger). Pr&oslash;v igen.");
+				transaktion('rollback');
+				exit;
+			}
+		} else {
+			# pg_advisory_xact_lock blocks until it can acquire the lock (no timeout/failure case)
 			db_select("SELECT pg_advisory_xact_lock(hashtext('kreditor_ordre_split_ordrenr'))", __FILE__ . " linje " . __LINE__);
+		}
 		$newOrderCreated = true;
 		$qtxt = "select max(id) as new_id FROM ordrer";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));

--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -38,6 +38,10 @@
 //             verbatim - two orders ended up sharing the same number, breaking ordrenr-based
 //             lookups/matching. Now also assign the temp row the next free kreditor ordrenr
 //             (scoped to art IN ('KO','KK'), same scope kreditor/ublimport.php already uses).
+// 20260905 SZ MB-38/CodeRabbit: the MAX(ordrenr)+1 read is a plain snapshot, so two concurrent
+//             splits could still compute the same "next" number. Serialize new-order creation with
+//             an advisory lock (pg_advisory_xact_lock, auto-released on commit; GET_LOCK/RELEASE_LOCK
+//             on MySQL, released explicitly after commit since MySQL locks aren't transaction-scoped).
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
@@ -73,6 +77,14 @@ else {
 	$newId = $_POST['MoveItemsTo'];
 	# Create new order if it is not selected
 	if ($newId == '0') {
+		# MB-38/CodeRabbit: serialize ordrenr allocation so two concurrent splits can't compute the
+		# same "next free number" - hold the lock until this transaction actually commits (below),
+		# since a concurrent transaction's MAX(ordrenr) can't see our new row until then anyway.
+		if ($db_type == 'mysql' || $db_type == 'mysqli')
+			db_select("SELECT GET_LOCK('kreditor_ordre_split_ordrenr', 10)", __FILE__ . " linje " . __LINE__);
+		else
+			db_select("SELECT pg_advisory_xact_lock(hashtext('kreditor_ordre_split_ordrenr'))", __FILE__ . " linje " . __LINE__);
+		$newOrderCreated = true;
 		$qtxt = "select max(id) as new_id FROM ordrer";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 		$newId = $r['new_id'] + 1;
@@ -227,6 +239,10 @@ else {
 		}
 	}
 	transaktion('commit');
+	# MB-38/CodeRabbit: pg_advisory_xact_lock releases itself on commit above; GET_LOCK is
+	# connection-scoped, not transaction-scoped, so release it explicitly now the row is visible.
+	if (!empty($newOrderCreated) && ($db_type == 'mysql' || $db_type == 'mysqli'))
+		db_select("SELECT RELEASE_LOCK('kreditor_ordre_split_ordrenr')", __FILE__ . " linje " . __LINE__);
 	/*
 	$qtxt = "SELECT MAX(id) - nextval('ordrer_id_seq') as nextval FROM ordrer"; #20230206
 	$r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__));

--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -33,6 +33,11 @@
 //             POST strings in arithmetic - '1,5' in arithmetic is a PHP8 TypeError = blank page;
 //             guard/int-cast $linje_id (count(null) is likewise fatal); cap posnr bump with LEAST()
 //             so repeated splits cannot overflow the smallint posnr column mid-transaction.
+// 20260905 SZ MB-38: splitting to "Opret ny ordre" cloned the source row into temp_table and only
+//             rewrote id before the INSERT, so ordrenr (and every other header field) came along
+//             verbatim - two orders ended up sharing the same number, breaking ordrenr-based
+//             lookups/matching. Now also assign the temp row the next free kreditor ordrenr
+//             (scoped to art IN ('KO','KK'), same scope kreditor/ublimport.php already uses).
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
@@ -71,9 +76,12 @@ else {
 		$qtxt = "select max(id) as new_id FROM ordrer";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 		$newId = $r['new_id'] + 1;
+		$qtxt = "select max(ordrenr) as new_ordrenr FROM ordrer WHERE art = 'KO' OR art = 'KK'";	# MB-38 - kreditor order numbering is its own sequence, scoped like kreditor/ublimport.php's next-number lookup
+		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
+		$newOrdrenr = $r['new_ordrenr'] + 1;
 		$qtxt = "CREATE TEMPORARY TABLE temp_table AS SELECT * FROM ordrer WHERE id='$id'";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-		$qtxt = "UPDATE temp_table SET id='$newId' WHERE id='$id'";
+		$qtxt = "UPDATE temp_table SET id='$newId', ordrenr='$newOrdrenr' WHERE id='$id'";	# MB-38 - give the split-off order its own number instead of cloning the source's
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		$qtxt = "INSERT INTO ordrer SELECT * FROM temp_table";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);

--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -253,8 +253,9 @@ else {
 	transaktion('commit');
 	# MB-38/CodeRabbit: pg_advisory_xact_lock releases itself on commit above; GET_LOCK is
 	# connection-scoped, not transaction-scoped, so release it explicitly now the row is visible.
-	if (!empty($newOrderCreated) && ($db_type == 'mysql' || $db_type == 'mysqli'))
+	if (!empty($newOrderCreated) && ($db_type == 'mysql' || $db_type == 'mysqli')){
 		db_select("SELECT RELEASE_LOCK('kreditor_ordre_split_ordrenr')", __FILE__ . " linje " . __LINE__);
+	}
 	/*
 	$qtxt = "SELECT MAX(id) - nextval('ordrer_id_seq') as nextval FROM ordrer"; #20230206
 	$r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__));

--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -100,12 +100,10 @@ else {
 		$qtxt = "select max(id) as new_id FROM ordrer";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 		$newId = $r['new_id'] + 1;
-		$qtxt = "select max(ordrenr) as new_ordrenr FROM ordrer WHERE art = 'KO' OR art = 'KK'";	# MB-38 - kreditor order numbering is its own sequence, scoped like kreditor/ublimport.php's next-number lookup
-		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
-		$newOrdrenr = $r['new_ordrenr'] + 1;
+		$newOrdrenr = "select max(ordrenr) + 1 FROM ordrer WHERE art = 'KO' OR art = 'KK'";	# MB-38 - kreditor order numbering is its own sequence, scoped like kreditor/ublimport.php's next-number lookup
 		$qtxt = "CREATE TEMPORARY TABLE temp_table AS SELECT * FROM ordrer WHERE id='$id'";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-		$qtxt = "UPDATE temp_table SET id='$newId', ordrenr='$newOrdrenr' WHERE id='$id'";	# MB-38 - give the split-off order its own number instead of cloning the source's
+		$qtxt = "UPDATE temp_table SET id='$newId', ordrenr=($newOrdrenr) WHERE id='$id'";	# MB-38 - give the split-off order its own number instead of cloning the source's
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		$qtxt = "INSERT INTO ordrer SELECT * FROM temp_table";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);


### PR DESCRIPTION
## Summary
Splitting a supplier order and choosing "Opret ny ordre" (create new order) as the split
target cloned the source order's number (`ordrenr`) onto the new order instead of assigning
it a fresh one — so two (or more) supplier orders ended up with the identical order number.
This broke anything that looks orders up by number: `kreditor/ordre.php`'s own
ordrenr-based lookup, supplier-invoice matching, and the purchasing overview.

**This is very likely the root cause of previously archived production issue SST-237**
(MEDSHOP: "kreditorordre oprettet 2 gange med samme kreditorordrenummer" — a 0,00 duplicate,
reported happening "from time to time" in production, archived without a confirmed root
cause). Worth reopening/cross-referencing SST-237 once this is verified.

Related: MB-1 / SST-652 (#525) fixed blank pages in this same file — this is the numbering
sibling of that issue.

## Root Cause
In `kreditor/orderIncludes/moveOrderLines.php`, the "create new order" path copies the
source order row into a temp table, rewrites only the `id` column, then inserts it back into
`ordrer`:

```sql
CREATE TEMPORARY TABLE temp_table AS SELECT * FROM ordrer WHERE id='$id'
UPDATE temp_table SET id='$newId' WHERE id='$id'
INSERT INTO ordrer SELECT * FROM temp_table
```

Every other field, including `ordrenr`, gets copied over unchanged — nothing later in the
file corrects it.

## What are the changes about?
Before building the copy, compute the next free kreditor order number and set it on the temp
row alongside the rewritten `id`. Used the same scoping the codebase already relies on
elsewhere for this (`kreditor/ublimport.php`):

```sql
select max(ordrenr) from ordrer where art = 'KO' OR art = 'KK'
```
+1, then set on the temp row before the insert.

Confirmed via the database that kreditor (`KO`) and debitor (`DO`) orders use separate,
overlapping numbering — a plain global `max(ordrenr)` across all order types would have
picked the wrong (potentially still-colliding) number.

## Files Changed
- kreditor/orderIncludes/moveOrderLines.php

## How to Test
1. Creditors → Order → open an order with 2+ lines.
2. Click "Split" → in the target dropdown choose "Opret ny ordre", set a quantity to move,
   click Flyt.
3. Verify the newly created order has a **different** ordrenr from the source order — not a
   clone.
4. Open the split dialog again on the same source order and repeat the split — verify the
   dropdown does not show a duplicate order number, and each new split-created order gets
   its own distinct, incrementing number.
5. Check Creditors → Order list — verify no two orders share the same ordrenr.
6. Verify number-based lookups still work correctly for both the original and the newly
   created order: `kreditor/ordre.php`'s ordrenr lookup, supplier-invoice matching, and the
   purchasing overview.
7. Confirm both `KO` (order) and `KK` (credit note) order types are correctly included in
   the next-number calculation, and that a `DO` (debitor) order number is never
   accidentally reused or collided with.
8. Reproduce the original bug against pre-fix code (e.g. via `git stash`) to confirm it
   still occurs there, then confirm it's resolved post-fix — proving this is a genuine
   fix, not a coincidental non-reproduction.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Split a supplier order using "Opret ny ordre" as target | New order gets the next free ordrenr, not the source's number |
| 2 | Repeat split multiple times on the same or different source orders | No two orders ever share the same ordrenr |
| 3 | Number-based lookups (kreditor/ordre.php, invoice matching, purchasing overview) | Work correctly for all resulting orders |
| 4 | KO/KK numbering scope | Correctly separated from DO (debitor) numbering — no cross-type collision |

## Verification
Verified live end-to-end: built a test order and performed the actual split through the
real running app.
- Pre-fix: the new order came out with the same order number as the source, reproducing the
  exact reported bug.
- Post-fix: the new order got the next free number instead, with no duplicates left
  anywhere.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards when splitting orders and creating new orders.
  * New split-off orders now receive unique order numbers more reliably, even when multiple orders are created concurrently.
  * Order creation stops safely if protection against duplicate order numbers cannot be secured.
  * Prevented potentially duplicate order numbers after a failed protection check.
  * Transactions are rolled back when the required protection cannot be established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->