### PR TITLE
Fix credit-note return date validation

### DIFF
--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -107,6 +107,7 @@
 // 20260818 Sawaneh Credit notes: only cap the quantity when the line points the wrong way or more
 //                  is credited than invoiced, so it can be reduced. Handles invoice lines that are
 //                  themselves negative. Shows the max in the alert. Removed debug_kreditnota logging.
+// 20260831 CDX/MJ JOB-106 Allow credit-note return dates before the credit-note order date
 // 20260907 CDX/LH Share the invoice payment gate with the assistant's saved-state reader.
 // 20260908 CL/Sawaneh SST-763: PBS button on posted PBS invoices opens debitor/pbs_gensend.php
 //                     (attempt history + resend after a Nets rejection).
@@ -1649,7 +1650,7 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 				print "<BODY onLoad=\"javascript:alert('$alert')\">\n";
 				$levdate = date("Y-m-d");
 			} else $levdate = $ordredate;;
-		} elseif ($levdate < $ordredate) {
+		} elseif (delivery_date_before_order_date($art, $levdate, $ordredate)) {
 			$alert1 = findtekst('1679|Leveringsdato er før ordredato', $sprog_id);
 			print "<BODY onLoad=\"javascript:alert('$alert1')\">\n";
 			$status = 0;

--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -112,6 +112,9 @@
 // 20260908 CL/Sawaneh SST-763: PBS button on posted PBS invoices opens debitor/pbs_gensend.php
 //                     (attempt history + resend after a Nets rejection).
 // 20260910 CL/NTR SST-763: tekst ids 5170-5190 moved to 3385-3404; 5180 replaced by existing 828 (Fakturanr.).
+// 20260911 CDX/MJ JOB-106 Approval guard validates the effective order type: an all-negative DO
+//             order only becomes a DK credit note in bogfor(), long after this runs, so a valid
+//             return date was refused at approval.
 
 @session_start();
 $s_id = session_id();
@@ -1650,7 +1653,7 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 				print "<BODY onLoad=\"javascript:alert('$alert')\">\n";
 				$levdate = date("Y-m-d");
 			} else $levdate = $ordredate;;
-		} elseif (delivery_date_before_order_date($art, $levdate, $ordredate)) {
+		} elseif (delivery_date_before_order_date(order_becomes_credit_note($id, $art) ? 'DK' : $art, $levdate, $ordredate)) {
 			$alert1 = findtekst('1679|Leveringsdato er før ordredato', $sprog_id);
 			print "<BODY onLoad=\"javascript:alert('$alert1')\">\n";
 			$status = 0;

--- a/finans/ordre.php
+++ b/finans/ordre.php
@@ -17,6 +17,7 @@
 // Copyright (c) 2004-2010 DANOSOFT ApS
 // ----------------------------------------------------------------------
 // 20260831 CDX/MJ JOB-106 Allow credit-note return dates before the credit-note order date
+// 20260911 CDX/MJ JOB-106 Approval guard validates the effective order type (see debitor/ordre.php).
 
 @session_start();
 $s_id=session_id();
@@ -383,7 +384,7 @@ if (isset($_POST['submit'])) {
 				$levdate=date("Y-m-d");
 			} else $levdate=$ordredate;;
 		}
-		elseif (delivery_date_before_order_date($art, $levdate, $ordredate)) {
+		elseif (delivery_date_before_order_date(order_becomes_credit_note($id, $art) ? 'DK' : $art, $levdate, $ordredate)) {
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato er f&oslash;r ordredato')\">";
 			$status=0;
 		}

--- a/finans/ordre.php
+++ b/finans/ordre.php
@@ -16,6 +16,7 @@
 //
 // Copyright (c) 2004-2010 DANOSOFT ApS
 // ----------------------------------------------------------------------
+// 20260831 CDX/MJ JOB-106 Allow credit-note return dates before the credit-note order date
 
 @session_start();
 $s_id=session_id();
@@ -382,7 +383,7 @@ if (isset($_POST['submit'])) {
 				$levdate=date("Y-m-d");
 			} else $levdate=$ordredate;;
 		}
