### PR TITLE
Update later fiscal years' opening balances after journal posting

### DIFF
--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// ---------------finans/bogfor.php---------- patch 5.0.0 --- 2026.08.19 ---
+// ---------------finans/bogfor.php---------- patch 5.0.1 --- 2026.09.07 ---
 // LICENSE
 //
 // This program is free software. You can redistribute it and / or
@@ -20,7 +20,7 @@
 // but WITHOUT ANY KIND OF CLAIM OR WARRANTY. 
 // See GNU General Public License for more details.
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
-// Copyright (c) 2003-2025 Saldi.dk ApS
+// Copyright (c) 2003-2026 Danosoft ApS
 // ----------------------------------------------------------------------
 // 20121122 - Åbne poster udlignes ikke mere automatisk hvis forskelligt projektnummer. Søg 20121122
 // 20130210 - Break ændret til break 1
@@ -61,6 +61,7 @@
 // 20260819 CX/PHR - Fall back to account VAT unless a confirmed journal line has VAT on only one side.
 // 20260822 Sawaneh Show journal id and note in heading and above movements so output identifies the journal;
 //                  print icon on the simulation/posting view prints just the report
+// 20260907 CDX/PHR Update following fiscal years' opening balances within the journal posting transaction.
 
 
 @session_start();
@@ -1089,6 +1090,8 @@ function bogfor($kladde_id,$kladdenote,$simuler) {
 				$transamount[$x]=($temp+$transamount[$x]);
 				db_modify("update kontoplan set saldo = $transamount[$x] where id = '$kasklid[$x]'",__FILE__ . " linje " . __LINE__);
 			}
