### PR TITLE
Kassekladde pre release improvements

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -2620,10 +2620,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		$kkVisHintKey = 'saldiKkHint_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $db . '_' . $bruger_id . '_' . $brugernavn);
 		print "<div id='kkVisHint'>$kkVisHintTxt<br><button type='button' id='kkVisHintOk'>" . htmlspecialchars($kkVisGotIt, ENT_QUOTES, $charset) . "</button></div>";
 		print "<script>
-		document.addEventListener('change',function(e){
-			if(!e.target.classList.contains('kk-col-toggle')) return;
-			var col=e.target.getAttribute('data-col');
-			var show=e.target.checked;
+		function kkApplyColToggle(col,show){
 			if(col==='ac_forslag'||col==='ac_opslag'){
 				window.saldiAutocompleteOptions=window.saldiAutocompleteOptions||{};
 				if(col==='ac_forslag'){window.saldiAutocompleteOptions.showLastPostings=show;}
@@ -2631,10 +2628,17 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			}else{
 				document.querySelectorAll('.kk-col-'+col).forEach(function(el){el.style.display=show?'table-cell':'none';});
 			}
+		}
+		function kkSaveCols(){
 			var hidden=[];
 			document.querySelectorAll('.kk-col-toggle').forEach(function(cb){if(!cb.checked) hidden.push(cb.getAttribute('data-col'));});
 			var fd=new FormData();fd.append('save_kk_cols',hidden.join(','));
 			fetch(window.location.pathname+window.location.search,{method:'POST',body:fd,credentials:'same-origin'}).catch(function(){});
+		}
+		document.addEventListener('change',function(e){
+			if(!e.target.classList.contains('kk-col-toggle')) return;
+			kkApplyColToggle(e.target.getAttribute('data-col'),e.target.checked);
+			kkSaveCols();
 		});
 		(function(){
 			var panel=document.getElementById('kkVisPanel');
@@ -2667,9 +2671,12 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 				if(panel.classList.contains('kkVisOpen') && !panel.contains(e.target) && e.target!==toggleBtn && !toggleBtn.contains(e.target)){panel.classList.remove('kkVisOpen');}
 			});
 			document.getElementById('kkVisShowAll').addEventListener('click',function(){
+				// apply all toggles first, then persist ONCE - one change event per box
+				// would fire N concurrent saves that can complete out of order
 				document.querySelectorAll('#kkVisPanel .kk-col-toggle').forEach(function(cb){
-					if(!cb.checked){cb.checked=true;cb.dispatchEvent(new Event('change',{bubbles:true}));}
+					if(!cb.checked){cb.checked=true;kkApplyColToggle(cb.getAttribute('data-col'),true);}
 				});
+				kkSaveCols();
 			});
 		})();
 		</script>";
@@ -4506,8 +4513,8 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 					return ($r['bilag'] . ",0,bogfort");
 				}
 			}
-			return ("0,0,0");
 		}
+		return ("0,0,0");
 	}
 
 	$x--;

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -101,6 +101,9 @@
 //                  texts 5147/5148), dismissed per user via localStorage - product card hint pattern.
 // 20260907 Sawaneh Column/panel save fetch uses keepalive so a refresh right after toggling can no
 //                  longer cancel the persistence request (choices appeared to reset on fast reload).
+// 20260907 Sawaneh Column/panel choices now also persist for revisor/admin sessions: online.php gives
+//                  those bruger_id = -1 and the save/read guards required > 0, so admins silently lost
+//                  every choice on reload (pre-existing bug in the column picker, inherited by Part B).
 // 20260904 Sawaneh Gear button docked into the top line next to 'Ny' (menu S, via topLineKassekladde.php);
 //                  other menu styles keep the floating button; panel now opens just below the button.
 // 20260907 CDX/LH Keep counter-account types in suggestions and match posted duplicates in base currency
