### PR TITLE
Fix: db_select() no longer issues ROLLBACK on a failed query (#503 follow-up, SST-672)

### DIFF
--- a/includes/db_query.php
+++ b/includes/db_query.php
@@ -40,6 +40,7 @@
 // 20260820 Sawaneh The fallback alert text used the HTML entity &aelig;, which JS alert() shows
 //                  literally; replaced with a literal æ like the rest of the string
 // 20260824 CL/SZ db_select(): ROLLBACK the connection on a Postgres query error - reproduced
+// 20260907 CL/LH db_select(): drop the pg ROLLBACK from #503 - it turned failed postings into partial commits
 //                that without it, one failed query inside an open transaction ("current
 //                transaction is aborted...") silently fails every later query on that same
 //                connection for the rest of the request; confirmed harmless when no
@@ -292,7 +293,11 @@ if (!function_exists('db_select')) {
 			$errtxt = pg_last_error($use_connection);
 			if ($errtxt) {
 				error_log("db_select failed: $qtext");
-				pg_query($use_connection, "ROLLBACK"); // 20260824 CL/SZ a failed query inside an open transaction otherwise poisons every later query on this connection for the rest of the request ("current transaction is aborted..."); harmless no-op outside a transaction (SST-672)
+				// 20260907 CL/LH Removed the ROLLBACK added 20260824 (#503, SST-672): db_select() only alerts and
+				// continues on the first error, so the rollback discarded the work already done inside a
+				// transaktion('begin') block and every later write autocommitted - a failed posting became a
+				// partial posting instead of the previous all-or-nothing failure. The aborted transaction is
+				// the caller's to roll back (SD-595 $db_modify_fejl pattern, finans/bogfor.php).
 			}
 		}
 


### PR DESCRIPTION
## What
PR #503 made `db_select()` run `ROLLBACK` on PostgreSQL whenever a query failed (`includes/db_query.php:295`), to stop the "current transaction is aborted" lockup from SST-672.

But `db_select()` only alerts and continues on the first error (the `exit` is in the else branch at ~:347). Inside a `transaktion('begin')` block that means: work done before the failure is rolled back, and every `db_modify()` after it runs in autocommit and persists. A failed posting became a **partial, unbalanced posting** where it used to be all-or-nothing. It also bypassed the SD-595 `$db_modify_fejl` mechanism that lets the caller decide (finans/bogfor.php, #459).

## How
Remove the `ROLLBACK` line, keep the `error_log`. The failing queries that caused SST-672 were fixed by the other hunks of #503, which stay.

## Affected paths / manual test
- `debitor/bogfor.php`, `debitor/levering.php`, `debitor/massefakt.php`, `debitor/genfakturer.php`, `lager/lagerregulering.php`, `admin/opret.php` (all wrap writes in `transaktion('begin')`).
1. Post a normal invoice on test_31: posts as before.
2. Force a select to fail mid-posting (e.g. temporarily rename a column referenced by a select inside `debitor/bogfor.php` on a scratch tenant): expect the alert and **no** rows in `transaktioner`/`openpost` for that order, instead of a half-written posting.
3. Kontokort1 / kassekladde from SST-672 still open without the lockup (their queries were fixed in #503).

Cross-checked by GPT-6 Astra (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4xFKPi2G5K4dYXtY8ZrhV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Postgres query errors no longer automatically roll back the active transaction.
  - Work completed earlier in an open transaction is preserved, allowing the caller to decide whether a rollback is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->