-		elseif ($levdate<$ordredate) {
+		elseif (delivery_date_before_order_date($art, $levdate, $ordredate)) {
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato er f&oslash;r ordredato')\">";
 			$status=0;
 		}

--- a/includes/ordrefunc.php
+++ b/includes/ordrefunc.php
@@ -125,7 +125,21 @@
 //             out-of-balance order BEFORE any transaktioner/openpost rows are written (previously the
 //             imbalance was detected after posting, with no rollback for callers outside bogfor).
 //             Also guarded the vatAccount rounding loops against infinite loop on empty SM account list
+// 20260831 CDX/MJ JOB-106 Allow credit-note return dates before the credit-note order date
 // 20260908 CL/Sawaneh SST-763: duplicate pbsfakt() removed; includes/pbsfunc.php is included instead.
+
+/**
+ * Check whether a delivery date invalidly precedes its order date.
+ *
+ * Customer credit notes use levdate as the return date, so their date is not
+ * ordered relative to the date on which the credit note was created.
+ *
+ * @return bool True when the delivery date is invalid for this order type.
+ */
+function delivery_date_before_order_date($art, $levdate, $ordredate)
+{
+	return !$levdate || ($art !== 'DK' && $levdate < $ordredate);
+}
 
 function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 	/* echo "<!--function levering start-->"; */
@@ -244,14 +258,14 @@ function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 		$ordredate = $fakturadate;
 	}
 	$r = db_fetch_array(db_select("select * from ordrer where id = '$id'", __FILE__ . " linje " . __LINE__));
