### PR TITLE
Fix: MB-16 sheet gate blocked account-less sheet prints (#506 follow-up)

### DIFF
--- a/lager/labelprint_includes/newlabel.php
+++ b/lager/labelprint_includes/newlabel.php
@@ -38,6 +38,10 @@
 //                 sheet grid - only a real full-sheet ($page, no specific id) print still uses the
 //                 whole grid. Fixes a single-label print producing an extra, effectively blank
 //                 second label (MB-16).
+// 20260907 CL/LH  The sheet gate no longer requires $account/$condition: an account-less
+//                 $page print (any template with $rows) fills the grid again from the item's
+//                 own description/price; the mylabel sheet query stays inside
+//                 if ($account && $condition) where MB-16 needs it.
 
 $line=explode("\n",$txt);
 $top=$txt='';
@@ -110,7 +114,7 @@ for ($l=0;$l<count($labels);$l++) {
 	// otherwise every other cell in the grid renders with fallback/blank data
 	// nobody asked for (MB-16: a single-label print produced a second,
 	// effectively blank label). 20260826 CL/SZ.
-	$sheetPrint = (!$labels[$l] && $page && $account && $condition);
+	$sheetPrint = (!$labels[$l] && $page);
 	$cellRows = $sheetPrint ? $rows : 1;
 	$cellCols = $sheetPrint ? $cols : 1;
 	for ($a=1;$a<=$cellRows;$a++) {


### PR DESCRIPTION
## What
#506 gated the label grid with `$sheetPrint = (!$labels[$l] && $page && $account && $condition);` (`lager/labelprint_includes/newlabel.php:113`). The two extra conjuncts also disable the grid for a sheet print **without** a mit-salg account, which is a real path: `lager/labelprint.php:148` routes any template containing `$rows` here, and the fallback at ~191-197 fills the cells from the item's own description/price. An Avery-style `$rows=5; $cols=2` template for an item with no account printed 1 label instead of 10.

## How
`$sheetPrint = (!$labels[$l] && $page);` — the mylabel sheet query stays inside `if ($account && $condition)` where MB-16 needs it.

## Manual test
1. Sheet template, item without mit-salg account: full sheet of identical labels.
2. Sheet template with account: unchanged from #506.
3. Single label (MB-16 case): still exactly one label, no blank second label.

Flagged, not changed: `tests/characterization/lager/labelprint_includes/NewlabelCharacterizationTest.test.php:42` hardcodes a Postgres password as a class constant (against `doc/ai/convention_no_hardcoded_secrets.md`). Should read env / connect.php; rotate if real.

Cross-checked by GPT-6 Astra (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4xFKPi2G5K4dYXtY8ZrhV