+			include_once(__DIR__ . '/../includes/updateFollowingOpeningBalances.php');
+			updateFollowingOpeningBalances($regnaar);
 		}
 #xit;
 	} else {

--- a/includes/genberegn.php
+++ b/includes/genberegn.php
@@ -4,7 +4,7 @@
 //               \__ \/ _ \| |_| |) | | _ | |) |  <
 //               |___/_/ \_|___|___/|_||_||___/|_\_\
 //
-// ------includes/genberegn.php-------lap 5.0.0------2026.02.10---
+// ------includes/genberegn.php-------lap 5.0.1------2026.09.07---
 // LICENS
 //
 // Dette program er fri software. Du kan gendistribuere det og / eller
@@ -23,19 +23,21 @@
 // En dansk oversaettelse af licensen kan laeses her:
 // http://www.saldi.dk/dok/GNU_GPL_v2.html
 //
-// Copyright (c) 2003-2026 saldi.dk aps
+// Copyright (c) 2003-2026 Danosoft ApS
 // ----------------------------------------------------------------------
 
 // 20130210 Break ændret til break 1
 // 20181126 - PHR Definition af div. variabler mm.
 // 20190321 PHR Added function equalizeMatchingRecords.
 // 20260210 PHR PHP8
+// 20260907 CDX/PHR Allow recalculation within the caller's tenant transaction and scope primo resets to one year.
 
 @session_start();
 $s_id=session_id();
 
 if (!function_exists('genberegn')) {
-	function genberegn($regnskabsaar) {
+	function genberegn($regnskabsaar, $updateUsage = true) {
+		$regnskabsaar = (int)$regnskabsaar;
 		$qtxt="select * from grupper where kodenr='$regnskabsaar' and art='RA'";
 		$query = db_select($qtxt,__FILE__ . " linje " . __LINE__);
 		$row = db_fetch_array($query);
@@ -53,7 +55,7 @@ if (!function_exists('genberegn')) {
 		$regnstart = $startaar. "-" . $startmaaned . "-" . '01';
 		$regnslut = $slutaar . "-" . $slutmaaned . "-" . $slutdato;
 	
-		db_modify("update kontoplan set primo=0 where kontotype!= 'S'",__FILE__ . " linje " . __LINE__);
+		db_modify("update kontoplan set primo=0 where kontotype!= 'S' and regnskabsaar='$regnskabsaar'",__FILE__ . " linje " . __LINE__);
 		db_modify("update kontoplan set saldo=0 where regnskabsaar='$regnskabsaar'",__FILE__ . " linje " . __LINE__);
 		$qtxt="select * from kontoplan where regnskabsaar='$regnskabsaar' and (kontotype='D' or kontotype='S') order by kontonr";
 		$q1=db_select($qtxt,__FILE__ . " linje " . __LINE__);
@@ -111,9 +113,11 @@ if (!function_exists('genberegn')) {
 		$logdate=date("Y-m-d");
 		$logtime=date("H:i:s");
 		db_modify("update grupper set box7='$logdate',box8='$logtime' where art='RA' and kodenr='$regnskabsaar'",__FILE__ . " linje " . __LINE__);
-		include("../includes/connect.php");
-		db_modify("update regnskab set  posteret='$transantal' where id='$db_id'",__FILE__ . " linje " . __LINE__);
-		include("../includes/online.php");
+		if ($updateUsage) {
+			include(__DIR__ . '/connect.php');
+			db_modify("update regnskab set posteret='$transantal' where id='" . (int)$db_id . "'", __FILE__ . ' line ' . __LINE__);
+			include(__DIR__ . '/online.php');
+		}
 	}
 } 
 

--- a/includes/updateFollowingOpeningBalances.php
+++ b/includes/updateFollowingOpeningBalances.php
@@ -1,0 +1,110 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- includes/updateFollowingOpeningBalances.php --- patch 5.0.1 --- 2026.09.07 ---
+// LICENS
+//
+// Dette program er fri software. Du kan gendistribuere det og / eller
+// modificere det under betingelserne i GNU General Public License (GPL)
+// som er udgivet af The Free Software Foundation; enten i version 2
+// af denne licens eller en senere version efter eget valg.
+// Fra og med version 3.2.2 dog under iagttagelse af følgende:
+//
+// Programmet må ikke uden forudgående skriftlig aftale anvendes
+// i konkurrence med saldi.dk aps eller anden rettighedshaver til programmet.
+//
+// Programmet er udgivet med haab om at det vil vaere til gavn,
+// men UDEN NOGEN FORM FOR REKLAMATIONSRET ELLER GARANTI. Se
+// GNU General Public Licensen for flere detaljer.
+//
+// En dansk oversaettelse af licensen kan laeses her:
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2026 Danosoft ApS
+// ----------------------------------------------------------------------
+// 20260907 CDX/PHR Carry revised year-end balances through subsequent fiscal years after journal posting.
+
+/**
+ * Rebuild subsequent opening balances using the transfer rules from fiscalYearInc/yearX.php.
+ * The caller owns the tenant transaction. Closed years retain their status.
+ * Deleted years and missing predecessors form a boundary because their source data is unavailable.
+ *
+ * @return int[] Fiscal year numbers whose opening balances were updated.
+ */
+function updateFollowingOpeningBalances($postedYear) {
+	$postedYear = (int)$postedYear;
+	$years = array();
+	$q = db_select("select kodenr, box1, box2, box3, box4, box10 from grupper where art = 'RA'", __FILE__ . ' line ' . __LINE__);
+	while ($row = db_fetch_array($q)) {
+		$years[(int)$row['kodenr']] = $row;
+	}
+	$updated = array();
+	for ($sourceYear = $postedYear; isset($years[$sourceYear], $years[$sourceYear + 1]); $sourceYear++) {
+		$targetYear = $sourceYear + 1;
+		$source = $years[$sourceYear];
+		$target = $years[$targetYear];
+		if ($source['box10'] === 'on' || $target['box10'] === 'on') {
+			break;
+		}
+		$startYear = (int)$source['box2'];
+		$startMonth = (int)$source['box1'];
+		$endYear = (int)$source['box4'];
+		$endMonth = (int)$source['box3'];
+		if (!checkdate($startMonth, 1, $startYear) || !checkdate($endMonth, 1, $endYear)) {
+			throw new RuntimeException('Invalid fiscal year dates while updating opening balances.');
+		}
+		$start = sprintf('%04d-%02d-01', $startYear, $startMonth);
+		$end = date('Y-m-t', strtotime(sprintf('%04d-%02d-01', $endYear, $endMonth)));
+		$opening = array();
+		$q = db_select("select kontonr from kontoplan where regnskabsaar = '$targetYear' and kontotype = 'S'", __FILE__ . ' line ' . __LINE__);
+		while ($row = db_fetch_array($q)) {
+			$opening[(int)$row['kontonr']] = 0;
+		}
+		if (!$opening) {
+			break;
+		}
+		$movement = array();
+		$q = db_select("select kontonr, debet, kredit from transaktioner where transdate >= '$start' and transdate <= '$end'", __FILE__ . ' line ' . __LINE__);
+		while ($row = db_fetch_array($q)) {
+			$account = (int)$row['kontonr'];
+			if (!isset($movement[$account])) $movement[$account] = 0;
+			$movement[$account] += afrund($row['debet'] - $row['kredit'], 2);
+		}
+		$profit = 0;
+		$resultAccount = null;
+		$q = db_select("select kontonr, kontotype, primo, overfor_til from kontoplan where regnskabsaar = '$sourceYear' and kontotype in ('S', 'D', 'X') order by kontonr", __FILE__ . ' line ' . __LINE__);
+		while ($row = db_fetch_array($q)) {
+			$account = (int)$row['kontonr'];
+			$amount = isset($movement[$account]) ? $movement[$account] : 0;
+			if ($row['kontotype'] === 'D') {
+				$profit += afrund($row['primo'], 2) + $amount;
+			} elseif ($row['kontotype'] === 'X' && $resultAccount === null) {
+				$resultAccount = $row;
+			} elseif ($row['kontotype'] === 'S') {
+				$destination = (int)$row['overfor_til'];
+				if (!isset($opening[$destination])) $destination = $account;
+				if (isset($opening[$destination])) {
+					$opening[$destination] += (float)$row['primo'] + $amount;
+				}
+			}
+		}
+		if ($resultAccount !== null) {
+			$destination = (int)$resultAccount['overfor_til'];
+			$account = (int)$resultAccount['kontonr'];
+			if (isset($opening[$destination])) {
+				$opening[$destination] += afrund($profit, 2) + (isset($movement[$account]) ? $movement[$account] : 0);
+			}
+		}
+		foreach ($opening as $account => $amount) {
+			$amount = (float)afrund($amount, 2);
+			db_modify("update kontoplan set primo = '$amount' where regnskabsaar = '$targetYear' and kontonr = '$account' and kontotype = 'S'", __FILE__ . ' line ' . __LINE__);
+		}
+		// Avoid switching database connections while the journal transaction is active.
+		genberegn($targetYear, false);
+		$updated[] = $targetYear;
+	}
+	return $updated;
+}

--- a/includes/updateFollowingOpeningBalances.php
+++ b/includes/updateFollowingOpeningBalances.php
@@ -26,11 +26,15 @@
 // Copyright (c) 2026 Danosoft ApS
 // ----------------------------------------------------------------------
 // 20260907 CDX/PHR Carry revised year-end balances through subsequent fiscal years after journal posting.
+// 20260907 CL/NTR  Stop propagation instead of dropping balances when the target year lacks a
+//                  destination account for a status or result balance.
 
 /**
  * Rebuild subsequent opening balances using the transfer rules from fiscalYearInc/yearX.php.
  * The caller owns the tenant transaction. Closed years retain their status.
  * Deleted years and missing predecessors form a boundary because their source data is unavailable.
+ * A target year that lacks the destination account for a status or result balance is also a boundary,
+ * so a partially transferable year is never written.
  *
  * @return int[] Fiscal year numbers whose opening balances were updated.
  */
@@ -75,6 +79,7 @@ function updateFollowingOpeningBalances($postedYear) {
 		}
 		$profit = 0;
 		$resultAccount = null;
+		$missingDestination = false;
 		$q = db_select("select kontonr, kontotype, primo, overfor_til from kontoplan where regnskabsaar = '$sourceYear' and kontotype in ('S', 'D', 'X') order by kontonr", __FILE__ . ' line ' . __LINE__);
 		while ($row = db_fetch_array($q)) {
 			$account = (int)$row['kontonr'];
@@ -88,6 +93,8 @@ function updateFollowingOpeningBalances($postedYear) {
 				if (!isset($opening[$destination])) $destination = $account;
 				if (isset($opening[$destination])) {
 					$opening[$destination] += (float)$row['primo'] + $amount;
+				} else {
+					$missingDestination = true;
 				}
 			}
 		}
@@ -96,7 +103,13 @@ function updateFollowingOpeningBalances($postedYear) {
 			$account = (int)$resultAccount['kontonr'];
 			if (isset($opening[$destination])) {
 				$opening[$destination] += afrund($profit, 2) + (isset($movement[$account]) ? $movement[$account] : 0);
+			} else {
+				$missingDestination = true;
 			}
+		}
+		if ($missingDestination) {
+			// A balance has no account to land on in the target year, so leave it and later years untouched.
+			break;
 		}
 		foreach ($opening as $account => $amount) {
 			$amount = (float)afrund($amount, 2);

--- a/includes/updateFollowingOpeningBalances.php
+++ b/includes/updateFollowingOpeningBalances.php
@@ -106,6 +106,8 @@ function updateFollowingOpeningBalances($postedYear) {
 			} else {
 				$missingDestination = true;
 			}
+		} else {
+			$missingDestination = true;
 		}
 		if ($missingDestination) {
 			// A balance has no account to land on in the target year, so leave it and later years untouched.

--- a/tests/test_following_opening_balances.php
+++ b/tests/test_following_opening_balances.php
@@ -1,0 +1,85 @@
+<?php
+// --- tests/test_following_opening_balances.php --- patch 5.0.1 --- 2026.09.07 ---
+// Copyright (c) 2026 Danosoft ApS
+// ----------------------------------------------------------------------
+// 20260907 CDX/PHR Verify chained opening balances against isolated PostgreSQL temporary tables.
+// Run with SALDI_TEST_DSN and libpq credentials (for example PGPASSFILE).
+
+if (PHP_SAPI !== 'cli') exit('CLI only');
+require_once(__DIR__ . '/../includes/genberegn.php');
+require_once(__DIR__ . '/../includes/updateFollowingOpeningBalances.php');
+$dsn = getenv('SALDI_TEST_DSN');
+if (!$dsn) exit("Set SALDI_TEST_DSN to a PostgreSQL test connection.\n");
+$connection = pg_connect($dsn);
+if (!$connection) throw new RuntimeException('Could not connect to the test database.');
+
+function db_select($sql, $location = '') {
+	$result = pg_query($GLOBALS['connection'], $sql);
+	if (!$result) throw new RuntimeException(pg_last_error($GLOBALS['connection']));
+	return $result;
+}
+function db_modify($sql, $location = '') { return db_select($sql, $location); }
+function db_fetch_array($result) { return pg_fetch_assoc($result); }
+function afrund($value, $decimals) { return round((float)$value, $decimals); }
+function checkOpening($condition, $message) {
+	if (!$condition) throw new RuntimeException($message);
+	echo "PASS: $message\n";
+}
+function accountValue($year, $account, $field) {
+	$row = db_fetch_array(db_select("select $field from kontoplan where regnskabsaar=$year and kontonr=$account"));
+	return (float)$row[$field];
+}
+
+db_modify('begin');
+try {
+	// Temporary names shadow tenant tables; no persistent tables or rows are changed.
+	db_modify("create temp table grupper (kodenr integer, art text, box1 text, box2 text, box3 text, box4 text, box5 text, box6 text, box7 text, box8 text, box10 text)");
+	db_modify("create temp table kontoplan (id serial, regnskabsaar integer, kontonr integer, kontotype text, primo numeric default 0, saldo numeric default 0, overfor_til integer default 0, fra_kto integer default 0, lukket text default '')");
+	db_modify("create temp table transaktioner (id serial, kontonr integer, transdate date, debet numeric default 0, kredit numeric default 0)");
+	foreach (array(8, 9, 10, 11) as $year) {
+		$calendar = 2014 + $year;
+		$end = $calendar + 1;
+		$open = $year === 10 ? '' : 'on';
+		db_modify("insert into grupper (kodenr,art,box1,box2,box3,box4,box5,box10) values ($year,'RA','7','$calendar','6','$end','$open','')");
+		foreach (array(1000 => 'D', 1999 => 'X', 2000 => 'S', 2100 => 'S', 2500 => 'S', 2900 => 'Z', 2950 => 'R', 3000 => 'S') as $account => $type) {
+			$destination = $account === 1999 ? 3000 : ($account === 2100 ? 2000 : 0);
+			$from = $type === 'Z' ? 2000 : ($type === 'R' ? 2900 : 0);
+			db_modify("insert into kontoplan (regnskabsaar,kontonr,kontotype,primo,saldo,overfor_til,fra_kto) values ($year,$account,'$type',777,888,$destination,$from)");
+		}
+	}
+	db_modify("update kontoplan set primo=0,saldo=0 where regnskabsaar=9");
+	db_modify("update kontoplan set primo=1000 where regnskabsaar=9 and kontonr=2000");
+	db_modify("update kontoplan set primo=-1000 where regnskabsaar=9 and kontonr=3000");
+	db_modify("insert into transaktioner (kontonr,transdate,debet,kredit) values
+		(2000,'2024-02-29',100,0), (1000,'2024-02-29',0,100),
+		(2100,'2024-06-30',20,0), (1000,'2024-06-30',0,20),
+		(2000,'2024-07-01',50,0), (1000,'2024-07-01',0,50),
+		(2000,'2025-07-01',25,0), (1000,'2025-07-01',0,25)");
+	checkOpening(updateFollowingOpeningBalances(9) === array(10, 11), 'Update every subsequent year in numeric order');
+	checkOpening(accountValue(10, 2000, 'primo') === 1120.0, 'Merge transfer accounts and use the same-account fallback');
+	checkOpening(accountValue(10, 3000, 'primo') === -1120.0, 'Transfer annual profit through the X account');
+	checkOpening(accountValue(11, 2000, 'primo') === 1170.0, 'Propagate the corrected opening and intermediate-year movement');
+	checkOpening(accountValue(11, 3000, 'primo') === -1170.0, 'Accumulate retained profit over multiple years');
+	checkOpening(accountValue(11, 2000, 'saldo') === 1195.0, 'Recalculate the latest-year closing balance');
+	checkOpening(accountValue(10, 2900, 'saldo') === 1170.0 && accountValue(10, 2950, 'saldo') === 1170.0, 'Recalculate subtotal and reference accounts');
+	checkOpening(accountValue(10, 2500, 'primo') === 0.0 && accountValue(10, 1000, 'primo') === 0.0, 'Clear obsolete opening values without carrying income accounts forward');
+	checkOpening(accountValue(8, 1000, 'primo') === 777.0 && accountValue(9, 2000, 'primo') === 1000.0, 'Preserve earlier years and the posted year opening');
+	$row = db_fetch_array(db_select("select box5 from grupper where kodenr=10"));
+	checkOpening($row['box5'] === '', 'Update a closed year without reopening it');
+	updateFollowingOpeningBalances(9);
+	checkOpening(accountValue(11, 2000, 'primo') === 1170.0, 'Repeated recalculation is idempotent');
+	checkOpening(updateFollowingOpeningBalances(11) === array(), 'Posting in the newest year does not change openings');
+	db_modify('savepoint additional_posting');
+	db_modify("insert into transaktioner (kontonr,transdate,debet,kredit) values (2000,'2024-03-01',5.25,0),(1999,'2024-03-01',0,5.25)");
+	updateFollowingOpeningBalances(9);
+	checkOpening(accountValue(11, 2000, 'primo') === 1175.25 && accountValue(11, 3000, 'primo') === -1175.25, 'Include a backdated posting directly to the result account');
+	db_modify('rollback to savepoint additional_posting');
+	checkOpening(accountValue(11, 2000, 'primo') === 1170.0, 'Opening updates roll back with the posting transaction');
+	db_modify("update grupper set box10='on' where kodenr=10");
+	checkOpening(updateFollowingOpeningBalances(9) === array(), 'Preserve opening balances across deleted-year boundaries');
+	db_modify("delete from grupper where kodenr=10");
+	checkOpening(updateFollowingOpeningBalances(9) === array(), 'Do not jump over a missing fiscal year');
+} finally {
+	db_modify('rollback');
+	pg_close($connection);
+}

--- a/tests/test_following_opening_balances.php
+++ b/tests/test_following_opening_balances.php
@@ -3,6 +3,7 @@
 // Copyright (c) 2026 Danosoft ApS
 // ----------------------------------------------------------------------
 // 20260907 CDX/PHR Verify chained opening balances against isolated PostgreSQL temporary tables.
+// 20260907 CL/NTR  Cover missing status and result destinations in the target year.
 // Run with SALDI_TEST_DSN and libpq credentials (for example PGPASSFILE).
 
 if (PHP_SAPI !== 'cli') exit('CLI only');
@@ -69,6 +70,19 @@ try {
 	updateFollowingOpeningBalances(9);
 	checkOpening(accountValue(11, 2000, 'primo') === 1170.0, 'Repeated recalculation is idempotent');
 	checkOpening(updateFollowingOpeningBalances(11) === array(), 'Posting in the newest year does not change openings');
+	db_modify('savepoint missing_status_destination');
+	db_modify("update kontoplan set primo=4444 where regnskabsaar in (10, 11) and kontonr=2000");
+	db_modify("delete from kontoplan where regnskabsaar=10 and kontonr=2500");
+	checkOpening(updateFollowingOpeningBalances(9) === array(), 'Stop when a status account has neither a transfer nor a same-number account in the next year');
+	checkOpening(accountValue(10, 2000, 'primo') === 4444.0 && accountValue(11, 2000, 'primo') === 4444.0, 'Leave the target year and later years unwritten when a status destination is missing');
+	db_modify('rollback to savepoint missing_status_destination');
+	db_modify('savepoint missing_result_destination');
+	db_modify("update kontoplan set primo=4444 where regnskabsaar in (10, 11) and kontonr=2000");
+	db_modify("update kontoplan set overfor_til=3999 where regnskabsaar=9 and kontonr=1999");
+	checkOpening(updateFollowingOpeningBalances(9) === array(), 'Stop when the result account transfers to an account missing from the next year');
+	checkOpening(accountValue(10, 2000, 'primo') === 4444.0 && accountValue(11, 2000, 'primo') === 4444.0, 'Leave the target year and later years unwritten when the result destination is missing');
+	db_modify('rollback to savepoint missing_result_destination');
+	checkOpening(updateFollowingOpeningBalances(9) === array(10, 11) && accountValue(11, 2000, 'primo') === 1170.0, 'Resume propagation once every destination exists again');
 	db_modify('savepoint additional_posting');
 	db_modify("insert into transaktioner (kontonr,transdate,debet,kredit) values (2000,'2024-03-01',5.25,0),(1999,'2024-03-01',0,5.25)");
 	updateFollowingOpeningBalances(9);


### PR DESCRIPTION
Posting a cash journal in an earlier fiscal year leaves subsequent opening balances outdated. Users currently have to open each later year under fiscal-year settings and save it manually. This change updates those balances automatically after successful journal posting.

Changes:
- Rebuild subsequent opening balances in fiscal-year order using the existing transfer-account rules, including annual profit through the X account, explicit balance-account transfers, and same-account fallback.
- Recalculate balances, subtotals, and reference accounts in each affected year. Closed years keep their posting status.
- Run within the journal's tenant transaction, so opening-balance updates roll back with the posting. Simulation and already-posted journal rejection do not invoke the update.
- Add an optional `genberegn(..., false)` mode to avoid switching database connections during the transaction. Scope non-balance-account opening resets to the recalculated year.
- Stop at missing or deleted fiscal years, or a target year without balance accounts, rather than reconstructing unavailable history.
- Update the four file headers to 5.0.1, 2026.09.07, and Danosoft ApS.

Validation:
- `tests/test_following_opening_balances.php`: 16 PostgreSQL checks passed on this branch. Coverage includes multiple subsequent years, fiscal-year numbers 9–11, non-calendar years, leap day, closed years, transfer mappings, annual profit, direct result-account postings, subtotals, idempotence, and transaction rollback.
- Fixtures use temporary tables and all database changes are rolled back; existing accounting data is unchanged.
- PHP syntax checks passed for all four files; `git diff --check` passed.

Manual regression checks (browser flow not yet tested):
- `finans/bogfor.php`: Post a journal in an earlier year with two later years. Verify their opening balances immediately without saving fiscal-year settings. Repeat in the newest year, simulate a journal, and attempt a closed-period or already-posted journal.
- `updateFollowingOpeningBalances`: Check balance-account remapping and annual-profit transfers against the values shown in fiscal-year settings. Include a closed intermediate year and verify that it stays closed.
- `genberegn`: Verify opening balances, closing balances, subtotals, and reference accounts in the later years. Confirm that earlier years' openings are preserved.
- `systemdata/regnskabskort.php` / `fiscalYearInc/yearX.php`: Open and save the later years after automatic propagation; the opening balances should remain unchanged.

This PR contains only the opening-balance changes and their test, separate from the POS cash-count PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posting entries now automatically update opening balances for subsequent fiscal years.
  * Account movements and profit can carry forward across multiple consecutive years.
  * Future-year balances are recalculated after backdated postings.

* **Bug Fixes**
  * Opening-balance resets are limited to the selected fiscal year.
  * Recalculations stop safely at closed or missing fiscal years.
  * Incomplete transfers are not applied when required accounts or destinations are unavailable.
  * Repeated recalculations produce consistent results without duplicating updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->