-	if ($fakturadate && !$r['levdate']) {
+	if (!$r['levdate']) {
 		if ($webservice)
 			return ('Manglende leveringsdato');
 		else
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato SKAL udfyldes')\">";
 		exit;
 	} else {
-		if (!$hurtigfakt && $r['levdate'] < $r['ordredate']) {
+		if (!$hurtigfakt && delivery_date_before_order_date($art, $r['levdate'], $r['ordredate'])) {
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato er f&oslash;r ordredato $r[levdate]<$r[ordredate]')\">";
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";
 			exit;
@@ -1429,7 +1443,7 @@ function bogfor($id, $webservice=false)
 		else
 			return ("Leveringsdato SKAL udfyldes");
 	}
-	if ($levdate < $ordredate) {
+	if (delivery_date_before_order_date($art, $levdate, $ordredate)) {
 		transaktion('rollback');
 		if ($webservice)
 			return ("Deliverydate prior to orderdate");

--- a/includes/ordrefunc.php
+++ b/includes/ordrefunc.php
@@ -127,6 +127,9 @@
 //             Also guarded the vatAccount rounding loops against infinite loop on empty SM account list
 // 20260831 CDX/MJ JOB-106 Allow credit-note return dates before the credit-note order date
 // 20260908 CL/Sawaneh SST-763: duplicate pbsfakt() removed; includes/pbsfunc.php is included instead.
+// 20260908 CDX/MJ JOB-106 Validate the date against the effective order type: an all-negative DO
+//             order is turned into a DK credit note by bogfor(), but only after the date checks
+//             had already run, so a valid return date was still rejected for that case
 
 /**
  * Check whether a delivery date invalidly precedes its order date.
@@ -139,6 +142,48 @@
 function delivery_date_before_order_date($art, $levdate, $ordredate)
 {
 	return !$levdate || ($art !== 'DK' && $levdate < $ordredate);
+}
+
+/**
+ * Decide whether an order will be converted into a credit note when it is posted.
+ *
+ * bogfor() turns an all-negative DO order into a DK credit note (its $dan_kn flag),
+ * but not until after the delivery date has been validated. Callers that validate
+ * earlier have to classify the order themselves, or they reject a return date that
+ * is legitimately older than the order date.
+ *
+ * Mirrors the $dan_kn loop in bogfor(): same query, same row order, same conditions.
+ *
+ * @param int|string $id  Order id.
+ * @param string     $art Order type as currently stored.
+ * @return bool True when this is a DO order whose lines all point the credit way.
+ */
+function order_becomes_credit_note($id, $art)
+{
+	if ($art !== 'DO') {
+		return false;
+	}
+	$id = intval($id);
+	$dan_kn = 1;
+	$a = 0;
+	$z = 0;
+	$q = db_select("select vare_id, antal from ordrelinjer where ordre_id = '$id' and antal != '0' order by saet", __FILE__ . " linje " . __LINE__);
+	while ($r = db_fetch_array($q)) {
+		$z++;
+		if ($r['antal'] < 0) {
+			$a += $r['antal'];
+		}
+		if ($r['vare_id'] && $r['antal'] >= 0) {
+			$dan_kn = 0;
+		}
+		if ($dan_kn && !$a) {
+			$dan_kn = 0;
+		}
+	}
+	if ($dan_kn && !$z) {
+		$dan_kn = 0;
+	}
+	return (bool)$dan_kn;
 }
 
 function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
@@ -265,7 +310,8 @@ function levering($id,$hurtigfakt,$genfakt,$webservice=false) {
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato SKAL udfyldes')\">";
 		exit;
 	} else {
-		if (!$hurtigfakt && delivery_date_before_order_date($art, $r['levdate'], $r['ordredate'])) {
+		$effektiv_art = order_becomes_credit_note($id, $art) ? 'DK' : $art;
+		if (!$hurtigfakt && delivery_date_before_order_date($effektiv_art, $r['levdate'], $r['ordredate'])) {
 			print "<BODY onLoad=\"javascript:alert('Leveringsdato er f&oslash;r ordredato $r[levdate]<$r[ordredate]')\">";
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";
 			exit;
@@ -1443,7 +1489,7 @@ function bogfor($id, $webservice=false)
 		else
 			return ("Leveringsdato SKAL udfyldes");
 	}
-	if (delivery_date_before_order_date($art, $levdate, $ordredate)) {
+	if (delivery_date_before_order_date($dan_kn ? 'DK' : $art, $levdate, $ordredate)) {
 		transaktion('rollback');
 		if ($webservice)
 			return ("Deliverydate prior to orderdate");

--- a/tests/characterization/includes/order_date_validation/OrderDateValidationCharacterizationTest.test.php
+++ b/tests/characterization/includes/order_date_validation/OrderDateValidationCharacterizationTest.test.php
@@ -1,0 +1,28 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../../includes/ordrefunc.php';
+
+final class OrderDateValidationCharacterizationTest extends TestCase
+{
+	public function testCreditNoteReturnDateMayPrecedeCreditNoteOrderDate(): void
+	{
+		$this->assertFalse(delivery_date_before_order_date('DK', '2026-05-08', '2026-08-31'));
+	}
+
+	public function testCreditNoteStillRequiresReturnDate(): void
+	{
+		$this->assertTrue(delivery_date_before_order_date('DK', '', '2026-08-31'));
+	}
+
+	public function testSalesOrderDeliveryDateMayNotPrecedeOrderDate(): void
+	{
+		$this->assertTrue(delivery_date_before_order_date('DO', '2026-05-08', '2026-08-31'));
+	}
+
+	public function testSalesOrderDeliveryDateMayEqualOrderDate(): void
+	{
+		$this->assertFalse(delivery_date_before_order_date('DO', '2026-08-31', '2026-08-31'));
+	}
+}


### PR DESCRIPTION
A customer credit note must accept a return date earlier than its creation date. The same applies to an all-negative customer order that becomes a credit note during posting. Ordinary sales and purchase orders must still reject delivery dates before the order date.

The shared date check in `includes/ordrefunc.php` validates the effective order type in all four paths: debtor approval, finance approval, delivery, and posting. Empty dates remain invalid. Positive, mixed-sign, empty, and zero-quantity orders do not receive the credit-note exception.

Merged current master (`e9442a65`), resolving the history-header conflict while retaining the current employee-field changes and the credit-note approval fix.

## Validation

- `php tests/integration/creditNoteDateValidation.php`: 44 checks execute the actual four guard expressions and credit-note classifier with a SQL double, with warnings enabled.
- `OrderDateValidationCharacterizationTest.test.php`: 4 tests / 4 assertions passed.
- PHP lint and whitespace checks passed.
- These checks validate classification and guards; they do not execute the complete accounting posting transaction.

## Reviewer scenarios

In `debitor/ordre.php`, `finans/ordre.php`, and `includes/ordrefunc.php`, approve/deliver/post a DK credit note and an all-negative DO order with a return date before the order date. Repeat with an ordinary positive order, mixed-sign lines, missing dates, and a purchase order: those must retain their date restrictions. Check the employee fields after the merge.

The branch also requires `levdate` in the quick-invoice delivery path where the previous quick-invoice bypass allowed it to be absent. This pre-existing change in the PR remains a specific review point; the new regression matrix exercises normal delivery, not the full quick-invoice workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Credit notes can now use return dates earlier than the original order date when applicable.
  - Orders with missing delivery dates are now validated consistently.
  - Improved VAT validation prevents incorrect posting totals and identifies the affected account and order.
  - Approval, delivery, and posting checks now consistently recognize orders that will become credit notes.
- **User Experience**
  - Packing-slip actions now return users to the relevant order.
  - The “Completed by” field is positioned beside “Our reference” for easier viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->