@@ -495,7 +498,9 @@ $kk_toggle_cols = array(
 $kk_panel_opts = array('ac_forslag', 'ac_opslag');
 
 
-if (isset($_POST['save_kk_cols']) && isset($bruger_id) && $bruger_id > 0) {
+// (int)$bruger_id != 0: revisor/admin sessions have bruger_id = -1 (online.php) and must also
+// keep their choices - same self-consistent behaviour as the USET user settings.
+if (isset($_POST['save_kk_cols']) && isset($bruger_id) && (int)$bruger_id != 0) {
     $parts = array_filter(array_map('trim', explode(',', (string)$_POST['save_kk_cols'])));
     $clean = array();
     foreach ($parts as $p) {
@@ -516,7 +521,7 @@ if (isset($_POST['save_kk_cols']) && isset($bruger_id) && $bruger_id > 0) {
 
 $kk_hidden_cols = array();
 $kk_panel_hidden = array();
-if (isset($bruger_id) && $bruger_id > 0) {
+if (isset($bruger_id) && (int)$bruger_id != 0) {
     $kk_r = db_fetch_array(db_select("select box3 from grupper where ART='KASKL' and kode='1' and kodenr='$bruger_id'", __FILE__ . " linje " . __LINE__));
     if ($kk_r && trim((string)$kk_r['box3']) !== '') {
         foreach (explode(',', $kk_r['box3']) as $c) {

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -80,6 +80,27 @@
 //                  line skips kontroller()'s processing/tmpkassekl update and the error re-render shows the
 //                  operator's raw text instead of usdecimal()'s 100x value, the "+=" shortcut validates the
 //                  amount before indsaet_linjer(), and the texts moved from 5080/5081 to 5089/5090.
+// 20260903 Sawaneh Removed leftover debug output: per-line bilag console.log and the fiscal-year
+//                  console dump (incl. its debug-only grupper query); validation itself is unchanged.
+// 20260903 Sawaneh "Sidste 5 posteringer" counter-account suggestions now also cover finance (F) lines,
+//                  not only debitor/creditor lines. Still searches only the kassekladde table; extending
+//                  the suggestion SQL to posted transaktioner is a known later task.
+// 20260903 Sawaneh find_dublet() now also warns when a matching line is already posted: secondary lookup
+//                  in transaktioner (fiscal-year constrained, limit 1) pairing the voucher's debit/credit
+//                  rows; return extended backwards-compatibly with a source field; params SQL-escaped.
+// 20260903 Sawaneh Browser autofill disabled on the journal form and account fields (autocomplete=off) so
+//                  only the blue lookup panel opens; two new per-user checkboxes in the settings box select
+//                  which panel sections (suggestions/lookup) are shown, via window.saldiAutocompleteOptions.
+// 20260903 Sawaneh Always-visible balance status over the journal: green when total debit equals total
+//                  credit (base currency), red with the difference otherwise - display only, non-blocking.
+// 20260903 Sawaneh Removed the auto-balance prefill of the next empty line (same bilag + suggested
+//                  difference amount under bilag sorting) - the balance status at the top replaces it.
+// 20260903 Sawaneh Settings box restyled as the product card gear panel (fieldVisibility.php look):
+//                  round gear button, click-to-open panel with title/intro/Show all; same persistence.
+// 20260907 Sawaneh First-time hint bubble pointing at the gear ("klik for at tilpasse din opsætning",
+//                  texts 5147/5148), dismissed per user via localStorage - product card hint pattern.
+// 20260904 Sawaneh Gear button docked into the top line next to 'Ny' (menu S, via topLineKassekladde.php);
+//                  other menu styles keep the floating button; panel now opens just below the button.
 
 ob_start(); //Starter output buffering  
 
@@ -373,7 +394,7 @@ print '<script src="../javascript/datepickerDa.js"></script>';
 print "<script LANGUAGE='javascript' TYPE='text/javascript' SRC='../javascript/confirmclose.js'></script>";
 print "<script LANGUAGE='JavaScript' TYPE='text/javascript' SRC='../javascript/overlib.js'></script>";
 print '<link rel="stylesheet" type="text/css" href="../css/accountAutocomplete.css?v=4.1.4">';
-print '<script src="../javascript/accountAutocomplete.js?v=4.1.4" defer></script>';
+print '<script src="../javascript/accountAutocomplete.js?v=4.1.5" defer></script>';
 print "<script>
 	function fokuser(that, fgcolor, bgcolor){
 		that.style.color = fgcolor;
@@ -464,13 +485,15 @@ $kk_toggle_cols = array(
     'afd'   => 'Afd.',
     'ansat' => 'Ansat',
 );
+// Panel-sektioner i det blaa kontoopslag - ikke tabelkolonner, men gemmes/fravaelges via samme mekanisme
+$kk_panel_opts = array('ac_forslag', 'ac_opslag');
 
 
 if (isset($_POST['save_kk_cols']) && isset($bruger_id) && $bruger_id > 0) {
     $parts = array_filter(array_map('trim', explode(',', (string)$_POST['save_kk_cols'])));
     $clean = array();
     foreach ($parts as $p) {
-        if (array_key_exists($p, $kk_toggle_cols)) $clean[] = $p;
+        if (array_key_exists($p, $kk_toggle_cols) || in_array($p, $kk_panel_opts, true)) $clean[] = $p;
     }
     $cols_str = db_escape_string(implode(',', $clean));
     $exists = db_fetch_array(db_select("select id from grupper where ART='KASKL' and kode='1' and kodenr='$bruger_id'", __FILE__ . " linje " . __LINE__));
@@ -486,12 +509,14 @@ if (isset($_POST['save_kk_cols']) && isset($bruger_id) && $bruger_id > 0) {
 
 
 $kk_hidden_cols = array();
+$kk_panel_hidden = array();
 if (isset($bruger_id) && $bruger_id > 0) {
     $kk_r = db_fetch_array(db_select("select box3 from grupper where ART='KASKL' and kode='1' and kodenr='$bruger_id'", __FILE__ . " linje " . __LINE__));
     if ($kk_r && trim((string)$kk_r['box3']) !== '') {
         foreach (explode(',', $kk_r['box3']) as $c) {
             $c = trim($c);
             if (array_key_exists($c, $kk_toggle_cols)) $kk_hidden_cols[] = $c;
+            elseif (in_array($c, $kk_panel_opts, true)) $kk_panel_hidden[] = $c;
         }
     }
 }
@@ -2447,14 +2472,14 @@ if ($kladde_id) {
 if ($tjek) {
     $action_url .= "&tjek=$tjek";
 }
-print "<form name='kassekladde' id='kassekladde' action='$action_url' method='post'>";
+print "<form name='kassekladde' id='kassekladde' action='$action_url' method='post' autocomplete='off'>";
 print "<input type='hidden' name='kladde_id' value='$kladde_id'>";
 print "<input type='hidden' name='kladdenote' value='$kladdenote'>";
 print "<tr><td width='100%' valign='top' height='1%' align='center' class='kassekladde-note-tb'>
        <table width='100%' cellpadding='0' cellspacing='0' border='0' align='center' valign='top'>";
 print "<tbody>"; # Tabel 1.2 -> bemærkningstekst
 print "<tr style='vertical-align: middle;'>"; # Added vertical-align
-print "<td width='14%'></td>";
+print "<td width='14%' align='center'><span id='kk-balance-status'></span></td>";
 print "<td align='left' style='white-space: nowrap;'><b><span title='" . findtekst('1559|Her kan skrives en bemærkning til kladden', $sprog_id) . "'>" . findtekst('599|Bemærkning', $sprog_id) . ":</span></b>
 <input class='inputbox' type='text' style='width:750px; vertical-align: middle;' name='ny_kladdenote' value='$kladdenote'
 onchange='javascript:docChange = true;'></td>";
@@ -2528,40 +2553,125 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 
 }else{
 	if($bogfort != 'V' ){
-		// Column visibility — inject hide rules + picker UI
+		// Panel-sektioner i det blaa kontoopslag - laeses af accountAutocomplete.js (default: begge til)
+		$ac_forslag_on = in_array('ac_forslag', $kk_panel_hidden, true) ? 'false' : 'true';
+		$ac_opslag_on  = in_array('ac_opslag',  $kk_panel_hidden, true) ? 'false' : 'true';
+		print "<script>window.saldiAutocompleteOptions={showLastPostings:$ac_forslag_on,showAccountLookup:$ac_opslag_on};</script>";
+		// Column visibility — hide rules + gear settings panel (same look as the product card fieldVisibility panel)
 		print "<style>";
 		foreach ($kk_hidden_cols as $hc) {
 			print ".kk-col-" . htmlspecialchars($hc, ENT_QUOTES, $charset) . "{display:none;}";
 		}
 		print "
-		.kk-cols-picker{position:fixed;top:70px;right:18px;z-index:9999;text-align:right;}
-		.kk-cols-menu{display:none;position:absolute;right:0;top:100%;background:#fff;border:1px solid #ccc;box-shadow:0px 8px 16px rgba(0,0,0,.2);padding:10px 14px;z-index:10000;min-width:180px;text-align:left;}
-		.kk-cols-picker:hover .kk-cols-menu{display:block;}
-		.kk-cols-menu label{display:block;padding:3px 0;font-size:12px;cursor:pointer;white-space:nowrap;}
-		.kk-cols-menu input{margin-right:10px;vertical-align:middle;}
-		#kk-turn-arrow{transition:transform 0.1s ease-in-out;}
-		.kk-cols-picker:hover #kk-turn-arrow{transform:rotate(90deg);}
-		.kk-cols-picker .kk-cols-menu{min-width:180px;white-space:nowrap;}
+		.kkVisFab{position:fixed;right:14px;top:70px;z-index:9998;width:38px;height:38px;border:none;border-radius:50%;background:#15488f;color:#fff;font-size:19px;line-height:38px;text-align:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.35);transition:transform .25s ease, background .2s ease;padding:0;}
+		.kkVisFab:hover{background:#1d5cb4;transform:rotate(60deg);}
+		#kkVisPanel{position:fixed;right:14px;top:116px;z-index:9999;width:235px;background:#fff;border:1px solid #c6d2e4;border-radius:8px;box-shadow:0 6px 18px rgba(21,72,143,.25);font-family:Verdana, Arial, sans-serif;font-size:11px;color:#333;opacity:0;visibility:hidden;transform:translateX(12px);transition:opacity .2s ease, transform .2s ease, visibility .2s;}
+		#kkVisPanel.kkVisOpen{opacity:1;visibility:visible;transform:translateX(0);}
+		.kkVisHead{background:#15488f;color:#fff;font-weight:bold;font-size:12px;padding:8px 10px;border-radius:7px 7px 0 0;}
+		.kkVisIntro{padding:7px 10px 4px 10px;color:#667;line-height:1.4;}
+		.kkVisList{max-height:320px;overflow-y:auto;padding:4px 6px 6px 6px;}
+		.kkVisRow{display:flex;align-items:center;gap:7px;padding:5px 6px;border-radius:5px;cursor:pointer;user-select:none;}
+		.kkVisRow:hover{background:#eef3fa;}
+		.kkVisRow input{margin:0;cursor:pointer;}
+		.kkVisRow input:not(:checked)+span{color:#99a;text-decoration:line-through;}
+		.kkVisSplit{margin:4px 6px;border:none;border-top:1px solid #dde5f0;}
+		.kkVisFoot{border-top:1px solid #dde5f0;padding:7px 10px;text-align:right;}
+		.kkVisFoot button{background:none;border:none;padding:0;font:inherit;color:#15488f;cursor:pointer;text-decoration:underline;}
+		#kkVisHint{position:fixed;z-index:9997;width:215px;background:#15488f;color:#fff;border-radius:8px;box-shadow:0 6px 18px rgba(21,72,143,.35);font-family:Verdana, Arial, sans-serif;font-size:11px;line-height:1.45;padding:10px 12px;display:none;}
+		#kkVisHint.kkVisHintShow{display:block;animation:kkVisHintIn .35s ease;}
+		#kkVisHint:after{content:'';position:absolute;right:-6px;top:14px;width:12px;height:12px;background:#15488f;transform:rotate(45deg);}
+		#kkVisHintOk{display:inline-block;margin-top:8px;background:#fff;color:#15488f;border:none;border-radius:4px;padding:4px 12px;font-size:11px;font-weight:bold;cursor:pointer;}
+		#kkVisHintOk:hover{background:#dce7f7;}
+		@keyframes kkVisHintIn{from{opacity:0;transform:translateX(10px);}to{opacity:1;transform:translateX(0);}}
+		@media print{#kkVisToggle,#kkVisPanel,#kkVisHint{display:none;}}
 		</style>";
-		print "<div style='text-align:right;'><div class='kk-cols-picker' style='position:fixed;top:70px;right:18px;z-index:9999;display:inline-block;'>";
-		print "<svg id='kk-turn-arrow' xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='34px' fill='#000000'><path d='M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z'/></svg>";
-		print "<div class='kk-cols-menu'>";
+		$kkVisTitle   = findtekst('3380|Tilpas visning', $sprog_id);
+		$kkVisHelp    = findtekst('5145|Vælg hvilke kolonner og opslagssektioner der vises i kassekladden. Gælder kun visningen for dig.', $sprog_id);
+		# 5146, ikke 3382: pa nogle installationer holder tekster-tabellen allerede 3382 med en anden tekst
+		$kkVisShowAll = findtekst('5146|Vis alle', $sprog_id);
+		if ($menu != 'S') {
+			// menu S renders the gear inside the top line (topLineKassekladde.php); other menus get a floating button
+			print "<button type='button' id='kkVisToggle' class='kkVisFab' title='" . htmlspecialchars($kkVisTitle, ENT_QUOTES, $charset) . "'>&#9881;</button>";
+		}
+		print "<div id='kkVisPanel'>";
+		print "<div class='kkVisHead'>$kkVisTitle</div>";
+		print "<div class='kkVisIntro'>$kkVisHelp</div>";
+		print "<div class='kkVisList'>";
 		foreach ($kk_toggle_cols as $ckey => $clabel) {
 			$checked = in_array($ckey, $kk_hidden_cols, true) ? '' : 'checked';
-			print "<label><input type='checkbox' class='kk-col-toggle' data-col='" . htmlspecialchars($ckey, ENT_QUOTES, $charset) . "' $checked> " . htmlspecialchars($clabel, ENT_QUOTES, $charset) . "</label>";
+			print "<label class='kkVisRow'><input type='checkbox' class='kk-col-toggle' data-col='" . htmlspecialchars($ckey, ENT_QUOTES, $charset) . "' $checked><span>" . htmlspecialchars($clabel, ENT_QUOTES, $charset) . "</span></label>";
 		}
-		print "</div></div></div>";
+		$kk_panel_labels = array(
+			'ac_forslag' => findtekst('5142|Kontoforslag (sidste 5)', $sprog_id),
+			'ac_opslag'  => findtekst('5143|Konto-opslag', $sprog_id),
+		);
+		print "<hr class='kkVisSplit'>";
+		foreach ($kk_panel_labels as $ckey => $clabel) {
+			$checked = in_array($ckey, $kk_panel_hidden, true) ? '' : 'checked';
+			print "<label class='kkVisRow'><input type='checkbox' class='kk-col-toggle' data-col='" . htmlspecialchars($ckey, ENT_QUOTES, $charset) . "' $checked><span>" . htmlspecialchars($clabel, ENT_QUOTES, $charset) . "</span></label>";
+		}
+		print "</div>";
+		print "<div class='kkVisFoot'><button type='button' id='kkVisShowAll'>" . htmlspecialchars($kkVisShowAll, ENT_QUOTES, $charset) . "</button></div>";
+		print "</div>";
+		// First-time hint bubble pointing at the gear (same pattern as the product card's
+		// fieldVisibility hint); dismissal is remembered per company db + user in the browser.
+		$kkVisHintTxt = findtekst('5147|Nyt! Klik på tandhjulet for at tilpasse din opsætning af kassekladden.', $sprog_id);
+		$kkVisGotIt   = findtekst('5148|Forstået', $sprog_id);
+		$kkVisHintKey = 'saldiKkHint_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $db . '_' . $bruger_id . '_' . $brugernavn);
+		print "<div id='kkVisHint'>$kkVisHintTxt<br><button type='button' id='kkVisHintOk'>" . htmlspecialchars($kkVisGotIt, ENT_QUOTES, $charset) . "</button></div>";
 		print "<script>
 		document.addEventListener('change',function(e){
 			if(!e.target.classList.contains('kk-col-toggle')) return;
 			var col=e.target.getAttribute('data-col');
 			var show=e.target.checked;
-			document.querySelectorAll('.kk-col-'+col).forEach(function(el){el.style.display=show?'table-cell':'none';});
+			if(col==='ac_forslag'||col==='ac_opslag'){
+				window.saldiAutocompleteOptions=window.saldiAutocompleteOptions||{};
+				if(col==='ac_forslag'){window.saldiAutocompleteOptions.showLastPostings=show;}
+				else{window.saldiAutocompleteOptions.showAccountLookup=show;}
+			}else{
+				document.querySelectorAll('.kk-col-'+col).forEach(function(el){el.style.display=show?'table-cell':'none';});
+			}
 			var hidden=[];
 			document.querySelectorAll('.kk-col-toggle').forEach(function(cb){if(!cb.checked) hidden.push(cb.getAttribute('data-col'));});
 			var fd=new FormData();fd.append('save_kk_cols',hidden.join(','));
 			fetch(window.location.pathname+window.location.search,{method:'POST',body:fd,credentials:'same-origin'}).catch(function(){});
 		});
+		(function(){
+			var panel=document.getElementById('kkVisPanel');
+			var toggleBtn=document.getElementById('kkVisToggle');
+			if(!toggleBtn){return;}
+			var hint=document.getElementById('kkVisHint');
+			var hintKey='" . $kkVisHintKey . "';
+			function kkDismissHint(){
+				if(hint){hint.classList.remove('kkVisHintShow');}
+				try{localStorage.setItem(hintKey,'1');}catch(e){}
+			}
+			try{
+				if(hint && !localStorage.getItem(hintKey)){
+					var hr=toggleBtn.getBoundingClientRect();
+					hint.style.top=Math.max(4,hr.top-4)+'px';
+					hint.style.right=(window.innerWidth-hr.left+10)+'px';
+					hint.classList.add('kkVisHintShow');
+				}
+			}catch(e){}
+			if(document.getElementById('kkVisHintOk')){
+				document.getElementById('kkVisHintOk').addEventListener('click',kkDismissHint);
+			}
+			toggleBtn.addEventListener('click',function(){
+				kkDismissHint();
+				var r=toggleBtn.getBoundingClientRect();
+				panel.style.top=(r.bottom+6)+'px';
+				panel.classList.toggle('kkVisOpen');
+			});
+			document.addEventListener('click',function(e){
+				if(panel.classList.contains('kkVisOpen') && !panel.contains(e.target) && e.target!==toggleBtn && !toggleBtn.contains(e.target)){panel.classList.remove('kkVisOpen');}
+			});
+			document.getElementById('kkVisShowAll').addEventListener('click',function(){
+				document.querySelectorAll('#kkVisPanel .kk-col-toggle').forEach(function(cb){
+					if(!cb.checked){cb.checked=true;cb.dispatchEvent(new Event('change',{bubbles:true}));}
+				});
+			});
+		})();
 		</script>";
 
 		$kk_editable_view = true;
@@ -2865,7 +2975,8 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 	#now uses grid
 } else { ################################ Kladden er ikke bogfort ########################################
 
-	$debetsum = $kontrolmoms = $kontrolsaldo = $kreditsum = 0;
+	$kontrolmoms = $kontrolsaldo = 0;
+	$kladde_debetsum = $kladde_kreditsum = 0; # samlet debet/kredit (basisvaluta) til balance-status
 	include_once("../includes/stdFunc/fiscalYear.php");
 	list($regnstart, $regnslut) = explode(":", fiscalYear($regnaar));
 
@@ -2959,7 +3070,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		}
 
 		if ($id[$y] && $debet[$y] && is_numeric($debet[$y]) && $kredit[$y] && is_numeric($kredit[$y]))
-			list($dub_bilag[$y], $dub_kladde_id[$y]) = explode(",", find_dublet($id[$y], $transdate[$y], $d_type[$y], $debet[$y], $k_type[$y], $kredit[$y], $amount[$y], $faktura[$y]));
+			list($dub_bilag[$y], $dub_kladde_id[$y], $dub_kilde[$y]) = explode(",", find_dublet($id[$y], $transdate[$y], $d_type[$y], $debet[$y], $k_type[$y], $kredit[$y], $amount[$y], $faktura[$y]));
 		print "<tr>";
 		if ($vis_bilag && !$fejl && isset($id[$y])) { #### use
 			$qtxt = "select id,filename,filepath from documents where source = 'kassekladde' and source_id = '$id[$y]' order by id limit 1";  //20230630
@@ -2992,7 +3103,12 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			$dub_bilag[$y] = 0;
 		if (!isset($dub_kladde_id[$y]))
 			$dub_kladde_id[$y] = 0;
-		if ($dub_bilag[$y] && $dub_kladde_id[$y]) {
+		if (!isset($dub_kilde[$y]))
+			$dub_kilde[$y] = '';
+		if ($dub_bilag[$y] && $dub_kilde[$y] == 'bogfort') {
+			$title = "title='" . findtekst('5141|En tilsvarende postering er allerede bogført med bilagsnummer', $sprog_id) . " $dub_bilag[$y]'";
+			$color = "color:#FF0000;";
+		} elseif ($dub_bilag[$y] && $dub_kladde_id[$y]) {
 			$title = "title='" . findtekst('1575|En tilsvarende postering er også ført på kladde', $sprog_id) . " $dub_kladde_id[$y] med bilagsnummer $dub_bilag[$y]'";
 			$color = "color:#FF0000;";
 		} else {
@@ -3010,23 +3126,22 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 				$bilag[$y] = $last_bilag;
 			}
 		}
-		echo "<script>console.log('bilag[$y]: " . $bilag[$y] . "');</script>";
 		print "<td><input class='inputbox' $title type='text' style='text-align:right;width:80px;$color' name='bila$y' $de_fok value =\"$bilag[$y]\" onchange='javascript:docChange = true;'></td>";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:85px;' name='dato$y' $de_fok value =\"$dato[$y]\" onchange='javascript:docChange = true;'></td>";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:300px;' name='besk$y' $de_fok value =\"$beskrivelse[$y]\" onchange='javascript:docChange = true;'></td>";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='d_ty$y' $de_fok value =\"$d_type[$y]\" onchange='javascript:docChange = true;'></td>";
-		if (($k_type[$y] == 'D' || $k_type[$y] == 'K') && $kredit[$y] && !$debet[$y]) {
+		if (($k_type[$y] == 'D' || $k_type[$y] == 'K' || $k_type[$y] == 'F' || !$k_type[$y]) && $kredit[$y] && !$debet[$y]) {
 			$lastPostingsAttr = sidste_5_forslag_attr($kredit[$y], $k_type[$y], 'D', $charset);
-			print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
+			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
 		} else
-			print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\" title='$debettext[$y]' onchange='javascript:docChange = true;'></td>\n";
+			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\" title='$debettext[$y]' onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_d'>" . render_vat_select("dvat$y", if_isset($debetvat[$y], ''), $vat_codes, $charset, lookup_account_vat_code($debet[$y], $d_type[$y], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='k_ty$y' $de_fok value =\"$k_type[$y]\" onchange='javascript:docChange = true;'></td>\n";
-		if (($d_type[$y] == 'D' || $d_type[$y] == 'K') && $debet[$y] && !$kredit[$y]) {
+		if (($d_type[$y] == 'D' || $d_type[$y] == 'K' || $d_type[$y] == 'F' || !$d_type[$y]) && $debet[$y] && !$kredit[$y]) {
 			$lastPostingsAttr = sidste_5_forslag_attr($debet[$y], $d_type[$y], 'K', $charset);
-			print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
+			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
 		} else
-			print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\" title= '$kredittext[$y]' onchange='javascript:docChange = true;'></td>\n";
+			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\" title= '$kredittext[$y]' onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_k'>" . render_vat_select("kvat$y", if_isset($kreditvat[$y], ''), $vat_codes, $charset, lookup_account_vat_code($kredit[$y], $k_type[$y], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='fakt$y' $de_fok value =\"$faktura[$y]\" onchange='javascript:docChange = true;'></td>\n";
 		if (!isset($valuta[$y])) $valuta[$y] = $baseCurrency;
@@ -3126,44 +3241,16 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		print "<input type=hidden name='dkka$y' value='$dkkamount[$y]'>";
 		print "<input type=hidden name='transdate[$y]' value='$transdate[$y]'>";
 		print "</tr>\n";
-		if ($kksort == "bilag,transdate") {
-			if ($bilag[$y] != $bilag[$y - 1]) {
-				$debetsum = 0;
-				$kreditsum = 0;
-				$amount[$x + 1] = 0;
-			}
-			if ((($debet[$y]) || ($kredit[$y])) && ($amount[$y] > 0)) {
-				if (($debet[$y]) || ($debet[$y] > 0))
-					$debetsum = $debetsum + $dkkamount[$y];
-				if (($kredit[$y]) || ($kredit[$y] > 0))
-					$kreditsum = $kreditsum + $dkkamount[$y];
-				if ((!$bilag[$x + 1]) || ($bilag[$x + 1] < $bilag[$y]))
-					$bilag[$x + 1] = $bilag[$y];
-				if (!$dato[$x + 1])
-					$dato[$x + 1] = $dato[$y];
-				$amount[$x + 1] = $debetsum - $kreditsum;
-			}
-		}
+		if ($debet[$y])
+			$kladde_debetsum += isset($dkkamount[$y]) ? (float)$dkkamount[$y] : 0;
+		if ($kredit[$y])
+			$kladde_kreditsum += isset($dkkamount[$y]) ? (float)$dkkamount[$y] : 0;
 	}
-	$aa = $x + 1;
-	//if (!isset($amount[$x+1])) $amount[$x+1]=0;
-	if (!array_key_exists($x + 1, $amount))
-		$amount[$x + 1] = 0;
-	if (abs($amount[$x + 1]) > 0.01) {
-		// 20251218: Voucher NOT in balance - create auto-balance line with SAME bilag number
-		$beskrivelse[$x + 1] = $beskrivelse[$x];
-		$bilag[$x + 1] = $bilag[$x];
-		//$dato[$x+1]=$dato[$x];
-		isset($dato[$x]) && $dato[$x + 1] = $dato[$x];
-		//$valuta[$x+1]=$valuta[$x]; #20121110 Rettet fra $valuta[$x+1]=$baseCurrency
-		isset($valuta[$x]) && $valuta[$x + 1] = $valuta[$x];
-	} else {
-		// 20251218: Voucher IS in balance - clear the auto-balance line, prepare next bilag
-		$amount[$x + 1] = '';
-		$beskrivelse[$x + 1] = '';
-		$bilag[$x + 1] = '';
-		$dato[$x + 1] = '';
-	} #end if(abs($amount[$x + 1]) > 0.01)
+	# Auto-balance forududfyldning af naeste linje fjernet 20260903 - balance-status oeverst erstatter den
+	$amount[$x + 1] = 0;
+	$beskrivelse[$x + 1] = '';
+	$bilag[$x + 1] = '';
+	$dato[$x + 1] = '';
 
 	if ($x > 20) {
 		$y = $x + 5;
@@ -3171,18 +3258,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		$y = 24;
 	}
 	$x++;
-	if (!$amount[$x])    $amount[$x] = 0;
-	if ($amount[$x] < 0) $amount[$x] = $amount[$x] * -1;
-	if ($amount[$x])     $belob = dkdecimal($amount[$x], 2);
-	else $belob = "";
-	if (!isset($amount[$x - 1])) $amount[$x - 1] = 0;
-	// 20251218 Modified: Only clear bilag/dato when voucher is balanced (amount[$x] near zero)
-	// Previously checked $amount[$x - 1] which was wrong - should check $amount[$x] (the imbalance)
-	if (abs($amount[$x]) < 0.01) {
-		$bilag[$x] = "";
-		$dato[$x] = "";
-		$belob = "";
-	}
+	$belob = "";
 	if ($fokus && (strstr($fokus, "belo") || strstr($fokus, "afd")) && strstr($submit, 'save')) {
 		$tmp = substr($fokus, 4) + 1;
 		if (!$debet[$tmp] && !$kredit[$tmp])
@@ -3307,12 +3383,12 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		name='besk$x' $de_fok value =\"$beskrivelse[$x]\" onchange='javascript:docChange = true;'></td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;'
 		name='d_ty$x' $de_fok value =\"$d_type[$x]\" onchange='javascript:docChange = true;'></td>\n";
-		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;'
+		print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;'
 		name='debe$x' $de_fok value =\"$debet[$x]\" onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_d'>" . render_vat_select("dvat$x", if_isset($debetvat[$x], ''), $vat_codes, $charset, lookup_account_vat_code($debet[$x], $d_type[$x], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;'
 		name='k_ty$x' $de_fok value =\"$k_type[$x]\" onchange='javascript:docChange = true;'></td>\n";
-		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;'
+		print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;'
 		name='kred$x' $de_fok value=\"$kredit[$x]\" onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_k'>" . render_vat_select("kvat$x", if_isset($kreditvat[$x], ''), $vat_codes, $charset, lookup_account_vat_code($kredit[$x], $k_type[$x], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;'
@@ -3403,10 +3479,10 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:85px;' name='dato$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:300px;' name='besk$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='d_ty$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
-		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='debe$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
+		print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='debe$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_d'>" . render_vat_select("dvat$z", '', $vat_codes, $charset) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='k_ty$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
-		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='kred$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
+		print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='kred$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
 		print "<td class='kk-col-vat_k'>" . render_vat_select("kvat$z", '', $vat_codes, $charset) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='fakt$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:right;width:100px;' name='belo$z' $de_fok onchange='javascript:docChange = true;'></td>\n";
@@ -3897,17 +3973,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			$ym = $year . $month;
 
 			if (!function_exists('checkOpenFiscalYear')) include_once('../includes/stdFunc/checkOpenFiscalYear.php');
-			// DEBUG 20251216 - Show all fiscal years directly
-			$debug_q = db_select("select kodenr, box1, box2, box3, box4, box5 from grupper where art = 'RA' order by kodenr", __FILE__ . " linje " . __LINE__);
-			$all_years = '';
-			while ($debug_r = db_fetch_array($debug_q)) {
-				$all_years .= "yr{$debug_r['kodenr']}:{$debug_r['box2']}{$debug_r['box1']}-{$debug_r['box4']}{$debug_r['box3']}(box5={$debug_r['box5']}); ";
-			}
-			print "<script>console.log('DEBUG ALL fiscal years: $all_years');</script>";
-			// END DEBUG
-			$debug_result = checkOpenFiscalYear($transdate);
-			print "<script>console.log('DEBUG fiscal year check: regnaar=$regnaar, transdate=$transdate, ym=$ym, aarstart=$aarstart, aarslut=$aarslut, result=" . ($debug_result ? 'PASS' : 'FAIL') . "');</script>";
-			if (!$debug_result) {
+			if (!checkOpenFiscalYear($transdate)) {
 			#if (!$fejl && $dato && ($ym < $aarstart || $ym > $aarslut)) {
 				$alert1 = findtekst('635|Dato', $sprog_id);
 				$alert2 = findtekst('1595|udenfor regnskabsår', $sprog_id);
@@ -4319,6 +4385,7 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 	{
 		global $kladde_id;
 		global $charset;
+		global $sprog_id;
 
 		$forslag = array(
 			'heading' => '',
@@ -4328,17 +4395,39 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		if (!is_numeric($kontonr)) {
 			return $forslag;
 		}
+		if (!$art) {
+			$art = 'F'; # blank type is treated as finance everywhere else in the file
+		}
+		if (!in_array($art, array('D', 'K', 'F'), true)) {
+			return $forslag;
+		}
 
-		if ($dk == "D") {
-			$txt = "select bilag,transdate,beskrivelse,debet as kontonr from kassekladde where k_type = '$art' and kredit = '$kontonr' and kladde_id != '$kladde_id' order by transdate desc";
+		$kontonr_sql = db_escape_string($kontonr);
+		$kladde_id_sql = (int)$kladde_id;
+		if ($art == 'F') {
+			$d_artcond = "(d_type = 'F' or d_type = '' or d_type is null)";
+			$k_artcond = "(k_type = 'F' or k_type = '' or k_type is null)";
 		} else {
-			$txt = "select bilag,transdate,beskrivelse,kredit as kontonr from kassekladde where d_type = '$art' and debet = '$kontonr' and kladde_id != '$kladde_id' order by transdate desc";
+			$d_artcond = "d_type = '$art'";
+			$k_artcond = "k_type = '$art'";
+		}
+		# NB: soger kun i kassekladde (aabne/tidligere kladdelinjer) - udvidelse til transaktioner er en senere opgave
+		if ($dk == "D") {
+			$txt = "select bilag,transdate,beskrivelse,debet as kontonr from kassekladde where $k_artcond and kredit = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc";
+		} else {
+			$txt = "select bilag,transdate,beskrivelse,kredit as kontonr from kassekladde where $d_artcond and debet = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc";
 		}
 
 		if ($art == 'K') {
 			$forslag['heading'] = "Sidste 5 posteringer for kreditor: $kontonr";
-		} else {
+		} elseif ($art == 'D') {
 			$forslag['heading'] = "Sidste 5 posteringer for debitor: $kontonr";
+		} else {
+			$heading = findtekst('5140|Sidste 5 posteringer for konto', $sprog_id) . ": $kontonr";
+			if ($charset && strtoupper($charset) != 'UTF-8' && function_exists('mb_convert_encoding')) {
+				$heading = mb_convert_encoding($heading, 'UTF-8', $charset);
+			}
+			$forslag['heading'] = $heading;
 		}
 
 		$q = db_select($txt, __FILE__ . " linje " . __LINE__);
@@ -4374,15 +4463,50 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		return " data-last-postings=\"" . htmlspecialchars($json, ENT_QUOTES, $charset) . "\"";
 	}
 	##########################################################################################################
+	# Returnerer "bilag,kladde_id,kilde" hvor kilde er 'kladde' (dublet i anden aaben kladde)
+	# eller 'bogfort' (dublet blandt bogfoerte posteringer) - "0,0,0" naar ingen dublet findes.
 	function find_dublet($id, $transdate, $d_type, $debet, $k_type, $kredit, $amount, $faktura) {
+		global $regnstart, $regnslut;
 		if ($id) {
 			$id = (int)$id;
-			$qtxt = "select bilag,kladde_id from kassekladde where transdate='$transdate' and d_type='$d_type' ";
-			$qtxt.= "and debet='$debet' and k_type='$k_type' and kredit='$kredit' and amount = '$amount' ";
-			$qtxt.= "and faktura = '$faktura' and id!='$id' limit 1";
+			$transdate_sql = db_escape_string($transdate);
+			$d_type_sql    = db_escape_string($d_type);
+			$debet_sql     = db_escape_string($debet);
+			$k_type_sql    = db_escape_string($k_type);
+			$kredit_sql    = db_escape_string($kredit);
+			$amount_sql    = db_escape_string($amount);
+			$faktura_sql   = db_escape_string($faktura);
+			$qtxt = "select bilag,kladde_id from kassekladde where transdate='$transdate_sql' and d_type='$d_type_sql' ";
+			$qtxt.= "and debet='$debet_sql' and k_type='$k_type_sql' and kredit='$kredit_sql' and amount = '$amount_sql' ";
+			$qtxt.= "and faktura = '$faktura_sql' and id!='$id' limit 1";
 			if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-				return ($r['bilag'] . "," . $r['kladde_id']);
-			} else return ("0,0");
+				return ($r['bilag'] . "," . $r['kladde_id'] . ",kladde");
+			}
+			# Ingen dublet i aabne kladder - slaa op blandt bogfoerte posteringer. En bogfoert linje ligger
+			# som separate debet-/kreditraekker i transaktioner (samme bilag+kladde_id), og momsbaerende
+			# sider er gemt ekskl. moms, saa bruttobeloebet matches mod mindst een af de to sider.
+			# D/K-konti bogfoeres paa samlekontoen og kan derfor kun matches paa deres F-modside.
+			$sider = array();
+			if ($d_type == 'F' || !$d_type) {
+				$sider[] = "t1.kontonr='" . (int)$debet . "'";
+			}
+			if ($k_type == 'F' || !$k_type) {
+				$sider[] = "t2.kontonr='" . (int)$kredit . "'";
+			}
+			if (count($sider) && $regnstart && $regnslut) {
+				$regnstart_sql = db_escape_string($regnstart);
+				$regnslut_sql  = db_escape_string($regnslut);
+				$qtxt = "select t1.bilag from transaktioner t1, transaktioner t2 ";
+				$qtxt.= "where t1.transdate='$transdate_sql' and t2.transdate='$transdate_sql' ";
+				$qtxt.= "and t1.transdate>='$regnstart_sql' and t1.transdate<='$regnslut_sql' ";
+				$qtxt.= "and t1.kladde_id=t2.kladde_id and t1.bilag=t2.bilag and t1.id!=t2.id ";
+				$qtxt.= "and t1.debet>0 and t2.kredit>0 and (t1.debet='$amount_sql' or t2.kredit='$amount_sql') ";
+				$qtxt.= "and t1.faktura='$faktura_sql' and " . implode(' and ', $sider) . " limit 1";
+				if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+					return ($r['bilag'] . ",0,bogfort");
+				}
+			}
+			return ("0,0,0");
 		}
 	}
 
@@ -4394,6 +4518,19 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		$fokus = "besk$x";
 	}
 	print "</tbody></table>";
+	if (!empty($kk_editable_view)) {
+		# Balance-status: genbruger de summer loekken allerede har akkumuleret - visning alene, blokerer intet
+		$kladde_diff = afrund($kladde_debetsum, 2) - afrund($kladde_kreditsum, 2);
+		if (abs($kladde_diff) < 0.005) {
+			$balance_txt = "<span style='color:#1a7a1a;'>" . findtekst('5144|Kladden balancerer', $sprog_id) . "</span>";
+		} else {
+			$balance_txt = "<span style='color:#cc0000;font-weight:bold;'>" . findtekst('2396|Difference', $sprog_id) . ": " . dkdecimal($kladde_diff, 2) . " $baseCurrency</span>";
+		}
+		# Fyldes ind i det tomme felt til venstre for bemaerkningslinjen - summerne kendes foerst efter loekken
+		$balance_pill = "<span style='display:inline-block;white-space:nowrap;background:#fff;border:1px solid #ddd;border-radius:4px;padding:2px 10px;font-size:12px;'>$balance_txt</span>";
+		print "<style>@media print{#kk-balance-status{display:none;}}</style>";
+		print "<script>var kkBalEl=document.getElementById('kk-balance-status');if(kkBalEl){kkBalEl.innerHTML=" . json_encode($balance_pill) . ";}</script>";
+	}
 	print "<script language=\"javascript\">";
 	print "var savedFocus = " . json_encode((string)$fokus) . ";";
 	print "var savedFocusField = savedFocus && document.forms[0] ? document.forms[0].elements[savedFocus] : null;";

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -99,6 +99,8 @@
 //                  round gear button, click-to-open panel with title/intro/Show all; same persistence.
 // 20260907 Sawaneh First-time hint bubble pointing at the gear ("klik for at tilpasse din opsætning",
 //                  texts 5147/5148), dismissed per user via localStorage - product card hint pattern.
+// 20260907 Sawaneh Column/panel save fetch uses keepalive so a refresh right after toggling can no
+//                  longer cancel the persistence request (choices appeared to reset on fast reload).
 // 20260904 Sawaneh Gear button docked into the top line next to 'Ny' (menu S, via topLineKassekladde.php);
 //                  other menu styles keep the floating button; panel now opens just below the button.
 
@@ -2633,7 +2635,8 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			var hidden=[];
 			document.querySelectorAll('.kk-col-toggle').forEach(function(cb){if(!cb.checked) hidden.push(cb.getAttribute('data-col'));});
 			var fd=new FormData();fd.append('save_kk_cols',hidden.join(','));
-			fetch(window.location.pathname+window.location.search,{method:'POST',body:fd,credentials:'same-origin'}).catch(function(){});
+			// keepalive: a reload right after toggling must not cancel the save request
+			fetch(window.location.pathname+window.location.search,{method:'POST',body:fd,credentials:'same-origin',keepalive:true}).catch(function(){});
 		}
 		document.addEventListener('change',function(e){
 			if(!e.target.classList.contains('kk-col-toggle')) return;

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -103,6 +103,10 @@
 //                  longer cancel the persistence request (choices appeared to reset on fast reload).
 // 20260904 Sawaneh Gear button docked into the top line next to 'Ny' (menu S, via topLineKassekladde.php);
 //                  other menu styles keep the floating button; panel now opens just below the button.
+// 20260907 CDX/LH Keep counter-account types in suggestions and match posted duplicates in base currency
+//                  with customer/supplier evidence; isolate journal history queries for regression tests.
+
+require_once __DIR__ . '/kassekladde_includes/journalHistory.php';
 
 ob_start(); //Starter output buffering  
 
@@ -396,7 +400,7 @@ print '<script src="../javascript/datepickerDa.js"></script>';
 print "<script LANGUAGE='javascript' TYPE='text/javascript' SRC='../javascript/confirmclose.js'></script>";
 print "<script LANGUAGE='JavaScript' TYPE='text/javascript' SRC='../javascript/overlib.js'></script>";
 print '<link rel="stylesheet" type="text/css" href="../css/accountAutocomplete.css?v=4.1.4">';
-print '<script src="../javascript/accountAutocomplete.js?v=4.1.5" defer></script>';
+print '<script src="../javascript/accountAutocomplete.js?v=4.1.6" defer></script>';
 print "<script>
 	function fokuser(that, fgcolor, bgcolor){
 		that.style.color = fgcolor;
@@ -3079,8 +3083,12 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			#if ($debet[$y] === '' && $kredit[$y] === '')	$kontrolsaldo = ''; #outcommented 20240401
 		}
 
-		if ($id[$y] && $debet[$y] && is_numeric($debet[$y]) && $kredit[$y] && is_numeric($kredit[$y]))
-			list($dub_bilag[$y], $dub_kladde_id[$y], $dub_kilde[$y]) = explode(",", find_dublet($id[$y], $transdate[$y], $d_type[$y], $debet[$y], $k_type[$y], $kredit[$y], $amount[$y], $faktura[$y]));
+		if ($id[$y] && $debet[$y] && is_numeric($debet[$y]) && $kredit[$y] && is_numeric($kredit[$y])) {
+			list($dub_bilag[$y], $dub_kladde_id[$y], $dub_kilde[$y]) = explode(",", find_dublet(
+				$id[$y], $transdate[$y], $d_type[$y], $debet[$y], $k_type[$y], $kredit[$y],
+				$amount[$y], $faktura[$y], $dkkamount[$y], $regnstart, $regnslut
+			));
+		}
 		print "<tr>";
 		if ($vis_bilag && !$fejl && isset($id[$y])) { #### use
 			$qtxt = "select id,filename,filepath from documents where source = 'kassekladde' and source_id = '$id[$y]' order by id limit 1";  //20230630
@@ -3141,17 +3149,19 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:300px;' name='besk$y' $de_fok value =\"$beskrivelse[$y]\" onchange='javascript:docChange = true;'></td>";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='d_ty$y' $de_fok value =\"$d_type[$y]\" onchange='javascript:docChange = true;'></td>";
 		if (($k_type[$y] == 'D' || $k_type[$y] == 'K' || $k_type[$y] == 'F' || !$k_type[$y]) && $kredit[$y] && !$debet[$y]) {
-			$lastPostingsAttr = sidste_5_forslag_attr($kredit[$y], $k_type[$y], 'D', $charset);
+			$lastPostingsAttr = sidste_5_forslag_attr($kredit[$y], $k_type[$y], 'D', $charset, $kladde_id, $sprog_id);
 			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
-		} else
+		} else {
 			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='debe$y' $de_fok value =\"$debet[$y]\" title='$debettext[$y]' onchange='javascript:docChange = true;'></td>\n";
+		}
 		print "<td class='kk-col-vat_d'>" . render_vat_select("dvat$y", if_isset($debetvat[$y], ''), $vat_codes, $charset, lookup_account_vat_code($debet[$y], $d_type[$y], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:left;width:25px;' name='k_ty$y' $de_fok value =\"$k_type[$y]\" onchange='javascript:docChange = true;'></td>\n";
 		if (($d_type[$y] == 'D' || $d_type[$y] == 'K' || $d_type[$y] == 'F' || !$d_type[$y]) && $debet[$y] && !$kredit[$y]) {
-			$lastPostingsAttr = sidste_5_forslag_attr($debet[$y], $d_type[$y], 'K', $charset);
+			$lastPostingsAttr = sidste_5_forslag_attr($debet[$y], $d_type[$y], 'K', $charset, $kladde_id, $sprog_id);
 			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\"$lastPostingsAttr onchange='javascript:docChange = true;'></td>\n";
-		} else
+		} else {
 			print "<td><input class='inputbox' type='text' autocomplete='off' style='text-align:right;width:75px;' name='kred$y' $de_fok value =\"$kredit[$y]\" title= '$kredittext[$y]' onchange='javascript:docChange = true;'></td>\n";
+		}
 		print "<td class='kk-col-vat_k'>" . render_vat_select("kvat$y", if_isset($kreditvat[$y], ''), $vat_codes, $charset, lookup_account_vat_code($kredit[$y], $k_type[$y], $regnaar, $vat_codes)) . "</td>\n";
 		print "<td><input class='inputbox' type='text' style='text-align:right;width:75px;' name='fakt$y' $de_fok value =\"$faktura[$y]\" onchange='javascript:docChange = true;'></td>\n";
 		if (!isset($valuta[$y])) $valuta[$y] = $baseCurrency;
@@ -4391,134 +4401,6 @@ if (($bogfort && $bogfort != '-') || $udskriv) {
 			return ($kontonr);
 	}
 	##########################################################################################################
-	function sidste_5_forslag($kontonr, $art, $dk)
-	{
-		global $kladde_id;
-		global $charset;
-		global $sprog_id;
-
-		$forslag = array(
-			'heading' => '',
-			'rows' => array()
-		);
-
-		if (!is_numeric($kontonr)) {
-			return $forslag;
-		}
-		if (!$art) {
-			$art = 'F'; # blank type is treated as finance everywhere else in the file
-		}
-		if (!in_array($art, array('D', 'K', 'F'), true)) {
-			return $forslag;
-		}
-
-		$kontonr_sql = db_escape_string($kontonr);
-		$kladde_id_sql = (int)$kladde_id;
-		if ($art == 'F') {
-			$d_artcond = "(d_type = 'F' or d_type = '' or d_type is null)";
-			$k_artcond = "(k_type = 'F' or k_type = '' or k_type is null)";
-		} else {
-			$d_artcond = "d_type = '$art'";
-			$k_artcond = "k_type = '$art'";
-		}
-		# NB: soger kun i kassekladde (aabne/tidligere kladdelinjer) - udvidelse til transaktioner er en senere opgave
-		if ($dk == "D") {
-			$txt = "select bilag,transdate,beskrivelse,debet as kontonr from kassekladde where $k_artcond and kredit = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc";
-		} else {
-			$txt = "select bilag,transdate,beskrivelse,kredit as kontonr from kassekladde where $d_artcond and debet = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc";
-		}
-
-		if ($art == 'K') {
-			$forslag['heading'] = "Sidste 5 posteringer for kreditor: $kontonr";
-		} elseif ($art == 'D') {
-			$forslag['heading'] = "Sidste 5 posteringer for debitor: $kontonr";
-		} else {
-			$heading = findtekst('5140|Sidste 5 posteringer for konto', $sprog_id) . ": $kontonr";
-			if ($charset && strtoupper($charset) != 'UTF-8' && function_exists('mb_convert_encoding')) {
-				$heading = mb_convert_encoding($heading, 'UTF-8', $charset);
-			}
-			$forslag['heading'] = $heading;
-		}
-
-		$q = db_select($txt, __FILE__ . " linje " . __LINE__);
-		while (count($forslag['rows']) < 5 && ($r = db_fetch_array($q))) {
-			if ($r['kontonr']) {
-				$tekst = stripslashes($r['beskrivelse']);
-				if ($charset && strtoupper($charset) != 'UTF-8' && function_exists('mb_convert_encoding')) {
-					$tekst = mb_convert_encoding($tekst, 'UTF-8', $charset);
-				}
-				$forslag['rows'][] = array(
-					'bilag' => $r['bilag'],
-					'dato' => dkdato($r['transdate']),
-					'tekst' => $tekst,
-					'kontonr' => $r['kontonr']
-				);
-			}
-		}
-
-		return $forslag;
-	}
-	##########################################################################################################
-	function sidste_5_forslag_attr($kontonr, $art, $dk, $charset)
-	{
-		$forslag = sidste_5_forslag($kontonr, $art, $dk);
-		if (!count($forslag['rows'])) {
-			return '';
-		}
-
-		$json = json_encode($forslag);
-		if ($json === false) {
-			return '';
-		}
-		return " data-last-postings=\"" . htmlspecialchars($json, ENT_QUOTES, $charset) . "\"";
-	}
-	##########################################################################################################
-	# Returnerer "bilag,kladde_id,kilde" hvor kilde er 'kladde' (dublet i anden aaben kladde)
-	# eller 'bogfort' (dublet blandt bogfoerte posteringer) - "0,0,0" naar ingen dublet findes.
-	function find_dublet($id, $transdate, $d_type, $debet, $k_type, $kredit, $amount, $faktura) {
-		global $regnstart, $regnslut;
-		if ($id) {
-			$id = (int)$id;
-			$transdate_sql = db_escape_string($transdate);
-			$d_type_sql    = db_escape_string($d_type);
-			$debet_sql     = db_escape_string($debet);
-			$k_type_sql    = db_escape_string($k_type);
-			$kredit_sql    = db_escape_string($kredit);
-			$amount_sql    = db_escape_string($amount);
-			$faktura_sql   = db_escape_string($faktura);
-			$qtxt = "select bilag,kladde_id from kassekladde where transdate='$transdate_sql' and d_type='$d_type_sql' ";
-			$qtxt.= "and debet='$debet_sql' and k_type='$k_type_sql' and kredit='$kredit_sql' and amount = '$amount_sql' ";
-			$qtxt.= "and faktura = '$faktura_sql' and id!='$id' limit 1";
-			if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-				return ($r['bilag'] . "," . $r['kladde_id'] . ",kladde");
-			}
-			# Ingen dublet i aabne kladder - slaa op blandt bogfoerte posteringer. En bogfoert linje ligger
-			# som separate debet-/kreditraekker i transaktioner (samme bilag+kladde_id), og momsbaerende
-			# sider er gemt ekskl. moms, saa bruttobeloebet matches mod mindst een af de to sider.
-			# D/K-konti bogfoeres paa samlekontoen og kan derfor kun matches paa deres F-modside.
-			$sider = array();
-			if ($d_type == 'F' || !$d_type) {
-				$sider[] = "t1.kontonr='" . (int)$debet . "'";
-			}
-			if ($k_type == 'F' || !$k_type) {
-				$sider[] = "t2.kontonr='" . (int)$kredit . "'";
-			}
-			if (count($sider) && $regnstart && $regnslut) {
-				$regnstart_sql = db_escape_string($regnstart);
-				$regnslut_sql  = db_escape_string($regnslut);
-				$qtxt = "select t1.bilag from transaktioner t1, transaktioner t2 ";
-				$qtxt.= "where t1.transdate='$transdate_sql' and t2.transdate='$transdate_sql' ";
-				$qtxt.= "and t1.transdate>='$regnstart_sql' and t1.transdate<='$regnslut_sql' ";
-				$qtxt.= "and t1.kladde_id=t2.kladde_id and t1.bilag=t2.bilag and t1.id!=t2.id ";
-				$qtxt.= "and t1.debet>0 and t2.kredit>0 and (t1.debet='$amount_sql' or t2.kredit='$amount_sql') ";
-				$qtxt.= "and t1.faktura='$faktura_sql' and " . implode(' and ', $sider) . " limit 1";
-				if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-					return ($r['bilag'] . ",0,bogfort");
-				}
-			}
-		}
-		return ("0,0,0");
-	}
 
 	$x--;
 	if (!$fokus && $x == 1)

--- a/finans/kassekladde_includes/journalHistory.php
+++ b/finans/kassekladde_includes/journalHistory.php
@@ -1,0 +1,151 @@
+<?php
+// 20260907 CDX/LH Preserve suggestion account types and match posted duplicates by currency and counterparty.
+
+/**
+ * Find recent counter-accounts without losing their customer/supplier/finance identity.
+ *
+ * @return array{
+ *   heading: string,
+ *   rows: array<array{bilag: mixed, dato: string, tekst: string, kontonr: mixed, art: string}>
+ * }
+ */
+function sidste_5_forslag($kontonr, $art, $dk, $kladde_id, $charset, $sprog_id)
+{
+	$forslag = array(
+		'heading' => '',
+		'rows' => array()
+	);
+
+	if (!is_numeric($kontonr)) {
+		return $forslag;
+	}
+	$art = strtoupper(trim((string)$art)) ?: 'F';
+	if (!in_array($art, array('D', 'K', 'F'), true)) {
+		return $forslag;
+	}
+
+	$kontonr_sql = db_escape_string($kontonr);
+	$kladde_id_sql = (int)$kladde_id;
+	if ($art == 'F') {
+		$d_artcond = "(d_type = 'F' or d_type = '' or d_type is null)";
+		$k_artcond = "(k_type = 'F' or k_type = '' or k_type is null)";
+	} else {
+		$d_artcond = "d_type = '$art'";
+		$k_artcond = "k_type = '$art'";
+	}
+	# NB: soger kun i kassekladde (aabne/tidligere kladdelinjer) - udvidelse til transaktioner er en senere opgave
+	if ($dk == "D") {
+		$txt = "select bilag,transdate,beskrivelse,debet as kontonr,d_type as kontoart from kassekladde where $k_artcond and kredit = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc,id desc";
+	} else {
+		$txt = "select bilag,transdate,beskrivelse,kredit as kontonr,k_type as kontoart from kassekladde where $d_artcond and debet = '$kontonr_sql' and kladde_id != '$kladde_id_sql' order by transdate desc,id desc";
+	}
+
+	if ($art == 'K') {
+		$forslag['heading'] = "Sidste 5 posteringer for kreditor: $kontonr";
+	} elseif ($art == 'D') {
+		$forslag['heading'] = "Sidste 5 posteringer for debitor: $kontonr";
+	} else {
+		$heading = findtekst('5140|Sidste 5 posteringer for konto', $sprog_id) . ": $kontonr";
+		if ($charset && strtoupper($charset) != 'UTF-8' && function_exists('mb_convert_encoding')) {
+			$heading = mb_convert_encoding($heading, 'UTF-8', $charset);
+		}
+		$forslag['heading'] = $heading;
+	}
+
+	$q = db_select($txt, __FILE__ . " linje " . __LINE__);
+	while (count($forslag['rows']) < 5 && ($r = db_fetch_array($q))) {
+		$counterType = strtoupper(trim((string)$r['kontoart'])) ?: 'F';
+		if ($r['kontonr'] && in_array($counterType, array('D', 'K', 'F'), true)) {
+			$tekst = stripslashes($r['beskrivelse']);
+			if ($charset && strtoupper($charset) != 'UTF-8' && function_exists('mb_convert_encoding')) {
+				$tekst = mb_convert_encoding($tekst, 'UTF-8', $charset);
+			}
+			$forslag['rows'][] = array(
+				'bilag' => $r['bilag'],
+				'dato' => dkdato($r['transdate']),
+				'tekst' => $tekst,
+				'kontonr' => $r['kontonr'],
+				'art' => $counterType
+			);
+		}
+	}
+
+	return $forslag;
+}
+##########################################################################################################
+/** @return string HTML attribute containing the historical counter-accounts. */
+function sidste_5_forslag_attr($kontonr, $art, $dk, $charset, $kladde_id, $sprog_id)
+{
+	$forslag = sidste_5_forslag($kontonr, $art, $dk, $kladde_id, $charset, $sprog_id);
+	if (!count($forslag['rows'])) {
+		return '';
+	}
+
+	$json = json_encode($forslag);
+	if ($json === false) {
+		return '';
+	}
+	return " data-last-postings=\"" . htmlspecialchars($json, ENT_QUOTES, $charset) . "\"";
+}
+##########################################################################################################
+/**
+ * Match draft rows in their entered currency and posted rows in base currency.
+ *
+ * @return string "bilag,kladde_id,kilde", where kilde is kladde or bogfort; "0,0,0" when absent.
+ */
+function find_dublet($id, $transdate, $d_type, $debet, $k_type, $kredit, $amount, $faktura, $baseAmount, $regnstart, $regnslut) {
+	if ($id) {
+		$id = (int)$id;
+		$transdate_sql = db_escape_string($transdate);
+		$d_type_sql    = db_escape_string($d_type);
+		$debet_sql     = db_escape_string($debet);
+		$k_type_sql    = db_escape_string($k_type);
+		$kredit_sql    = db_escape_string($kredit);
+		$amount_sql    = db_escape_string($amount);
+		$faktura_sql   = db_escape_string($faktura);
+		$qtxt = "select bilag,kladde_id from kassekladde where transdate='$transdate_sql' and d_type='$d_type_sql' ";
+		$qtxt.= "and debet='$debet_sql' and k_type='$k_type_sql' and kredit='$kredit_sql' and amount = '$amount_sql' ";
+		$qtxt.= "and faktura = '$faktura_sql' and id!='$id' limit 1";
+		if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+			return ($r['bilag'] . "," . $r['kladde_id'] . ",kladde");
+		}
+		# Ingen dublet i aabne kladder - slaa op blandt bogfoerte posteringer. En bogfoert linje ligger
+		# som separate debet-/kreditraekker i transaktioner (samme bilag+kladde_id), og momsbaerende
+		# sider er gemt ekskl. moms, saa bruttobeloebet matches mod mindst een af de to sider.
+		# D/K-konti kræver en tilsvarende openpost for den konkrete kunde/leverandør.
+		# Beløb i transaktioner er i basisvaluta, mens kassekladde bruger bilagets valuta.
+		$base_amount_sql = number_format((float)$baseAmount, 2, '.', '');
+		$sider = array();
+		foreach (array(array('t1', $d_type, $debet, 1), array('t2', $k_type, $kredit, -1)) as $side) {
+			list($alias, $type, $account, $sign) = $side;
+			$type = strtoupper(trim((string)$type)) ?: 'F';
+			if ($type === 'F') {
+				$sider[] = "$alias.kontonr='" . (int)$account . "'";
+			} elseif ($type === 'D' || $type === 'K') {
+				$account_sql = db_escape_string($account);
+				$signed_amount_sql = number_format((float)$baseAmount * $sign, 2, '.', '');
+				$sider[] = "exists (select 1 from openpost o join adresser a on a.id=o.konto_id "
+					. "where a.art='$type' and a.kontonr='$account_sql' "
+					. "and o.kladde_id=$alias.kladde_id and o.refnr=$alias.bilag "
+					. "and o.transdate=$alias.transdate and o.faktnr='$faktura_sql' "
+					. "and round(o.amount * coalesce(nullif(o.valutakurs,0),100) / 100,2)=$signed_amount_sql)";
+			} else {
+				return "0,0,0";
+			}
+		}
+		if (count($sider) && $regnstart && $regnslut) {
+			$regnstart_sql = db_escape_string($regnstart);
+			$regnslut_sql  = db_escape_string($regnslut);
+			$qtxt = "select t1.bilag from transaktioner t1, transaktioner t2 ";
+			$qtxt.= "where t1.transdate='$transdate_sql' and t2.transdate='$transdate_sql' ";
+			$qtxt.= "and t1.transdate>='$regnstart_sql' and t1.transdate<='$regnslut_sql' ";
+			$qtxt.= "and t1.kladde_id=t2.kladde_id and t1.bilag=t2.bilag and t1.id!=t2.id ";
+			$qtxt.= "and t1.debet>0 and t2.kredit>0 and (t1.debet='$base_amount_sql' or t2.kredit='$base_amount_sql') ";
+			$qtxt.= "and t1.faktura='$faktura_sql' and t2.faktura='$faktura_sql' and " . implode(' and ', $sider) . " limit 1";
+			if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+				return ($r['bilag'] . ",0,bogfort");
+			}
+		}
+	}
+	return ("0,0,0");
+}

--- a/finans/kassekladde_includes/topLineKassekladde.php
+++ b/finans/kassekladde_includes/topLineKassekladde.php
@@ -23,6 +23,8 @@
 // Copyright (c) 2003-2026 Saldi.dk ApS
 // -----------------------------------------------------------------------------------
 // 20260126 PHR fixed $exitDraft
+// 20260904 Sawaneh Gear button for the Customize view panel added next to 'Ny' (editable journals only);
+//                  the panel itself and its logic live in kassekladde.php.
 
 $border = 'border:1px';
 $TableBG = "bgcolor=$bgcolor";
@@ -88,8 +90,16 @@ print "<td id='create-new' width='5%' style='$buttonStyle'>
 	<a href=\"javascript:confirmClose('../finans/kassekladde.php?exitDraft=$kladde_id','$tekst')\" accesskey='N'>
 	<button class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">
 		$add_icon ".
-		findtekst('39|Ny', $sprog_id)." 
+		findtekst('39|Ny', $sprog_id)."
 	</button></a></td>";
+
+if ($bogfort == '-' || $bogfort == '') { // gear only where the Customize view panel exists (editable journal)
+	$gear_icon = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M370-80l-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm112-260q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Z"/></svg>';
+	$gear_title = htmlspecialchars(findtekst('3380|Tilpas visning', $sprog_id), ENT_QUOTES, $charset);
+	print "<td id='kk-vis-cell' width='3%' style='$buttonStyle'>
+		<button type='button' id='kkVisToggle' class='center-btn' style='$buttonStyle; width:100%; justify-content:center;' title='$gear_title' onMouseOver=\"this.style.cursor='pointer'\">
+		$gear_icon</button></td>";
+}
 
 print "</tr></tbody></table></td></tr>\n"; # <- Tabel 1.1
 
@@ -102,6 +112,8 @@ print "</tr></tbody></table></td></tr>\n"; # <- Tabel 1.1
 		text-decoration: none;
 		gap: 5px;
 	}
+	#kkVisToggle svg { transition: transform .25s ease; }
+	#kkVisToggle:hover svg { transform: rotate(60deg); }
 	 /* no use for underlines on the top href buttons */
 	.header-row a,
 	.header-row a:link,

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -5079,3 +5079,12 @@
 5079	Din ændring blev ikke gemt - denne labels skabelon er ændret siden siden blev indlæst (fx i en anden fane), og kan nu kun redigeres som rå HTML. Genindlæs siden og prøv igen.	Your change wasn't saved - this label's template has changed since the page was loaded (e.g. in another tab), and can now only be edited as raw HTML. Reload the page and try again.	Endringen din ble ikke lagret - denne etikettens mal er endret siden siden ble lastet (f.eks. i en annen fane), og kan nå bare redigeres som rå HTML. Last siden på nytt og prøv igjen.
 5089	Beløbet	The amount	Beløpet
 5090	er ikke et gyldigt beløb - brug komma som decimaltegn, fx 1.234,56 (Bilag nr	is not a valid amount - use a comma as the decimal separator, e.g. 1.234,56 (Attachment no	er ikke et gyldig beløp - bruk komma som desimaltegn, f.eks. 1.234,56 (Bilag nr
+5140	Sidste 5 posteringer for konto	Last 5 postings for account	Siste 5 posteringer for konto
+5141	En tilsvarende postering er allerede bogført med bilagsnummer	A matching entry has already been posted with voucher number	En tilsvarende postering er allerede bokført med bilagsnummer
+5142	Kontoforslag (sidste 5)	Account suggestions (last 5)	Kontoforslag (siste 5)
+5143	Konto-opslag	Account lookup	Kontooppslag
+5144	Kladden balancerer	The journal balances	Kladden balanserer
+5145	Vælg hvilke kolonner og opslagssektioner der vises i kassekladden. Gælder kun visningen for dig.	Choose which columns and lookup sections are shown in the cash journal. Only affects what you see.	Velg hvilke kolonner og oppslagsseksjoner som vises i kassekladden. Gjelder bare visningen for deg.
+5146	Vis alle	Show all	Vis alle
+5147	Nyt! Klik på tandhjulet for at tilpasse din opsætning af kassekladden.	New! Click the gear to customize your setup of the cash journal.	Nytt! Klikk på tannhjulet for å tilpasse oppsettet av kassekladden.
+5148	Forstået	Got it	Skjønner

--- a/javascript/accountAutocomplete.js
+++ b/javascript/accountAutocomplete.js
@@ -12,6 +12,17 @@
         return window.saldiTranslations || {};
     }
 
+    // Per-page panel-section config (set by kassekladde.php). Pages that don't define
+    // window.saldiAutocompleteOptions (bank import, document pool, order autocomplete)
+    // keep the default behaviour: both sections shown.
+    function getPanelOptions() {
+        const opts = window.saldiAutocompleteOptions || {};
+        return {
+            showLastPostings: opts.showLastPostings !== false,
+            showAccountLookup: opts.showAccountLookup !== false
+        };
+    }
+
     let activeDropdown = null;
     let activeInput = null;
     let debounceTimer = null;
@@ -532,6 +543,17 @@
             }
         }
 
+        const panelOptions = getPanelOptions();
+        if (!panelOptions.showLastPostings && !panelOptions.showAccountLookup) {
+            closeDropdown();
+            return;
+        }
+        if (!panelOptions.showAccountLookup) {
+            // Lookup section deselected: skip the server search and show suggestions only
+            renderDropdown(input, [], searchType, searchValue, null);
+            return;
+        }
+
         let basePath = '';
         if (window.location.pathname.includes('/finans/')) {
             basePath = 'kassekladde_includes/accountSearch.php';
@@ -1013,7 +1035,8 @@
     function renderDropdown(input, results, searchType, currentSearchValueParam, pagination) {
         const dropdown = input.autocompleteDropdown;
         const trans = getTrans();
-        const lastPostings = getLastPostings(input);
+        const panelOptions = getPanelOptions();
+        const lastPostings = panelOptions.showLastPostings ? getLastPostings(input) : { heading: '', rows: [] };
         const hasLastPostings = lastPostings.rows && lastPostings.rows.length > 0;
         const columnCount = searchType === 'finance' ? 5 : 2;
 
@@ -1022,7 +1045,7 @@
         pagination = pagination || { page: 1, total: 0, hasMore: false };
 
         if (!results || results.length === 0) {
-            if (currentSearchValueParam !== '' || hasLastPostings) {
+            if ((currentSearchValueParam !== '' && panelOptions.showAccountLookup) || hasLastPostings) {
                 let noResultHtml = '<div class="account-autocomplete-no-results">' + trans.noResults + '</div>';
                 if (hasLastPostings) {
                     noResultHtml = '<div class="account-autocomplete-results">' +

--- a/javascript/accountAutocomplete.js
+++ b/javascript/accountAutocomplete.js
@@ -1,4 +1,6 @@
 
+// 20260907 CDX/LH Preserve D/K/F account types when selecting a historical counter-account.
+//                  Handle each keyboard selection once, without bubbling into a second move.
 (function () {
     'use strict'; 
 
@@ -124,7 +126,7 @@
                 focusViaKeyboardNav = true;
             }
 
-            if (activeDropdown) {
+            if (activeDropdown && !e.defaultPrevented) {
                 handleKeyboardNavigation(e);
             }
         });
@@ -668,8 +670,9 @@
 
             html += '<tr class="account-autocomplete-item account-autocomplete-last-posting-item"' +
                 ' data-kontonr="' + escapeHtml(item.kontonr || '') + '"' +
+                ' data-account-type="' + escapeHtml(item.art || '') + '"' +
                 ' data-index="last-' + index + '">' +
-                '<td>' + escapeHtml(item.kontonr || '') + '</td>' +
+                '<td>' + escapeHtml((item.art ? item.art + ' ' : '') + (item.kontonr || '')) + '</td>' +
                 '<td title="' + escapeHtml(description) + '">' + escapeHtml(description) + '</td>';
 
             for (let i = 2; i < columnCount; i++) {
@@ -1360,6 +1363,17 @@
             : undefined;
 
         input.value = kontonr;
+
+        if (input.fieldType === 'debet' || input.fieldType === 'kredit') {
+            const accountType = selectedItem ? selectedItem.dataset.accountType : '';
+            if (['D', 'K', 'F'].includes(accountType)) {
+                const typeName = (input.fieldType === 'debet' ? 'd_ty' : 'k_ty') + rowNum;
+                const typeField = (input.form || document).querySelector('input[name="' + typeName + '"]');
+                if (typeField && typeField.value !== accountType) {
+                    setFieldValue(typeField, accountType);
+                }
+            }
+        }
 
         // Dispatch both input and change events to ensure all handlers are triggered
         input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/tests/characterization/finans/JournalHistoryRegressionTest.test.php
+++ b/tests/characterization/finans/JournalHistoryRegressionTest.test.php
@@ -1,0 +1,158 @@
+<?php
+// 20260907 CDX/LH Cover typed historical suggestions and posted duplicate identity/currency.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class JournalHistoryRegressionTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite is required for the isolated journal fixtures.');
+        }
+        require_once __DIR__ . '/support/journal_history_database.php';
+        require_once dirname(__DIR__, 3) . '/finans/kassekladde_includes/journalHistory.php';
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $GLOBALS['journalHistoryTestDb'] = $this->db;
+        $this->db->exec('CREATE TABLE kassekladde (id INTEGER, bilag INTEGER, kladde_id INTEGER,
+            transdate TEXT, d_type TEXT, debet TEXT, k_type TEXT, kredit TEXT, amount NUMERIC,
+            faktura TEXT, beskrivelse TEXT)');
+        $this->db->exec('CREATE TABLE transaktioner (id INTEGER, bilag INTEGER, kladde_id INTEGER,
+            transdate TEXT, kontonr INTEGER, debet NUMERIC, kredit NUMERIC, faktura TEXT)');
+        $this->db->exec('CREATE TABLE adresser (id INTEGER, kontonr TEXT, art TEXT)');
+        $this->db->exec('CREATE TABLE openpost (konto_id INTEGER, kladde_id INTEGER, refnr INTEGER,
+            transdate TEXT, faktnr TEXT, amount NUMERIC, valutakurs NUMERIC)');
+        $this->db->exec("INSERT INTO adresser VALUES (1,'3000','K'),(2,'3001','K'),(3,'3000','D')");
+    }
+
+    public static function accountTypes(): array
+    {
+        return [['K', 'K'], ['D', 'D'], ['F', 'F'], ['', 'F'], [null, 'F']];
+    }
+
+    #[DataProvider('accountTypes')]
+    public function testSuggestionsPreserveCounterAccountType(?string $storedType, string $expectedType): void
+    {
+        $insert = $this->db->prepare("INSERT INTO kassekladde VALUES
+            (1,10,80,'2025-09-07','F','5800',?,'3000',125,'INV','Supplier payment'),
+            (2,11,80,'2025-09-08',?,'3000','F','5800',125,'INV','Customer receipt')");
+        $insert->execute([$storedType, $storedType]);
+        foreach (['D', 'K'] as $side) {
+            $suggestions = sidste_5_forslag('5800', 'F', $side, 90, 'UTF-8', 1);
+            self::assertCount(1, $suggestions['rows']);
+            self::assertSame('3000', $suggestions['rows'][0]['kontonr']);
+            self::assertSame($expectedType, $suggestions['rows'][0]['art']);
+        }
+    }
+
+    public function testSuggestionsExcludeCurrentJournalAndRetainOnlyFiveRecentRows(): void
+    {
+        for ($id = 1; $id <= 8; $id++) {
+            $this->db->exec("INSERT INTO kassekladde VALUES
+                ($id,$id,80,'2025-09-07','F','5800','F','4000',125,'INV','Historical line')");
+        }
+        $this->db->exec("INSERT INTO kassekladde VALUES
+            (9,9,90,'2025-09-09','F','5800','K','3000',125,'INV','Current line')");
+        $suggestions = sidste_5_forslag('5800', 'F', 'K', 90, 'UTF-8', 1);
+        self::assertSame([8, 7, 6, 5, 4], array_column($suggestions['rows'], 'bilag'));
+    }
+
+    public function testDraftDuplicateStillUsesTheEnteredAmount(): void
+    {
+        $this->db->exec("INSERT INTO kassekladde VALUES
+            (1,10,80,'2025-09-07','F','5800','K','3000',100,'INV','EUR payment')");
+        self::assertSame('10,80,kladde', $this->duplicate('F', '5800', 'K', '3000', 100, 750));
+    }
+
+    public static function ledgerCurrencies(): array
+    {
+        return [[100, 100], [100, 750], [12.34, 92.55]];
+    }
+
+    #[DataProvider('ledgerCurrencies')]
+    public function testPostedDuplicateUsesTheConvertedBaseAmount(float $entered, float $base): void
+    {
+        $this->ledger(5800, 4000, $base);
+        self::assertSame('20,0,bogfort', $this->duplicate('F', '5800', 'F', '4000', $entered, $base));
+        self::assertSame('0,0,0', $this->duplicate('F', '5800', 'F', '4000', $entered, $base + 1));
+    }
+
+    public static function counterpartySides(): array
+    {
+        return [['K', false, 1, 125, 100], ['D', true, 3, 125, 100], ['K', false, 1, 100, 750]];
+    }
+
+    #[DataProvider('counterpartySides')]
+    public function testPostedDuplicateRequiresTheActualCounterparty(
+        string $type, bool $debitSide, int $addressId, float $entered, float $rate
+    ): void {
+        $base = $entered * $rate / 100;
+        $this->ledger($debitSide ? 5600 : 5800, $debitSide ? 5800 : 8600, $base);
+        $signed = $debitSide ? $entered : -$entered;
+        $this->db->exec("INSERT INTO openpost VALUES ($addressId,80,20,'2025-09-07','INV',$signed,$rate)");
+        $match = $debitSide
+            ? $this->duplicate($type, '3000', 'F', '5800', $entered, $base)
+            : $this->duplicate('F', '5800', $type, '3000', $entered, $base);
+        self::assertSame('20,0,bogfort', $match);
+        $other = $debitSide
+            ? $this->duplicate($type, '3001', 'F', '5800', $entered, $base)
+            : $this->duplicate('F', '5800', $type, '3001', $entered, $base);
+        self::assertSame('0,0,0', $other);
+        $this->db->exec('DELETE FROM openpost');
+        self::assertSame('0,0,0', $debitSide
+            ? $this->duplicate($type, '3000', 'F', '5800', $entered, $base)
+            : $this->duplicate('F', '5800', $type, '3000', $entered, $base));
+    }
+
+    public function testSupplierEvidenceCannotMatchACustomerWithTheSameNumber(): void
+    {
+        $this->ledger(5800, 8600, 125);
+        $this->db->exec("INSERT INTO openpost VALUES (1,80,20,'2025-09-07','INV',-125,100)");
+        self::assertSame('0,0,0', $this->duplicate('F', '5800', 'D', '3000', 125, 125));
+    }
+
+    public function testOtherVoucherOrAmountIsNotCounterpartyEvidence(): void
+    {
+        $this->ledger(5800, 8600, 125);
+        $this->db->exec("INSERT INTO openpost VALUES
+            (1,81,20,'2025-09-07','INV',-125,100),
+            (1,80,21,'2025-09-07','INV',-125,100),
+            (1,80,20,'2025-09-07','INV',-100,100)");
+        self::assertSame('0,0,0', $this->duplicate('F', '5800', 'K', '3000', 125, 125));
+    }
+
+    public function testLedgerPairRequiresTheSameInvoiceOnBothSides(): void
+    {
+        $this->ledger(5800, 4000, 125);
+        $this->db->exec("UPDATE transaktioner SET faktura='OTHER' WHERE id=2");
+        self::assertSame('0,0,0', $this->duplicate('F', '5800', 'F', '4000', 125, 125));
+    }
+
+    public function testFiscalYearBoundariesExcludeOldLedgerRows(): void
+    {
+        $this->ledger(5800, 4000, 125);
+        self::assertSame('0,0,0', find_dublet(99, '2025-09-07', 'F', '5800', 'F', '4000',
+            125, 'INV', 125, '2026-01-01', '2026-12-31'));
+    }
+
+    private function ledger(int $debit, int $credit, float $amount): void
+    {
+        $insert = $this->db->prepare("INSERT INTO transaktioner VALUES
+            (1,20,80,'2025-09-07',?,?,0,'INV'),(2,20,80,'2025-09-07',?,0,?,'INV')");
+        $insert->execute([$debit, $amount, $credit, $amount]);
+    }
+
+    private function duplicate(string $dType, string $debit, string $kType, string $credit, float $amount, float $base): string
+    {
+        return find_dublet(99, '2025-09-07', $dType, $debit, $kType, $credit, $amount, 'INV',
+            $base, '2025-01-01', '2025-12-31');
+    }
+}

--- a/tests/characterization/finans/support/journal_history_database.php
+++ b/tests/characterization/finans/support/journal_history_database.php
@@ -1,0 +1,22 @@
+<?php
+// 20260907 CDX/LH Execute the journal history queries against an isolated in-memory database.
+
+function db_select($sql, $source) {
+    return $GLOBALS['journalHistoryTestDb']->query($sql);
+}
+
+function db_fetch_array($statement) {
+    return $statement->fetch(PDO::FETCH_ASSOC);
+}
+
+function db_escape_string($value) {
+    return str_replace("'", "''", (string)$value);
+}
+
+function dkdato($date) {
+    return date('d-m-Y', strtotime($date));
+}
+
+function findtekst($text, $language) {
+    return explode('|', $text, 2)[1];
+}

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1,0 +1,22 @@
+Run the autocomplete browser tests from the repository root after installing the development dependencies and Playwright's Chromium:
+
+```sh
+npm install
+npx playwright install chromium
+npx playwright test --config tests/ui/playwright.config.mjs
+```
+
+These tests run the application autocomplete script in a browser with an isolated form and account-search responses. They require no tenant, credentials or external services. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium installation, and `SALDI_UI_TEST_OUTPUT` to choose an artifact directory.
+
+The journal history query regressions run with PHPUnit and `pdo_sqlite`:
+
+```sh
+vendor/bin/phpunit --no-configuration tests/characterization/finans/JournalHistoryRegressionTest.test.php
+```
+
+For integration verification on a disposable tenant, cover these paths:
+
+- `sidste_5_forslag()` and `selectAccount()`: create a finance account with the same number as a supplier. Select that supplier from a bank account's recent postings, save, and post. Verify type K, the supplier open item, and the supplier control account in the ledger. Repeat in the debit direction with a customer.
+- `find_dublet()`: use matching date, invoice, bank and amount for two different suppliers. Only the actual supplier should warn, including when the source journal row has been removed and `openpost` identifies the posted supplier.
+- Currency conversion: enter EUR 100 matching ledger-only DKK 750 at rate 750. Confirm the posted-duplicate warning; use a DKK control and a different-amount negative control.
+- VAT and lookup controls: select D/K/F suggestions on both sides, check VAT clearing/defaults, and try all four combinations of history and account lookup. Confirm ordinary lookup retains its selected account type.

--- a/tests/ui/account-autocomplete.spec.mjs
+++ b/tests/ui/account-autocomplete.spec.mjs
@@ -1,0 +1,81 @@
+// 20260907 CDX/LH Exercise the real autocomplete script with typed historical counter-accounts.
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('../../javascript/accountAutocomplete.js', import.meta.url));
+
+async function openForm(page, side, initialType, rows, lookup = false) {
+    const accountField = side === 'debet' ? 'debe1' : 'kred1';
+    const typeField = side === 'debet' ? 'd_ty1' : 'k_ty1';
+    await page.route('http://saldi.test/**', route => {
+        if (route.request().url().includes('accountSearch.php')) {
+            return route.fulfill({ json: { results: [{ kontonr: '990003', beskrivelse: 'Lookup account', moms: 'K1' }] } });
+        }
+        return route.fulfill({ contentType: 'text/html', body: `<!doctype html><html><body>
+            <form id="kassekladde">
+            <input name="d_ty1" value="F"><input name="debe1">
+            <select name="dvat1"><option value=""></option><option value="K1">K1</option></select>
+            <input name="k_ty1" value="F"><input name="kred1">
+            <select name="kvat1"><option value=""></option><option value="K1">K1</option></select>
+            <input name="belo1"><input type="checkbox" name="moms1">
+            </form></body></html>` });
+    });
+    await page.goto('http://saldi.test/finans/kassekladde.php');
+    await page.locator(`[name=${typeField}]`).fill(initialType);
+    await page.locator(`[name=${accountField}]`).evaluate((input, options) => {
+        input.dataset.lastPostings = JSON.stringify({ heading: 'Recent counter-accounts', rows: options.rows });
+        window.saldiAutocompleteOptions = { showLastPostings: options.rows.length > 0, showAccountLookup: options.lookup };
+    }, { rows, lookup });
+    await page.addScriptTag({ path: script });
+}
+
+for (const side of ['debet', 'kredit']) {
+    for (const accountType of ['D', 'K', 'F']) {
+        test(`${side} historical ${accountType} selection updates account type and VAT`, async ({ page }) => {
+            const accountField = side === 'debet' ? 'debe1' : 'kred1';
+            const typeField = side === 'debet' ? 'd_ty1' : 'k_ty1';
+            const vatField = side === 'debet' ? 'dvat1' : 'kvat1';
+            const initialType = accountType === 'F' ? 'K' : 'F';
+            const errors = [];
+            page.on('pageerror', error => errors.push(error.message));
+            await openForm(page, side, initialType, [
+                { kontonr: '990003', art: accountType, dato: '07-09-2025', bilag: '10', tekst: 'Prior payment' },
+            ]);
+            await page.locator(`[name=${accountField}]`).click();
+            const suggestion = page.locator('.account-autocomplete-last-posting-item:visible');
+            const suggestionText = await suggestion.innerText();
+            await suggestion.click();
+            await expect(page.locator(`[name=${accountField}]`)).toHaveValue('990003');
+            await expect(page.locator(`[name=${typeField}]`)).toHaveValue(accountType);
+            expect(suggestionText).toContain(`${accountType} 990003`);
+            await expect(page.locator(`[name=${vatField}]`)).toHaveValue(accountType === 'F' ? 'K1' : '');
+            expect(errors).toEqual([]);
+        });
+    }
+}
+
+test('arrow keys move one row and Enter keeps the highlighted supplier type', async ({ page }) => {
+    await openForm(page, 'kredit', 'F', [
+        { kontonr: '4000', art: 'F', tekst: 'Expense' },
+        { kontonr: '990003', art: 'K', tekst: 'Supplier' },
+    ]);
+    const field = page.locator('[name=kred1]');
+    await field.click();
+    await expect(page.locator('.account-autocomplete-last-posting-item:visible')).toHaveCount(2);
+    await field.press('ArrowDown');
+    await expect(page.locator('.account-autocomplete-item.selected:visible')).toHaveAttribute('data-kontonr', '4000');
+    await field.press('ArrowDown');
+    await expect(page.locator('.account-autocomplete-item.selected:visible')).toHaveAttribute('data-kontonr', '990003');
+    await field.press('Enter');
+    await expect(field).toHaveValue('990003');
+    await expect(page.locator('[name=k_ty1]')).toHaveValue('K');
+});
+
+test('ordinary supplier lookup retains the selected account type', async ({ page }) => {
+    await openForm(page, 'kredit', 'K', [], true);
+    const field = page.locator('[name=kred1]');
+    await field.fill('990003');
+    await page.locator('.account-autocomplete-item[data-kontonr="990003"]:visible').click();
+    await expect(field).toHaveValue('990003');
+    await expect(page.locator('[name=k_ty1]')).toHaveValue('K');
+});

--- a/tests/ui/playwright.config.mjs
+++ b/tests/ui/playwright.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: '.',
+    testMatch: '**/*.spec.mjs',
+    workers: 1,
+    retries: 0,
+    reporter: 'list',
+    outputDir: process.env.SALDI_UI_TEST_OUTPUT || '../../.codex-run/ui-test-results',
+    use: {
+        browserName: 'chromium',
+        headless: true,
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+            ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+            : {},
+    },
+});


### PR DESCRIPTION
## What are the changes about?
Provide a brief explanation of the changes you have made

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


## What are the changes about?
Pre-release improvement spec for the cash journal (4 mandatory tasks + optional task 5) plus two customer follow-ups:

1. **Debug cleanup** – removed the per-line `bilag` console.log and the fiscal-year console dump (incl. its debug-only grupper query). Validation unchanged.
2. **Last-5-postings for finance accounts** – counter-account suggestions now also cover F/blank-type lines (previously D/K only). Heading via findtekst (5140). Still searches kassekladde only; extending to transaktioner is a documented later task.
3. **Duplicate warning for posted entries** – if no duplicate exists in open journals, `find_dublet()` runs a fiscal-year-constrained, indexed self-join on transaktioner pairing the voucher's debit/credit rows (limit 1). Non-blocking red highlight + new tooltip (5141). Return format extended backwards-compatibly with a source field; params SQL-escaped.
4. **Autofill off + panel sections** – `autocomplete=off` on the form and account fields kills the dark browser box; two per-user checkboxes (5142/5143) control the blue panel's suggestion/lookup sections via `window.saldiAutocompleteOptions` (default both-on, so bank import/doc pool/order autocomplete are unaffected). Script cache-busted to v4.1.5.
5. **Balance indicator** – always-visible status left of the Remark field: green "Kladden balancerer" (5144) or red difference in base currency. Display only, same sums bogfor.php validates against.

Follow-ups: the auto-balance prefill of the next line is removed (the status replaces it, and it was the source of the July duplicate-lines bug), and the settings box is restyled as the product card's gear panel (gear docked next to "Ny" in menu S, floating elsewhere; texts 5145/5146) with a dismissable first-time hint bubble (5147/5148).

Texts 5140–5148 ship via importfiler/tekster.csv (5120–5134 are reserved by unmerged branches; reusing 3382 proved collision-prone against legacy tekster rows on ssl12 — heads-up for the product card panel's 3380–3384).

**Manual test (done on ssl12):** journals with 30+ lines render with no console debug; F-line suggestions appear on saved lines; posted-duplicate turns bilag red without blocking save/post; Chrome+Firefox show no browser autofill box; all four checkbox combinations, persistence across browsers, unaffected sharing modules; balance pill red/green verified against Simulate; next-line bilag+1/date-copy intact with no amount prefill; gear panel + Show all + hint dismissal verified.

`finans/bogfor.php` untouched; no DB schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable account-lookup sections with persistent preferences.
  - Added a gear button for customizing editable journals.
  - Improved recent-posting suggestions, including account types and finance entries.
  - Added duplicate-entry detection across open and posted transactions, including currency and fiscal-year validation.

- **Bug Fixes**
  - Improved account autocomplete selection and keyboard navigation.
  - Prevented irrelevant lookup requests when panels are disabled.
  - Improved matching of duplicate transactions and counterparties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->