### PR TITLE
WP-1: navigation infrastructure fixes (return-link audit)

### DIFF
--- a/debitor/ansatte.php
+++ b/debitor/ansatte.php
@@ -22,6 +22,7 @@
 // 20221229 PHR Some cleanup
 // 20250913 LEO Added display of existing employees and top menu and "Delete all" button
 // 20260818 LH  MB-14: fixed "Uforudset hændelse" on save (guard missing 'mobile' column like kreditor/ansatte.php, redirect back to account)
+// 20260904 Sawaneh WP-1.1: header Historik/Kontokort icon retursides now target this ansatte page (urlencoded, with konto_id)
 
 @session_start();
 $s_id=session_id();
@@ -235,7 +236,9 @@ if ($menu == 'T') {
 	
 	print "</div>";
 	print "<div class=\"headerTxt\">$title</div>";
-	print "<div class=\"headerbtnRght headLink\"><a href='historikkort.php?id=$id&returside=debitorkort.php' title='" . findtekst('131|Historik', $sprog_id) . "'><i class='fa fa-history fa-lg'></i></a>&nbsp;&nbsp;<a href='rapport.php?rapportart=kontokort&konto_fra=$kontonr&konto_til=$kontonr&returside=../debitor/debitorkort.php?id=$id' title='" . findtekst('133|Kontokort', $sprog_id) . "'><i class='fa fa-vcard fa-lg'></i></a>";
+	// 20260904 WP-1.1: retursides carried the employee id (or no id at all) and only
+	// worked while the nav stack overrode them; back now targets this ansatte page.
+	print "<div class=\"headerbtnRght headLink\"><a href='historikkort.php?id=$id&returside=" . urlencode("../debitor/ansatte.php?konto_id=$konto_id") . "' title='" . findtekst('131|Historik', $sprog_id) . "'><i class='fa fa-history fa-lg'></i></a>&nbsp;&nbsp;<a href='rapport.php?rapportart=kontokort&konto_fra=$kontonr&konto_til=$kontonr&returside=" . urlencode("../debitor/ansatte.php?konto_id=$konto_id") . "' title='" . findtekst('133|Kontokort', $sprog_id) . "'><i class='fa fa-vcard fa-lg'></i></a>";
 	if (substr($rettigheder, 5, 1) == '1') {
 		print "&nbsp;&nbsp;<a href='ordreliste.php?konto_id=$id&valg=faktura&returside=../debitor/debitorkort.php?id=$id' title='" . findtekst('134|Fakturaliste', $sprog_id) . "'><i class='fa fa-dollar fa-lg'></i></a>";
 	} else {

--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -104,6 +104,7 @@
 // 20260905 SZ MB-32: blank Customer no. popped a false "must be integers" alert under PHP 8 - (float)''
 //             compared to '' is now a string comparison ("0" != ""), true, where PHP 7 compared both as
 //             0. Skip the check when the field is blank, matching debitor/debkort_save.php's SD-513 fix
+// 20260904 Sawaneh WP-1.1: Historik/Opgaveliste links now urlencode a returside that carries the card id (was id-less, masked by the nav stack)
 @session_start();
 $s_id = session_id();
 
@@ -1311,14 +1312,14 @@ if ($menu == 'T') {
 	}
 	print "</div>";
 	print "<div class=\"headerTxt\">$title</div>";
-	print "<div class=\"headerbtnRght headLink\"><a href='historikkort.php?id=$id&returside=debitorkort.php' title='" . findtekst('131|Historik', $sprog_id) . "'><i class='fa fa-history fa-lg'></i></a>&nbsp;&nbsp;<a href='rapport.php?rapportart=kontokort&layout=grid&konto_fra=$kontonr&konto_til=$kontonr&returside=../debitor/debitorkort.php?id=$id' title='" . findtekst('133|Kontokort', $sprog_id) . "'><i class='fa fa-vcard fa-lg'></i></a>";
+	print "<div class=\"headerbtnRght headLink\"><a href='historikkort.php?id=$id&returside=" . urlencode("debitorkort.php?id=$id") . "' title='" . findtekst('131|Historik', $sprog_id) . "'><i class='fa fa-history fa-lg'></i></a>&nbsp;&nbsp;<a href='rapport.php?rapportart=kontokort&layout=grid&konto_fra=$kontonr&konto_til=$kontonr&returside=../debitor/debitorkort.php?id=$id' title='" . findtekst('133|Kontokort', $sprog_id) . "'><i class='fa fa-vcard fa-lg'></i></a>";
 	if (substr($rettigheder, 5, 1) == '1') {
 		print "&nbsp;&nbsp;<a href='ordreliste.php?konto_id=$id&account_context=1&valg=faktura&returside=../debitor/debitorkort.php?id=$id' title='" . findtekst('134|Fakturaliste', $sprog_id) . "'><i class='fa fa-dollar fa-lg'></i></a>";
 	} else {
 		print "";
 	}
 	if ($jobkort) {
-		print "&nbsp;&nbsp;<a href='jobliste.php?konto_id=$id&returside=debitorkort.php' title='" . findtekst('38|Opgaveliste', $sprog_id) . "'><i class='fa fa-list-ul fa-lg'></i></a>";
+		print "&nbsp;&nbsp;<a href='jobliste.php?konto_id=$id&returside=" . urlencode("debitorkort.php?id=$id") . "' title='" . findtekst('38|Opgaveliste', $sprog_id) . "'><i class='fa fa-list-ul fa-lg'></i></a>";
 	} else {
 		print "";
 	}
@@ -2558,7 +2559,7 @@ $buttons_html = "<div class='sticky-custom-buttons' style='display: flex; justif
 if ($popup) {
     $buttons_html .= "<button type='button' onclick=\"window.open('historikkort.php?id=$id&amp;returside=../includes/luk.php', 'historik')\" style='$buttonStyle; padding: 8px 16px; cursor: pointer;' title='$tekst_historik'>" . findtekst('131|Historik', $sprog_id) . "</button>";
 } elseif ($returside != "historikkort.php") {
-    $buttons_html .= "<button type='button' onclick=\"window.location.href='historikkort.php?id=$id&amp;returside=debitorkort.php'\" style='$buttonStyle; padding: 8px 16px; cursor: pointer;' title='$tekst_historik'>" . findtekst('131|Historik', $sprog_id) . "</button>";
+    $buttons_html .= "<button type='button' onclick=\"window.location.href='historikkort.php?id=$id&amp;returside=" . urlencode("debitorkort.php?id=$id") . "'\" style='$buttonStyle; padding: 8px 16px; cursor: pointer;' title='$tekst_historik'>" . findtekst('131|Historik', $sprog_id) . "</button>";
 } else {
     $buttons_html .= "<button type='button' onclick=\"window.location.href='historikkort.php?id=$id'\" style='$buttonStyle; padding: 8px 16px; cursor: pointer;' title='$tekst_historik'>" . findtekst('131|Historik', $sprog_id) . "</button>";
 }
@@ -2610,7 +2611,7 @@ $buttons_html_escaped = str_replace("\n", "", $buttons_html_escaped);
 		print "title='$tekst'>" . findtekst('131|Historik', $sprog_id) . "<!--tekst 131--></td>\n";
 	} elseif ($returside != "historikkort.php") {
 		print "<td width='10%' $top_bund title='$tekst'><!--tekst 130-->";
-		print "<a href=historikkort.php?id=$id&returside=debitorkort.php>" . findtekst('131|Historik', $sprog_id) . "<!--tekst 131--></td>\n";
+		print "<a href=historikkort.php?id=$id&returside=" . urlencode("debitorkort.php?id=$id") . ">" . findtekst('131|Historik', $sprog_id) . "<!--tekst 131--></td>\n";
 	} else {
 		print "<td width='10%' $top_bund title='$tekst'><!--tekst 130-->";
 		print "<a href=historikkort.php?id=$id>" . findtekst('131|Historik', $sprog_id) . "<!--tekst 131--></td>\n";

--- a/debitor/debitorkort.php
+++ b/debitor/debitorkort.php
@@ -105,6 +105,7 @@
 //             compared to '' is now a string comparison ("0" != ""), true, where PHP 7 compared both as
 //             0. Skip the check when the field is blank, matching debitor/debkort_save.php's SD-513 fix
 // 20260904 Sawaneh WP-1.1: Historik/Opgaveliste links now urlencode a returside that carries the card id (was id-less, masked by the nav stack)
+// 20260907 CDX/LH Sanitize the return parameter once before navigation and order-context handling.
 @session_start();
 $s_id = session_id();
 
@@ -164,11 +165,10 @@ $queryString = $parts['query'] ?? '';
 
 ######################
 
-$backUrl = nav_back_url(isset($_GET['returside']) ? $_GET['returside'] : null);
+$returside = nav_sanitize_returside($_GET['returside'] ?? null);
+$backUrl = nav_back_url($returside);
 
-if ($_GET['returside']) {
-	
-	$returside = $_GET['returside'];
+if ($returside) {
 	$ordre_id = $_GET['ordre_id'];
 	$fokus = $_GET['fokus'];
 	// Only append ordre_id if it's not already in the returside URL

--- a/debitor/historikkort.php
+++ b/debitor/historikkort.php
@@ -25,6 +25,7 @@
 // 20241009 MMK - Added datepicker functionalaty
 // 20250808 PHR - Added $id to returside 
 // 20251121 LOE - Modified icons to SVG format and buttons to fit the new design
+// 20260904 Sawaneh WP-1.3c: luk.php returside now set on the popup=1 request flag, not the popup preference
 
 @session_start();
 $s_id = session_id();
@@ -106,7 +107,8 @@ if ($handling == 'slet') {
 if (isset($_GET['returside'])) {
 	$returside = $_GET['returside'];
 } else {
-	if ($popup) $returside = "../includes/luk.php";
+	// 20260904 Sawaneh WP-1.3c: request flag instead of popup preference
+	if (!empty($_GET['popup'])) $returside = "../includes/luk.php";
 	else $returside = "historik.php";
 }
 $returside = nav_back_url($returside);

--- a/debitor/pos_ordre.php
+++ b/debitor/pos_ordre.php
@@ -104,6 +104,7 @@
 // 20260707 MJ Add kasse to form action URL so drawer kasse is preserved on POST; restore commented-out drawer redirect in aabn_skuffe
 // 20260901 CL/LH opdater_konto: validated o_art mode from lookup row click; KO loads creditor
 //                 accounts only, and a missing/wrong-art account no longer wipes the order
+// 20260904 Sawaneh WP-1.3c: luk.php returside now set on the popup=1 request flag, not the popup preference
 @session_start();
 $s_id = session_id();
 ob_start();
@@ -596,7 +597,8 @@ $r = db_fetch_array(db_select("select box2 from grupper where art='OreDif'", __F
 $difkto = if_isset($r['box2'], NULL);
 $returside = (if_isset($_GET['returside']));
 if (!$returside) {
-	if ($popup)
+	// 20260904 Sawaneh WP-1.3c: request flag instead of popup preference
+	if (!empty($_GET['popup']))
 		$returside = "../includes/luk.php";
 	else
 		$returside = "../index/menu.php";

--- a/debitor/pos_ordre.php
+++ b/debitor/pos_ordre.php
@@ -105,6 +105,7 @@
 // 20260901 CL/LH opdater_konto: validated o_art mode from lookup row click; KO loads creditor
 //                 accounts only, and a missing/wrong-art account no longer wipes the order
 // 20260904 Sawaneh WP-1.3c: luk.php returside now set on the popup=1 request flag, not the popup preference
+// 20260907 CDX/LH Preserve popup context through POS forms, redirects and menu actions.
 @session_start();
 $s_id = session_id();
 ob_start();
@@ -136,6 +137,12 @@ $ifs = $pfs * 1.3;
 include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
+$posIsPopup = !empty($_GET['popup']) || !empty($_POST['popup']);
+$posReturnTarget = nav_sanitize_returside($_GET['returside'] ?? $_POST['returside'] ?? null);
+$posNavigationQuery = $posIsPopup ? 'popup=1&' : '';
+if ($posReturnTarget !== '') {
+	$posNavigationQuery .= 'returside=' . rawurlencode($posReturnTarget) . '&';
+}
 include("../includes/ordrefunc.php");
 include("../includes/posmenufunc.php");
 include("../debitor/func/pos_ordre_itemscan.php"); # 20190215
@@ -339,15 +346,17 @@ if ($bordvalg = if_isset($_POST['bordvalg'])) {
 		$bord = array();
 	}
 	if (count($bord) == 0) {
-		if ($bordnr || $bordnr == '0')
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?bordnr=$bordnr\">\n";
-		else
+		if ($bordnr || $bordnr == '0') {
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}bordnr=$bordnr\">\n";
+		} else {
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=../bordplaner/table_plan.php?id=$id\">\n";
+		}
 	} else {
-		if ($bordnr || $bordnr == '0')
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?bordnr=$bordnr\">\n";
-		else
+		if ($bordnr || $bordnr == '0') {
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}bordnr=$bordnr\">\n";
+		} else {
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=../bordplaner/bordplan.php?id=$id\">\n";
+		}
 	}
 	exit;
 }
@@ -377,7 +386,7 @@ if (!$id && !$bordnr && $bordnr != '0') { #20150305
 			$bordnr = $i;
 			$konto_id = if_isset($_GET['konto_id']);
 			setcookie("saldi_bordnr", $bordnr, time() + 60 * 60 * 24 * 30); #20150505-2
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?bordnr=$bordnr&konto_id=$konto_id\">\n"; #20150401
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}bordnr=$bordnr&konto_id=$konto_id\">\n"; #20150401
 			exit;
 			break 1;
 		}
@@ -456,7 +465,7 @@ if (isset($_GET['flyt_til']) && $id) { #20140508
 			}
 		}
 		transaktion('commit');
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$ny_id\">\n";
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$ny_id\">\n";
 	} else {
 		$qtxt = "select id from ordrer where art='PO' and status < '3' and nr = '$bordnr'";
 		if ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
@@ -466,7 +475,7 @@ if (isset($_GET['flyt_til']) && $id) { #20140508
 		} else {
 			db_modify("update ordrer set nr='$bordnr',hvem='$brugernavn' where id='$id'", __FILE__ . " linje " . __LINE__);
 		}
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
 	}
 } elseif (!$id && (count($bord) < 1 || (count($bord) >= 1 && ($bordnr >= '0' || isset($_GET['bordnr']))))) { #20210623
 	if (isset($_GET['bordnr']))
@@ -595,13 +604,13 @@ if (!$id || $id == 0) {
 
 $r = db_fetch_array(db_select("select box2 from grupper where art='OreDif'", __FILE__ . " linje " . __LINE__));
 $difkto = if_isset($r['box2'], NULL);
-$returside = (if_isset($_GET['returside']));
+$returside = $posReturnTarget;
 if (!$returside) {
-	// 20260904 Sawaneh WP-1.3c: request flag instead of popup preference
-	if (!empty($_GET['popup']))
+	if ($posIsPopup) {
 		$returside = "../includes/luk.php";
-	else
+	} else {
 		$returside = "../index/menu.php";
+	}
 }
 $qtxt = "select box3 from grupper where art = 'POS' and kodenr = '3' and fiscal_year = '$regnaar'";
 ($r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) ? $kundedisplay = $r['box3'] : $kundedisplay = NULL;
@@ -686,8 +695,9 @@ if (!isset($_COOKIE['saldi_pfs']) || !$_COOKIE['saldi_pfs'] || !$id) {
 		$pfs = $tmparray[$kasse - 1];
 	setcookie('saldi_pfs', $pfs, time() - 60);
 	setcookie('saldi_pfs', $pfs, time() + 60 * 60 * 24 * 365, '/');
-	if ($pfs && $pfs != $old_pfs)
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n"; # 20140424b
+	if ($pfs && $pfs != $old_pfs) {
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n"; # 20140424b
+	}
 }
 $ifs = $pfs * 1.3;
 
@@ -847,7 +857,7 @@ if ($vare_id_ny && !$vare_id) {
 		}
 	}
 	if ($id && !$vare_id_ny && !$folger && $initId == '0') { #20200112
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">";
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">";
 		exit;
 	}
 	$vare_id = $vare_id_ny;
@@ -1102,7 +1112,7 @@ if ($vare_id) {
 		$pris_ny = $kr . "," . $ore;
 	}
 	if (isset($_POST['ny']) && $_POST['ny'] == "Ny kunde") {
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php\">\n";
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}\">\n";
 		exit;
 		#		$id=0;
 #		$kontonr=0;
@@ -1168,11 +1178,11 @@ if ($vare_id) {
 	}
 	if (isset($_POST['krediter'])) {
 		list($ny_id, $samlet_pris) = explode(";", krediter_pos($id)); #20170622-1
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$ny_id&samlet_pris=$samlet_pris\">\n"; #20170622-1
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$ny_id&samlet_pris=$samlet_pris\">\n"; #20170622-1
 		$_SESSION['creditType'] = 'krediter';		# LN 20190206
 	} elseif (isset($_POST['return'])) {		# LN 20190206
 		list($ny_id, $samlet_pris) = explode(";", krediter_pos($id)); #20170622-1		
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$ny_id&samlet_pris=$samlet_pris\">\n"; #20170622-1		
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$ny_id&samlet_pris=$samlet_pris\">\n"; #20170622-1
 		$_SESSION['creditType'] = 'return';
 	} elseif (isset($_POST['Udskriv'])) {
 		$_SESSION['creditType'] = 'printReceipt';
@@ -1234,7 +1244,7 @@ if ($vare_id) {
 			print "<tr><td><br></td></tr>";
 			print "<tr><td align='center'><big>Bestillingen kan ikke nulstilles</big></td></tr>";
 			print "<tr><td><br></td></tr>";
-			print "<tr><td align='center'><input type=\"button\" style=\"width:100px;\" onclick=\"window.location.href='pos_ordre.php?id=$id'\" value=\"OK\"></td></tr>\n";
+			print "<tr><td align='center'><input type=\"button\" style=\"width:100px;\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id'\" value=\"OK\"></td></tr>\n";
 			print "</tbody></table>";
 			exit;
 		} elseif ($_POST['sum']) {
@@ -1301,7 +1311,7 @@ if ($vare_id) {
 
 	if ($indbetaling) {
 		if (substr($indbetaling, -1) == 't' || substr($modtaget, -1) == 't') { #20260204
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
 			exit;
 		}
 		$indbetaling = str_replace("a", "", $indbetaling);
@@ -1626,7 +1636,7 @@ if ($id && $gem) {
 	db_modify("update ordrelinjer set posnr=posnr*-1 where ordre_id='$id'", __FILE__ . " linje " . __LINE__);
 	db_modify("update ordrelinjer set posnr=posnr+100 where ordre_id='$id'", __FILE__ . " linje " . __LINE__);
 	#print "<BODY onLoad=\"javascript:alert('Tilbud gemt')\">\n";
-	print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php\">\n";
+	print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}\">\n";
 }
 if (!$id || $id == 0) {
 	$r = db_fetch_array(db_select("select box7,box10 from grupper where art = 'POS' and kodenr='2' and fiscal_year = '$regnaar'", __FILE__ . " linje " . __LINE__));
@@ -1686,7 +1696,7 @@ if ($tilfravalgNy && ($delFrTfv || $delFrTfv == '0')) {
 	}
 	$tilfravalgNy = trim($tilfravalgNy, chr(9));
 } else $tilfravalgNy = if_isset($_POST['tilfravalgNy']); #20220614
-print "<form name='pos_ordre' action='pos_ordre.php?id=$id&kasse=$kasse&bundmenu=$bundmenu&sidemenu=$sidemenu&bordnr=$bordnr";
+print "<form name='pos_ordre' action='pos_ordre.php?{$posNavigationQuery}id=$id&kasse=$kasse&bundmenu=$bundmenu&sidemenu=$sidemenu&bordnr=$bordnr";
 print "&del_bord=$del_bord&tilfravalgNy=" . str_replace(chr(9), '|', $tilfravalgNy) . "' method='post' autocomplete='off'>\n";
 print "<table width=\"100%\" height=\"100%\" bordercolor=\"#ffffff\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tbody>\n"; # Tabel 1 ->
 # 1 kvadrat.
@@ -1714,7 +1724,7 @@ if ($id && $betaling) {
 			if ($tracelog)
 				fwrite($tracelog, __FILE__ . " " . __LINE__ . " Calls: pos_txt_print($id,'','','','','')\n");
 			pos_txt_print($id, '', '', '', '', '');
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
 			exit;
 		}
 	} else {
@@ -1761,10 +1771,11 @@ if (strpos($betaling, onAmount())) {
 		$modtaget = $sum - $tmp;
 	}
 	$svar = afslut($id, $betaling, NULL, $modtaget, 0, NULL, NULL, NULL, NULL, $receipt_id, __LINE__);
-	if ($svar)
+	if ($svar) {
 		print "<BODY onLoad=\"javascript:alert('$svar')\">\n";
-	else
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+	} else {
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
+	}
 }
 if ($varenr_ny == 'fejl')
 	fejl($id, "$status");
@@ -1845,6 +1856,7 @@ if ($delayLoad == true) {
 }
 
 function betaling($id, $momssats, $betaling, $betaling2, $modtaget, $modtaget2, $kasse) {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	print "\n<!-- Function betaling (start)-->\n";
 	global $baseCurrency,$betalingsbet;
 	global $fokus;
@@ -1898,7 +1910,7 @@ function betaling($id, $momssats, $betaling, $betaling2, $modtaget, $modtaget2, 
 		if ($status > 2) { #20150324
 			$alert1 = findtekst(1865, $sprog_id);
 			alert("$alert1 $ref");
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
 		}
 		if ($konto_id) {
 			print "<tr><td><b>$kontonr</b>\n";
@@ -2021,6 +2033,7 @@ function betaling($id, $momssats, $betaling, $betaling2, $modtaget, $modtaget2, 
 } #endfunc betaling
 
 function skift_bruger($ny_bruger, $kode, $pwtjek) {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	global $brugernavn;
 	global $s_id;
 	global $db;
@@ -2037,7 +2050,7 @@ function skift_bruger($ny_bruger, $kode, $pwtjek) {
 		}
 		print "<table><tbody>\n";
 		print "<tr><td colspan=\"2\" align=\"center\">\n";
-		print "<form name=pos_ordre action=\"pos_ordre.php\" method=\"post\" autocomplete=\"off\">\n";
+		print "<form name=pos_ordre action=\"pos_ordre.php?{$posNavigationQuery}\" method=\"post\" autocomplete=\"off\">\n";
 		print "<big><b>" . findtekst('2251|Vælg brugernavn og angiv adgangskode', $sprog_id) . "</b></big>\n";
 		print "</td></tr>\n";
 		$stil = find_stil('select', 2, 0);
@@ -2070,11 +2083,11 @@ function skift_bruger($ny_bruger, $kode, $pwtjek) {
 			include("../includes/connect.php");
 			$qtxt = "update online set brugernavn='" . db_escape_string($brugernavn) . "' where session_id='$s_id' and db = '$db'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id&menu_id=$menu_id\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id&menu_id=$menu_id\">\n";
 		} else {
 			$alert1 = findtekst(1867, $sprog_id);
 			print "<BODY onLoad=\"javascript:alert('$ny_bruger $alert1')\">\n";
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id&menu_id=$menu_id\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id&menu_id=$menu_id\">\n";
 		}
 	} else {
 		$r = db_fetch_array(db_select("select id from brugere where brugernavn ='$ny_bruger'", __FILE__ . " linje " . __LINE__));
@@ -2089,13 +2102,14 @@ function skift_bruger($ny_bruger, $kode, $pwtjek) {
 		} else {
 			$alert = findtekst(1868, $sprog_id);
 			print "<BODY onLoad=\"javascript:alert('$alert')\">\n";
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?skift_bruger=1\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}skift_bruger=1\">\n";
 			exit;
 		}
 	}
 }
 
 function find_bon($bon) {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	global $db;
 	global $sprog_id;
 
@@ -2126,7 +2140,7 @@ function find_bon($bon) {
 	} else {
 		print "<table><tbody>\n";
 		print "<tr><td colspan=\"2\" alingn=\"center\">\n";
-		print "<form name=find_bon action=\"pos_ordre.php\" method=\"post\" autocomplete=\"off\">\n";
+		print "<form name=find_bon action=\"pos_ordre.php?{$posNavigationQuery}\" method=\"post\" autocomplete=\"off\">\n";
 		print "<big><b>" . findtekst('2249|Skriv bonnummer eller S for sidste bon', $sprog_id) . ":</b></big>\n";
 		print "</td></tr>\n";
 		#	if ($status>=3 && !$bon && $id) { #20140708
@@ -2149,6 +2163,7 @@ function find_bon($bon) {
 }
 
 function opret_posordre($konto_id, $kasse) {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	global $baseCurrency, $bordnr, $bruger_id, $brugernavn;
 	global $db;
 	global $firmanavn;
@@ -2163,7 +2178,7 @@ function opret_posordre($konto_id, $kasse) {
 		$kasse = 1;
 
 	if (file_exists("../temp/$db/$kasse.tid") && file_get_contents("../temp/$db/$kasse.tid") >= date("U")) { #20181024
-		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php\">\n";
+		print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}\">\n";
 		exit;
 	} else
 		file_put_contents("../temp/$db/$kasse.tid", date("U") + 1);
@@ -2204,7 +2219,7 @@ function opret_posordre($konto_id, $kasse) {
 	if (!$varenr_ny && ($bordnr || $bordnr == '0')) {
 		$qtxt = "select id from ordrer where art='PO' and nr = '$bordnr' and felt_5='$kasse' and status < '3'";
 		if ($r = db_fetch_array($q = db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
-			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$r[id]\">\n";
+			print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$r[id]\">\n";
 		}
 	}
 		$ordrenr = get_next_order_number('PO');
@@ -2414,6 +2429,7 @@ function opdater_konto($konto_id, $kontonr, $id, $o_art = 'PO') {
 
 function find_kasse($kasse)
 {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	global $afd, $db, $id, $regnaar, $sprog_id;
 
 	$id = (int)$id;
@@ -2428,7 +2444,7 @@ function find_kasse($kasse)
 			return ($kasse);
 	}
 	if (!$kasse || $kasse == "?") {
-		print "<form name=pos_ordre action=\"pos_ordre.php?kasse=opdat&del_bord=$del_bord&id=$id\" method=\"post\" autocomplete=\"off\">\n";
+		print "<form name=pos_ordre action=\"pos_ordre.php?{$posNavigationQuery}kasse=opdat&del_bord=$del_bord&id=$id\" method=\"post\" autocomplete=\"off\">\n";
 		$qtxt = "select * from grupper where art = 'POS' and kodenr='1' and fiscal_year = '$regnaar'";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 		$kasseantal = (int) $r['box1'];
@@ -2554,6 +2570,7 @@ function fejl($id, $fejltekst)
 
 function posbogfor($kasse, $regnstart, $reportNumber)
 {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	global $afd;
 	global $baseCurrency,$bruger_id, $brugernavn;
 	global $db;
@@ -2785,7 +2802,7 @@ function posbogfor($kasse, $regnstart, $reportNumber)
 						$txt2 = findtekst(1871, $sprog_id);
 						print "<BODY onLoad=\"javascript:alert('$alert1')\">\n";
 						exit;
-						print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?id=$id\">\n";
+						print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}id=$id\">\n";
 						exit;
 					}
 				}
@@ -3015,7 +3032,7 @@ function posbogfor($kasse, $regnstart, $reportNumber)
 	# <-- 20140709
 	setcookie("saldi_kasseoptael", NULL, time() - 10); #20200112
 	$pfnavn = "../temp/" . $db . "/kasseopg" . str_replace("-", "", $kasse) . ".txt";
-	print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?udskriv_kasseopg=$pfnavn&kasse=$kasse\">\n"; #20190813
+	print "<meta http-equiv=\"refresh\" content=\"0;URL=pos_ordre.php?{$posNavigationQuery}udskriv_kasseopg=$pfnavn&kasse=$kasse\">\n"; #20190813
 } #?id=$id&udskriv_kasseopg=$pfnavn&kasse=$kasse
 
 function kasseoptalling( // Called from cashBalance.php
@@ -3037,6 +3054,7 @@ function kasseoptalling( // Called from cashBalance.php
 	$kr_andet,
 	$optval
 ) {
+	$posNavigationQuery = nav_popup_query($_GET, $_POST);
 	$ore_10 = (int) $ore_10;
 	$ore_20 = (int) $ore_20;
 	$ore_50 = (int) $ore_50;
@@ -3171,7 +3189,7 @@ function kasseoptalling( // Called from cashBalance.php
 	print "<table><tbody>\n";
 	print "<tr><td width='30%'>";
 	print "<table><tbody>\n";
-	print "<form name=\"optael\" action=\"pos_ordre.php?id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr\" method=\"post\" autocomplete=\"off\">\n";
+	print "<form name=\"optael\" action=\"pos_ordre.php?{$posNavigationQuery}id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr\" method=\"post\" autocomplete=\"off\">\n";
 
 	
 	

--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -35,6 +35,7 @@
 // 20251021 LOE Added pagination and static header and footer
 // 20260126 PHR fixed $exitDraft
 // 20260706 MJ Optimized cash journal list entry counts for large databases.
+// 20260904 Sawaneh WP-1.4: pass GET returside (sanitised) to topLineFinans; exitDraft cast to int
 
 @session_start();
 $s_id=session_id();
@@ -199,7 +200,7 @@ print "<script LANGUAGE=\"JavaScript\" SRC=\"../javascript/moment.min.js\"></scr
 print "<script LANGUAGE=\"JavaScript\" SRC=\"../javascript/daterangepicker.min.js\" defer></script>";
 print '<link rel="stylesheet" type="text/css" href="../css/daterangepicker.css" />';
 
-$exitDraft = isset($_GET['exitDraft']) ? $_GET['exitDraft'] : null;
+$exitDraft = isset($_GET['exitDraft']) ? (int)$_GET['exitDraft'] : null;
 if ($exitDraft) {
 	$qtxt = "update kladdeliste set hvem = '', tidspkt = NULL where id = '$exitDraft'";
 	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -211,6 +212,10 @@ if (strpos(findtekst('639|Kladdeliste', $sprog_id),'undtrykke')) {
 }
 
 $valg = "Kladdeliste";
+// 20260904 Sawaneh WP-1.4: hand the incoming returside to the topline — topLineFinans
+// reads $returside, which was never populated here, so the menu's popup Luk
+// (returside=../includes/luk.php) never reached nav_back_url().
+$returside = isset($_GET['returside']) ? nav_sanitize_returside($_GET['returside']) : null;
 include("topLineFinans.php");
 include("../includes/grid.php");
 

--- a/finans/topLineFinans.php
+++ b/finans/topLineFinans.php
@@ -1,7 +1,14 @@
 <?php
-	include("../includes/oldDesign/header.php");
-	include("../includes/topline_settings.php");
+// 20260907 CDX/LH Quote and HTML-escape return links; encode nested return query values.
+/**
+ * Injected by ../includes/connect.php via the entry page that includes this file:
+ * @var string $charset
+ */
+	include(__DIR__ . '/../includes/oldDesign/header.php');
+	include(__DIR__ . '/../includes/topline_settings.php');
 	$returside = nav_back_url(isset($returside) ? $returside : null);
+	$retursideHref = htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+	$retursideQuery = rawurlencode($returside);
 
 	$border = 'border:1px';
 	$TableBG = "bgcolor=$bgcolor";
@@ -16,7 +23,7 @@
 	# Dont show close on sidebar
 	if ($menu !== "S") {
 		print "<td width=5% style=$buttonStyle>
-			<a href=$returside accesskey='L'>
+			<a href='$retursideHref' accesskey='L'>
 			<button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">
 			Luk</button></a></td>";
 	}
@@ -30,7 +37,7 @@
 							$icon_kladdeliste ".findtekst('639|Kladdeliste', $sprog_id)."
 							</button>";
 					} else {
-						print "<a href='kladdeliste.php?returside=$returside'>
+						print "<a href='kladdeliste.php?returside=$retursideQuery'>
 							<button class='headerbtn navbtn-top' style='$butUpStyle; width:100%' onMouseOver=\"this.style.cursor = 'pointer'\">
 							$icon_kladdeliste ".findtekst('639|Kladdeliste', $sprog_id)."
 							</button></a>";

--- a/includes/luk.php
+++ b/includes/luk.php
@@ -62,22 +62,33 @@ if (strpos($_SERVER['HTTP_USER_AGENT'],'Chrome')) $browser='chrome';
 elseif (strpos($_SERVER['HTTP_USER_AGENT'],'Firefox')) $browser='ff';
 elseif (strpos($_SERVER['HTTP_USER_AGENT'],'MSIE')) $browser='ie';
 
-$returside=if_isset($_GET['returside']);
+// 20260904 Sawaneh WP-1: returside sanitised (was reflected XSS/open redirect), popup=1
+//                  request flag also closes, blocked-close fallback goes to the returside
+//                  instead of the login page, and the unlock SQL params are cast/whitelisted.
+if (!function_exists('nav_sanitize_returside')) {
+	include(__DIR__ . "/stdFunc/navStack.php");
+}
+$returside=nav_sanitize_returside(if_isset($_GET['returside']));
 $tabel=if_isset($_GET['tabel']);
-$id=if_isset($_GET['id']);
-if($tabel && $id) {
+$id=(int)if_isset($_GET['id']);
+if($tabel && $id && preg_match('/^[A-Za-z_]+$/', $tabel)) {
 	if ($tabel == 'ordrer') {
 		db_modify("update ordrer set tidspkt='', hvem = case when art in ('DO','DK') then hvem else '' end where id=$id",__FILE__ . " linje " . __LINE__);
 	} else {
 		db_modify("update $tabel set tidspkt='', hvem='' where id=$id",__FILE__ . " linje " . __LINE__);
 	}
 }
+if (!isset($popup)) $popup = NULL;
+if (!empty($_GET['popup'])) $popup = 1; // request flag: this window IS a popup regardless of the user's popup preference
 if ($popup || !$returside) {
-	if ($browser=='chrome') print  "<body onload=\"javascript:closeChrome();\">";	
-	if ($browser=='ff') print  "<body onload=\"javascript:closeFF();\">";	
-	if ($browser=='ie') print  "<body onload=\"javascript:closeIE();\">";	
+	if ($browser=='chrome') print  "<body onload=\"javascript:closeChrome();\">";
+	if ($browser=='ff') print  "<body onload=\"javascript:closeFF();\">";
+	if ($browser=='ie') print  "<body onload=\"javascript:closeIE();\">";
 	print "<body onload=\"javascript:window.opener.focus();window.close();\">";
-	print "<meta http-equiv=\"refresh\" content=\"1;URL=../index/index.php\">";
+	// When window.close() is blocked (page not script-opened, e.g. inside the
+	// new-design iframe), fall back to the returside instead of the login page.
+	$lukFallback = $returside ? $returside : "../index/index.php";
+	print "<meta http-equiv=\"refresh\" content=\"1;URL=$lukFallback\">";
 } elseif ($returside) {
 	print "<meta http-equiv=\"refresh\" content=\"0;URL=$returside\">";
 }

--- a/includes/luk.php
+++ b/includes/luk.php
@@ -19,6 +19,7 @@
 //
 // Copyright (c) 2004-2011 DANOSOFT ApS
 // ------------------------------------------------------------------------------
+// 20260907 CDX/LH Restrict record unlocking to supported tables and escape refresh targets.
 ?>
 <head>
 
@@ -51,11 +52,12 @@ function closeIE() {
 </head> 
 
 <?php
-include("../includes/std_func.php");
-include("../includes/connect.php");
-$kilde=if_isset($_GET['kilde']);
+include(__DIR__ . "/std_func.php");
+include(__DIR__ . "/connect.php");
+require_once __DIR__ . '/stdFunc/unlockRecord.php';
+$kilde = $_GET['kilde'] ?? null;
 if ($kilde!='online.php') {
-	include("../includes/online.php");
+	include(__DIR__ . "/online.php");
 }
 $browser=NULL;
 if (strpos($_SERVER['HTTP_USER_AGENT'],'Chrome')) $browser='chrome';
@@ -68,16 +70,10 @@ elseif (strpos($_SERVER['HTTP_USER_AGENT'],'MSIE')) $browser='ie';
 if (!function_exists('nav_sanitize_returside')) {
 	include(__DIR__ . "/stdFunc/navStack.php");
 }
-$returside=nav_sanitize_returside(if_isset($_GET['returside']));
-$tabel=if_isset($_GET['tabel']);
-$id=(int)if_isset($_GET['id']);
-if($tabel && $id && preg_match('/^[A-Za-z_]+$/', $tabel)) {
-	if ($tabel == 'ordrer') {
-		db_modify("update ordrer set tidspkt='', hvem = case when art in ('DO','DK') then hvem else '' end where id=$id",__FILE__ . " linje " . __LINE__);
-	} else {
-		db_modify("update $tabel set tidspkt='', hvem='' where id=$id",__FILE__ . " linje " . __LINE__);
-	}
-}
+$returside = nav_sanitize_returside($_GET['returside'] ?? null);
+$tabel = $_GET['tabel'] ?? null;
+$id = (int)($_GET['id'] ?? 0);
+unlock_record($tabel, $id);
 if (!isset($popup)) $popup = NULL;
 if (!empty($_GET['popup'])) $popup = 1; // request flag: this window IS a popup regardless of the user's popup preference
 if ($popup || !$returside) {
@@ -88,8 +84,10 @@ if ($popup || !$returside) {
 	// When window.close() is blocked (page not script-opened, e.g. inside the
 	// new-design iframe), fall back to the returside instead of the login page.
 	$lukFallback = $returside ? $returside : "../index/index.php";
+	$lukFallback = htmlspecialchars($lukFallback, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 	print "<meta http-equiv=\"refresh\" content=\"1;URL=$lukFallback\">";
 } elseif ($returside) {
+	$returside = htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 	print "<meta http-equiv=\"refresh\" content=\"0;URL=$returside\">";
 }
 ?>

--- a/includes/online.php
+++ b/includes/online.php
@@ -61,6 +61,7 @@
 // 20260320 PHR cleanup (pdftk)
 // 20260402 PHR Bypass style if title = 'Bordplan'
 // 20260424 PHR Added thisDb to prevent admins updating in the wrong accunt
+// 20260904 Sawaneh WP-1.3: nav_push popup arg now uses the popup=1 request flag, not the user preference
 
 #include("../includes/connect.php"); #20211001
 if (!isset($buttonColor))    $buttonColor = '#114691';
@@ -287,7 +288,11 @@ if (isset($db_id) && isset($db) && isset($sqdb) && $db != $sqdb) { #20200928
 				db_modify("update grupper set box1='$jsvars' where  art = 'USET' and kodenr = '$bruger_id'", __FILE__ . " linje " . __LINE__);
 			}
 		}
-		nav_push(null, (bool)$popup);
+		// 20260904 Sawaneh WP-1.3: skip recording only when THIS request is a popup window
+		// (popup=1 on the URL), not when the user merely prefers popups — the preference
+		// made the nav stack permanently empty for those users, and genuine popups
+		// opened by others polluted the opener's stack.
+		nav_push(null, !empty($_GET['popup']) || !empty($_POST['popup']));
 		if ($db_ver > '3.7.4') {
 			$qtxt = "select var_value from settings where var_name = 'buttonColor' and var_grp = 'colors' and user_id = '$bruger_id'";
 			if ($r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {

--- a/includes/posmenufunc.php
+++ b/includes/posmenufunc.php
@@ -52,15 +52,19 @@
 // 20210824 PHR Set $id to 0 if NULL;
 // 20210827 PHR Removed changed made 21020812 as it does not make sense.
 // 20220209 PHR  
+// 20260907 CDX/LH Preserve explicit popup context in POS navigation and close the correct window.
 
-include("posmenufunc_includes/buttonFunc.php");
+include(__DIR__ . "/posmenufunc_includes/buttonFunc.php");
+require_once __DIR__ . '/stdFunc/navStack.php';
 
 
 if (!function_exists('menubuttons')) {
 	function menubuttons($id, $menu_id, $vare_id, $plads)
 	{
+		$posNavigationQuery = nav_popup_query($_GET, $_POST);
+		$posCloseUrl = $posNavigationQuery !== '' ? '../includes/luk.php?popup=1' : '../index/menu.php';
 
-		isset($_GET['returside']) ? $returside = $_GET['returside'] : $returside = NULL;
+		$returside = nav_sanitize_returside($_GET['returside'] ?? null);
 		global $afd, $afd_navn, $afd_lager;
 		global $betalingsbet, $bgcolor, $bgcolor2, $bgcolor4, $bgcolor5, $betvaluta, $bon, $bord, $bordnr, $bordnavn, $brugernavn;
 		global $fokus, $folger;
@@ -264,20 +268,20 @@ if (!function_exists('menubuttons')) {
 						#					print "<td><a style=\"text-decoration:none\" href=pos_ordre.php?id=$id&$menu=$menu_id&vare_id=$vare_id&vare_id_ny=$c";
 #					print "&antal_ny=$antal&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager";
 #					print "&tilfravalgNy=". str_replace(chr(9),'|',$tilfravalgNy) .">$knap</a>\n";
-						print "<td><span onclick = \"location.href = 'pos_ordre.php?id=$id&$menu=$menu_id&vare_id=$vare_id&vare_id_ny=$c";
+						print "<td><span onclick = \"location.href = 'pos_ordre.php?{$posNavigationQuery}id=$id&$menu=$menu_id&vare_id=$vare_id&vare_id_ny=$c";
 						print "&antal_ny=$antal&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager";
 						print "&tilfravalgNy=" . str_replace(chr(9), '|', $tilfravalgNy) . "'\">$knap</span>\n";
 					} elseif ($d == 2) {
 						# print "<td><a style=\"text-decoration:none\" href=pos_ordre.php?id=$id&vare_id=$vare_id&$menu=$c&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager>$knap</a>\n";
-						print "<td><span onclick = \"location.href = 'pos_ordre.php?id=$id&vare_id=$vare_id&$menu=$c";
+						print "<td><span onclick = \"location.href = 'pos_ordre.php?{$posNavigationQuery}id=$id&vare_id=$vare_id&$menu=$c";
 						print "&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager'\">$knap</span>\n";
 					} elseif ($d == 3) {
 						#					print "<td><a style=\"text-decoration:none\" href=pos_ordre.php?id=$id&konto_id=$c&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager>$knap</a>\n";
-						print "<td><span onclick = \"location.href = 'pos_ordre.php?id=$id&konto_id=$c&varenr_ny=$varenr_ny";
+						print "<td><span onclick = \"location.href = 'pos_ordre.php?{$posNavigationQuery}id=$id&konto_id=$c&varenr_ny=$varenr_ny";
 						print "&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager'\">$knap</span>\n";
 					} elseif ($d == 4) {
 						#					print "<td><a style=\"text-decoration:none\" href=pos_ordre.php?id=$id&spec_func=spec_$c&varenr_ny=$varenr_ny&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager>$knap</a>\n";
-						print "<td><span onclick = \"location.href = 'pos_ordre.php?id=$id&spec_func=spec_$c&varenr_ny=$varenr_ny";
+						print "<td><span onclick = \"location.href = 'pos_ordre.php?{$posNavigationQuery}id=$id&spec_func=spec_$c&varenr_ny=$varenr_ny";
 						print "&pris_ny=$pris_ny&folger=$folger&fokus=$fokus&bordnr=$bordnr&lager=$afd_lager'\">$knap</span>\n";
 					} elseif ($d == 5) {
 						$tmp = str_replace("background-color: ;", "background-color: $b;", $stil);
@@ -324,7 +328,7 @@ if (!function_exists('menubuttons')) {
 						} elseif ($c == '2') {
 							$txt = str_replace('$brugernavn', $brugernavn, $a);
 							$tmp = str_replace("background-color: ;", "background-color: $b;", $stil);
-							print "<td><INPUT $disabled onclick=\"window.location.href='pos_ordre.php?id=$id&skift_bruger=1&bordnr=$bordnr'\" type=\"button\" $tmp value= \"$txt\">\n";
+							print "<td><INPUT $disabled onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&skift_bruger=1&bordnr=$bordnr'\" type=\"button\" $tmp value= \"$txt\">\n";
 						} elseif ($c == '3') {
 							$txt = findtekst('2259|Del bord', $sprog_id);
 							$tmp = str_replace("background-color: ;", "background-color: $b;", $stil);
@@ -335,7 +339,7 @@ if (!function_exists('menubuttons')) {
 						} elseif ($c == '5') {
 							$txt = findtekst('2258|Find bon', $sprog_id);
 							$tmp = str_replace("background-color: ;", "background-color: $b;", $stil);
-							print "<td><input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?id=$id&find_bon=1'\" $tmp value=\"$txt\">\n";
+							print "<td><input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&find_bon=1'\" $tmp value=\"$txt\">\n";
 							#						$knap=str_replace("background-color: ;","background-color: $b;",$knap);
 #						print "<td>".$knap;
 						} elseif ($c == '6') {
@@ -344,11 +348,11 @@ if (!function_exists('menubuttons')) {
 							print "<td><INPUT $disabled $tmp TYPE=\"submit\" NAME=\"flyt_bord\" VALUE=\"$txt\">";
 						} elseif ($c == '7') {
 							$txt = findtekst('2261|Kasseoptælling', $sprog_id);
-							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr'\" $stil value=\"$txt\">\n";
+							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr'\" $stil value=\"$txt\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 						} elseif ($c == '8') {
-							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?id=$id&kasse=?&bordnr=$bordnr'\" $stil value=\"" . findtekst('931|Kasse', $sprog_id) . " $kasse\">\n";
+							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&kasse=?&bordnr=$bordnr'\" $stil value=\"" . findtekst('931|Kasse', $sprog_id) . " $kasse\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 						} elseif ($c == '9' || $c == '23') {
@@ -366,7 +370,7 @@ if (!function_exists('menubuttons')) {
 							}
 						} elseif ($c == '10') { #Luk
 							$txt = findtekst('2172|Luk', $sprog_id);
-							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='../index/menu.php'\" $stil value=\"$txt\">\n";
+							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='$posCloseUrl'\" $stil value=\"$txt\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 						} elseif ($c == '11') {
@@ -382,7 +386,7 @@ if (!function_exists('menubuttons')) {
 							$tmp = str_replace("background-color: ;", "background-color: $b;", $stil);
 							print "<td onclick=\"return confirm('" . findtekst('2398|Slet alt og start forfra', $sprog_id) . "?')\"><INPUT TYPE=\"submit\" $tmp NAME=\"forfra\" VALUE=\"$txt\" OnClick=\"pos_ordre.$fokus.value += 'f';pos_ordre.$fokus.focus();\">\n";
 						} elseif ($c == '14') {
-							$knap = "<input $disabled onclick=\"window.location.href='pos_ordre.php?id=$id&skift_bruger=2&brugernavn=$a&bordnr=$bordnr&$menu=$menu_id'\" type=\"button\" $stil value= \"$a\">\n";
+							$knap = "<input $disabled onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&skift_bruger=2&brugernavn=$a&bordnr=$bordnr&$menu=$menu_id'\" type=\"button\" $stil value= \"$a\">\n";
 							if (strtolower($brugernavn) == strtolower($a))
 								$knap = str_replace("background-color: ;", "background-color: #00ff00;", $knap);
 							else
@@ -411,7 +415,7 @@ if (!function_exists('menubuttons')) {
 							#						print "<TD onclick=\"return confirm('Tilbage til varescanning')\"><INPUT TYPE=\"submit\" $stil NAME=\"tilbage\" VALUE=\"Tilbage\" OnClick=\"pos_ordre.$fokus.value += 't';pos_ordre.$fokus.focus();\">\n";
 						} elseif ($c == '20') {
 							$txt = findtekst('2262|Ny kunde', $sprog_id);
-							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php'\" $stil value=\"$txt\">\n";
+							$knap = "<input $disabled type=\"button\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}'\" $stil value=\"$txt\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 							$r = db_fetch_array(db_select("select box13 from grupper where art = 'POS' and kodenr = '1'", __FILE__ . " linje " . __LINE__));
@@ -426,11 +430,13 @@ if (!function_exists('menubuttons')) {
 									$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 									if ($r['kodenr']) {
 										#20201109 Added '& skift_bruger=1' as skift_bruger (forced user select) was not called 
-										print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?id=0&menuvalg=$r[kodenr]&skift_bruger=1\">\n";
-									} else
-										print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?id=0&skift_bruger=1\">\n";
-								} else
-									print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?id=0\">\n";
+										print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?{$posNavigationQuery}id=0&menuvalg=$r[kodenr]&skift_bruger=1\">\n";
+									} else {
+										print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?{$posNavigationQuery}id=0&skift_bruger=1\">\n";
+									}
+								} else {
+									print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?{$posNavigationQuery}id=0\">\n";
+								}
 							}
 						} elseif ($c == '21') {
 							$txt = findtekst('2263|Korrektion', $sprog_id);
@@ -543,12 +549,12 @@ if (!function_exists('menubuttons')) {
 							print "<td><INPUT $disabled $tmp TYPE=\"submit\" NAME=\"kopi\" VALUE=\"$txt\">";
 						} elseif ($c == '44') {
 							$txt = findtekst('2264|Hent bestilling', $sprog_id);
-							$knap = "<input type=\"submit\" name=\"getOrder\" onclick=\"window.location.href='pos_ordre.php?id=$id&getOrder=true\" $disabled $tmp value=\"$txt\">\n";
+							$knap = "<input type=\"submit\" name=\"getOrder\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&getOrder=true\" $disabled $tmp value=\"$txt\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 						} elseif ($c == '45') {
 							$txt = findtekst('2265|Gem bestilling', $sprog_id);
-							$knap = "<input type=\"submit\" name=\"saveOrder\" onclick=\"window.location.href='pos_ordre.php?id=$id&saveOrder=true\" $disabled $tmp value=\"$txt\">\n";
+							$knap = "<input type=\"submit\" name=\"saveOrder\" onclick=\"window.location.href='pos_ordre.php?{$posNavigationQuery}id=$id&saveOrder=true\" $disabled $tmp value=\"$txt\">\n";
 							$knap = str_replace("background-color: ;", "background-color: $b;", $knap);
 							print "<td>" . $knap;
 						} elseif ($c == '46') {
@@ -635,6 +641,7 @@ if (!function_exists('menubuttons')) {
 if (!function_exists('systemknap')) {
 	function systemknap($system_id)
 	{
+		$posNavigationQuery = nav_popup_query($_GET, $_POST);
 		global $id;
 		global $kasse;
 		global $bord;
@@ -642,10 +649,10 @@ if (!function_exists('systemknap')) {
 		global $sprog_id;
 
 		if ($system_id == 2) {
-			$href = "pos_ordre.php?id=$id&skift_bruger=1&bordnr=$bordnr";
+			$href = "pos_ordre.php?{$posNavigationQuery}id=$id&skift_bruger=1&bordnr=$bordnr";
 			$return = "onclick=\"window.location.href='$href'\"";
 		} elseif ($system_id == 7) {
-			$href = "pos_ordre.php?id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr";
+			$href = "pos_ordre.php?{$posNavigationQuery}id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr";
 			$return = "onclick=\"window.location.href='$href'\"";
 		} elseif ($system_id == 8) {
 			$tmp = 'Bord';
@@ -653,10 +660,10 @@ if (!function_exists('systemknap')) {
 				if ($bordnr == $x)
 					$tmp = $bord[$x];
 			}
-			$href = "pos_ordre.php?id=$id&kasse=?&bordnr=$tmp";
+			$href = "pos_ordre.php?{$posNavigationQuery}id=$id&kasse=?&bordnr=$tmp";
 			$return = "onclick=\"window.location.href='$href'\"";
 		} elseif ($system_id == 10) {
-			$href = "../index/menu.php";
+			$href = $posNavigationQuery !== '' ? '../includes/luk.php?popup=1' : '../index/menu.php';
 			$return = "onclick=\"window.location.href='$href'\"";
 		} elseif ($system_id == 11) {
 			$txt = findtekst('2391|Skuffe', $sprog_id);
@@ -676,6 +683,7 @@ if (!function_exists('systemknap')) {
 if (!function_exists('tastatur')) {
 	function tastatur($kasse, $status)
 	{
+		$posNavigationQuery = nav_popup_query($_GET, $_POST);
 		print "\n<!-- Function tastatur (start)-->\n";
 
 		global $afd_lager;
@@ -725,13 +733,13 @@ if (!function_exists('tastatur')) {
 		if (!strpos($url, $_SERVER['PHP_SELF']))
 			$url .= $_SERVER['PHP_SELF'];
 		print "<tr>\n";
-		$href = "pos_ordre.php?id=$id&kasse=?&bordnr=$bordnr";
+		$href = "pos_ordre.php?{$posNavigationQuery}id=$id&kasse=?&bordnr=$bordnr";
 		print "<td width=\"$width\"><input $disabled type=\"button\" onclick=\"window.location.href='$href'\" $stil value=\"" . findtekst('931|Kasse', $sprog_id) . ": $kasse\"></td>\n";
-		$href = "pos_ordre.php?id=$id&skift_bruger=1&bordnr=$bordnr";
+		$href = "pos_ordre.php?{$posNavigationQuery}id=$id&skift_bruger=1&bordnr=$bordnr";
 		print "<td width=\"$width\"><input $disabled type=\"button\" onclick=\"window.location.href='$href'\" $stil value=\"$brugernavn\"></td>\n";
 		print "<td width=\"$width\">\n";
 		#	if ($optalassist) {
-		$href = "pos_ordre.php?id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr";
+		$href = "pos_ordre.php?{$posNavigationQuery}id=$id&kasse=$kasse&kassebeholdning=on&bordnr=$bordnr";
 		print "<input $disabled type=\"button\" onclick=\"window.location.href='$href'\" $stil value=\"Kasse\n opt&aelig;lling\">\n";
 		#	} else {
 #	}
@@ -758,13 +766,14 @@ if (!function_exists('tastatur')) {
 			#		print "<td><a href=http://$terminal_ip/pointd/point.php?url=$url&id=$id&kasse=$kasse>Kortterminal</a></td>\n"; #20131205
 		} else
 			print "<td width=\"$width\"></td>\n";
-		$href = "pos_ordre.php?id=$id&find_bon=1;";
+		$href = "pos_ordre.php?{$posNavigationQuery}id=$id&find_bon=1;";
 		print "<td width=\"$width\"><input $disabled type=\"button\" onclick=\"window.location.href='$href'\" $stil value=\"Find\n bon\"></td>\n";
 		$tmp = str_replace("background-color: $bgcolor5", 'background-color:#ff0000', $stil);
-		if ($popup)
-			$href = "../includes/luk.php";
-		else
+		if ($posNavigationQuery !== '') {
+			$href = "../includes/luk.php?popup=1";
+		} else {
 			$href = "../index/menu.php";
+		}
 		print "<td><input $disabled type=\"button\" onclick=\"window.location.href='$href'\" $tmp value=\"Luk\"></td>\n";
 		#	print "<td width=\"$width\" align=\"right\" valign=\"top\"><a href='pos_ordre.php?luk=1&returside=$returside'><div class=\"luk\"></div></a></td></tr>\n";
 		print "</tr>\n";
@@ -963,8 +972,9 @@ if (!function_exists('tastatur')) {
 			print "<TD COLSPAN=\"2\"><INPUT TYPE=\"submit\" $stil2 NAME=\"krediter\"VALUE=\"Korrektion\"></TD>\n";
 			print "<TD COLSPAN=\"2\"><INPUT TYPE=\"submit\" $stil2 NAME=\"return\"VALUE=\"Returnering\"></TD>\n"; # LN 20190205
 #		print "<TD COLSPAN=\"2\"><INPUT TYPE=\"submit\" $stil2 NAME=\"ny\"VALUE=\"Ny kunde\"></TD>\n";
-			if ($timeout && !$bon)
-				print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?id=0\">\n";
+			if ($timeout && !$bon) {
+				print "<meta http-equiv=\"refresh\" content=\"$timeout;URL=pos_ordre.php?{$posNavigationQuery}id=0\">\n";
+			}
 		}
 		print "</tr>\n";
 

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -19,6 +19,7 @@
 //                  stack (with a bare-script guard), luk.php retursides are honoured
 //                  so popup Luk closes, print pages are no longer recorded, dedup
 //                  compares the path only, and nav files are cleaned up on logout.
+// 20260907 CDX/LH Reject raw whitespace and control characters in request return targets.
 
 if (!defined('NAV_STACK_MAX'))   define('NAV_STACK_MAX',   10);
 if (!defined('NAV_DEFAULT_URL')) define('NAV_DEFAULT_URL', '../index/menu.php');
@@ -123,15 +124,20 @@ function nav_push(?string $current_url = null, bool $popup = false): void {
     _nav_write($stack);
 }
 
-function nav_sanitize_returside(?string $url): string {
+function nav_sanitize_returside($url): string {
     // Central guard for request-supplied back targets (returside). They end up in
     // meta refresh / href attributes, so reject anything that could escape an
     // attribute or navigate off-site. Root-relative paths must pass: several pages
     // send urlencode($_SERVER['REQUEST_URI']) as their returside.
     // Do NOT run this over internally-built absolute URLs (the POS print flow
     // hands saldiprint/localprint absolute retursides) — GET/POST values only.
-    if ($url === null || $url === '') return '';
-    if (strpbrk($url, "<>\"'") !== false) return '';
+    if (!is_string($url) || $url === '') return '';
+    // Raw whitespace can split an unquoted legacy attribute; embedded tabs/newlines
+    // can also disguise a URI scheme. Query values must URL-encode these characters.
+    if (preg_match('/[\x00-\x20\x7f<>"\'`]/', $url)) return '';
+    // An HTML character reference must not turn into a scheme or control character
+    // when a legacy view renders the URL. URL components use percent encoding.
+    if (preg_match('/&(?:#|[a-z][a-z0-9]*;)/i', $url)) return '';
     if (!_nav_is_safe_target($url)) return '';
     return $url;
 }

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -4,8 +4,21 @@
 // race conditions where concurrent AJAX requests overwrite the PHP session.
 //
 // Usage:
-//   nav_push()               — called once per page load in online.php
-//   nav_back_url($returside) — use in back buttons instead of $returside directly
+//   nav_push()                        — called once per page load in online.php
+//   nav_back_url($returside)          — use in back buttons instead of $returside directly
+//   nav_sanitize_returside($url)      — central guard for request-supplied back targets
+//   nav_forget() / nav_cleanup_old()  — file cleanup, called from index/logud.php
+//
+// Known limitation (documented, not fixed here): all tabs of one session share a
+// single nav file, so one tab's back-truncation can splice away another tab's
+// entries. A real fix needs a per-window key (window.name/tab token). Likewise
+// NAV_DEFAULT_URL is relative and only resolves from one-level-deep directories;
+// it cannot be made root-relative because installations may live under a subpath.
+//
+// 20260904 Sawaneh WP-1 of the return-link audit: explicit returside now beats the
+//                  stack (with a bare-script guard), luk.php retursides are honoured
+//                  so popup Luk closes, print pages are no longer recorded, dedup
+//                  compares the path only, and nav files are cleaned up on logout.
 
 if (!defined('NAV_STACK_MAX'))   define('NAV_STACK_MAX',   10);
 if (!defined('NAV_DEFAULT_URL')) define('NAV_DEFAULT_URL', '../index/menu.php');
@@ -21,7 +34,10 @@ function _nav_is_recordable(string $url): bool {
     // content iframe, not content itself — recording it lets nav_back_url()
     // hand a back button the shell's own URL, which gets loaded *into* the
     // iframe and nests a second shell (and sidebar) inside the first.
-    foreach (['luk.php', 'logud.php', 'login.php', 'ajax=1', 'index/main.php'] as $p) {
+    // udskriv/formularprint/koekkenprint are transient print/action pages: a back
+    // button must never resolve to them (it would re-print the document).
+    foreach (['luk.php', 'logud.php', 'login.php', 'ajax=1', 'index/main.php',
+              'udskriv.php', 'formularprint.php', 'koekkenprint.php'] as $p) {
         if (strpos($url, $p) !== false) return false;
     }
     return true;
@@ -47,10 +63,13 @@ function _nav_should_record(string $url): bool {
     return _nav_is_recordable($url);
 }
 
-function _nav_path(string $url): string {
-    $url = preg_replace('/[&?]returside=[^&]*/', '', $url);
+function _nav_page(string $url): string {
+    // Path only, no query/fragment: the same script with different filters counts
+    // as the same page when deduplicating, so the stack holds one entry per page
+    // (always with the newest query).
     $url = preg_replace('/#.*$/', '', $url);
-    return rtrim($url, '?&');
+    $url = preg_replace('/\?.*$/', '', $url);
+    return $url;
 }
 
 function _nav_is_safe_target(string $url): bool {
@@ -77,14 +96,19 @@ function nav_push(?string $current_url = null, bool $popup = false): void {
     if (!_nav_should_record($current_url)) return;
 
     $stack = _nav_read();
-    $norm  = _nav_path($current_url);
+    $norm  = _nav_page($current_url);
 
-    // Skip if same page as top of stack (reload / meta-refresh)
-    if (!empty($stack) && _nav_path(end($stack)) === $norm) return;
+    // Same page as top of stack (reload / filter change / meta-refresh):
+    // replace the entry so the stack keeps the newest query instead of the stale one
+    if (!empty($stack) && _nav_page(end($stack)) === $norm) {
+        $stack[count($stack) - 1] = $current_url;
+        _nav_write($stack);
+        return;
+    }
 
     // If page already exists earlier in stack (user went back), truncate there
     for ($i = count($stack) - 1; $i >= 0; $i--) {
-        if (_nav_path($stack[$i]) === $norm) {
+        if (_nav_page($stack[$i]) === $norm) {
             array_splice($stack, $i);
             break;
         }
@@ -99,19 +123,68 @@ function nav_push(?string $current_url = null, bool $popup = false): void {
     _nav_write($stack);
 }
 
+function nav_sanitize_returside(?string $url): string {
+    // Central guard for request-supplied back targets (returside). They end up in
+    // meta refresh / href attributes, so reject anything that could escape an
+    // attribute or navigate off-site. Root-relative paths must pass: several pages
+    // send urlencode($_SERVER['REQUEST_URI']) as their returside.
+    // Do NOT run this over internally-built absolute URLs (the POS print flow
+    // hands saldiprint/localprint absolute retursides) — GET/POST values only.
+    if ($url === null || $url === '') return '';
+    if (strpbrk($url, "<>\"'") !== false) return '';
+    if (!_nav_is_safe_target($url)) return '';
+    return $url;
+}
+
 function nav_back_url(?string $returside = null): string {
-    // Priority 1: nav file history — reflects where the user actually came from
+    $returside = nav_sanitize_returside($returside);
+
+    // A luk.php returside means "close this window" (popup Luk) — honour it before
+    // anything else, or the popup navigates to a page from the opener's history
+    // instead of closing.
+    if ($returside && strpos($returside, 'luk.php') !== false) {
+        return $returside;
+    }
+
     $stack = _nav_read();
+
+    // Prefer the explicit returside: report pages are rendered from POST submits,
+    // which nav_push() skips, so the stack can point at the unfiltered form while
+    // the returside carries the filters the user chose.
+    if ($returside) {
+        // ...unless the returside is a bare script name and the stack holds the
+        // same script *with* a query (typically the record id) — then the stack
+        // entry is the more precise target.
+        if (strpos($returside, '?') === false && count($stack) >= 2) {
+            $prev = $stack[count($stack) - 2];
+            if (strpos($prev, '?') !== false
+                && basename((string)parse_url($prev, PHP_URL_PATH)) === basename($returside)) {
+                return $prev;
+            }
+        }
+        return $returside;
+    }
+
     if (count($stack) >= 2) {
         return $stack[count($stack) - 2];
     }
-    // Priority 2: explicit returside — fallback for direct/bookmarked links.
-    // Request-controlled, so it's validated here (unlike the stack above, which
-    // only ever holds relative REQUEST_URI values PHP itself recorded).
-    if ($returside && strpos($returside, 'luk.php') === false && _nav_is_safe_target($returside)) {
-        return $returside;
-    }
     return NAV_DEFAULT_URL;
+}
+
+function nav_forget(): void {
+    // Called on logout, while the session id is still valid.
+    $file = _nav_file();
+    if (is_file($file)) @unlink($file);
+}
+
+function nav_cleanup_old(int $maxAgeSeconds = 172800): void {
+    // Nav files from sessions that never logged out cleanly; sweep on logout.
+    $files = glob(dirname(__DIR__, 2) . '/temp/nav_*.json');
+    if (!is_array($files)) return;
+    foreach ($files as $file) {
+        $mtime = @filemtime($file);
+        if ($mtime !== false && $mtime < time() - $maxAgeSeconds) @unlink($file);
+    }
 }
 
 endif;

--- a/includes/stdFunc/navStack.php
+++ b/includes/stdFunc/navStack.php
@@ -20,16 +20,27 @@
 //                  so popup Luk closes, print pages are no longer recorded, dedup
 //                  compares the path only, and nav files are cleaned up on logout.
 // 20260907 CDX/LH Reject raw whitespace and control characters in request return targets.
+// 20260907 CDX/LH Accept malformed request values at the navigation boundary without TypeError.
 
 if (!defined('NAV_STACK_MAX'))   define('NAV_STACK_MAX',   10);
 if (!defined('NAV_DEFAULT_URL')) define('NAV_DEFAULT_URL', '../index/menu.php');
 
 if (!function_exists('nav_push')):
 
+/**
+ * Locate the navigation file for the active session.
+ *
+ * @return string
+ */
 function _nav_file(): string {
     return dirname(__DIR__, 2) . '/temp/nav_' . preg_replace('/[^a-zA-Z0-9]/', '', session_id()) . '.json';
 }
 
+/**
+ * Exclude shells, transient actions and print endpoints from history.
+ *
+ * @return bool
+ */
 function _nav_is_recordable(string $url): bool {
     // index/main.php is the SPA shell that hosts every other page in its
     // content iframe, not content itself — recording it lets nav_back_url()
@@ -44,6 +55,11 @@ function _nav_is_recordable(string $url): bool {
     return true;
 }
 
+/**
+ * Load the current session history and remove unrecordable entries.
+ *
+ * @return list<string>
+ */
 function _nav_read(): array {
     $file = _nav_file();
     if (!is_file($file)) return [];
@@ -55,15 +71,30 @@ function _nav_read(): array {
     return array_values(array_filter($data, '_nav_is_recordable'));
 }
 
+/**
+ * Persist the ordered navigation history under an exclusive write lock.
+ *
+ * @return void
+ */
 function _nav_write(array $stack): void {
     file_put_contents(_nav_file(), json_encode($stack), LOCK_EX);
 }
 
+/**
+ * Record only navigable pages requested with GET.
+ *
+ * @return bool
+ */
 function _nav_should_record(string $url): bool {
     if ($_SERVER['REQUEST_METHOD'] === 'POST') return false;
     return _nav_is_recordable($url);
 }
 
+/**
+ * Return the path used to compare navigation entries.
+ *
+ * @return string
+ */
 function _nav_page(string $url): string {
     // Path only, no query/fragment: the same script with different filters counts
     // as the same page when deduplicating, so the stack holds one entry per page
@@ -73,6 +104,11 @@ function _nav_page(string $url): string {
     return $url;
 }
 
+/**
+ * Reject URI schemes and protocol-relative return destinations.
+ *
+ * @return bool
+ */
 function _nav_is_safe_target(string $url): bool {
     // Browsers strip leading control characters/whitespace before parsing a URL's
     // scheme, so "\tjavascript:..." would otherwise slip past the checks below.
@@ -91,6 +127,11 @@ function _nav_is_safe_target(string $url): bool {
     return true;
 }
 
+/**
+ * Record an inline page, retaining its latest query and bounding history size.
+ *
+ * @return void
+ */
 function nav_push(?string $current_url = null, bool $popup = false): void {
     if ($popup) return;
     if ($current_url === null) $current_url = $_SERVER['REQUEST_URI'];
@@ -124,6 +165,11 @@ function nav_push(?string $current_url = null, bool $popup = false): void {
     _nav_write($stack);
 }
 
+/**
+ * Validate a raw request value before it is used as a local return target.
+ *
+ * @return string
+ */
 function nav_sanitize_returside($url): string {
     // Central guard for request-supplied back targets (returside). They end up in
     // meta refresh / href attributes, so reject anything that could escape an
@@ -142,7 +188,22 @@ function nav_sanitize_returside($url): string {
     return $url;
 }
 
-function nav_back_url(?string $returside = null): string {
+/**
+ * Preserve a window's explicit popup flag when building another request URL.
+ *
+ * @return string Query prefix ending in an ampersand, or an empty string for inline pages.
+ */
+function nav_popup_query(array $get, array $post): string {
+    return !empty($get['popup']) || !empty($post['popup']) ? 'popup=1&' : '';
+}
+
+/**
+ * Resolve a request-supplied return target, rejecting arrays before string handling.
+ *
+ * @param mixed $returside Raw request value or an internally supplied return path.
+ * @return string Valid return target, previous navigation entry or the default page.
+ */
+function nav_back_url($returside = null): string {
     $returside = nav_sanitize_returside($returside);
 
     // A luk.php returside means "close this window" (popup Luk) — honour it before
@@ -177,12 +238,22 @@ function nav_back_url(?string $returside = null): string {
     return NAV_DEFAULT_URL;
 }
 
+/**
+ * Remove navigation history for the current session on logout.
+ *
+ * @return void
+ */
 function nav_forget(): void {
     // Called on logout, while the session id is still valid.
     $file = _nav_file();
     if (is_file($file)) @unlink($file);
 }
 
+/**
+ * Remove navigation files whose modification time exceeds the retention limit.
+ *
+ * @return void
+ */
 function nav_cleanup_old(int $maxAgeSeconds = 172800): void {
     // Nav files from sessions that never logged out cleanly; sweep on logout.
     $files = glob(dirname(__DIR__, 2) . '/temp/nav_*.json');

--- a/includes/stdFunc/unlockRecord.php
+++ b/includes/stdFunc/unlockRecord.php
@@ -1,0 +1,22 @@
+<?php
+// 20260907 CDX/LH Keep the close endpoint's unlock operation within its supported tables.
+
+/**
+ * Release an order or journal lock, retaining the responsible user on sales orders.
+ *
+ * @param mixed $table Request-supplied table name; only exact allowlisted names are accepted.
+ * @return void
+ */
+function unlock_record($table, int $id): void
+{
+    if (!$id || !in_array($table, ['kladdeliste', 'ordrer'], true)) {
+        return;
+    }
+
+    if ($table === 'ordrer') {
+        $query = "update ordrer set tidspkt='', hvem = case when art in ('DO','DK') then hvem else '' end where id=$id";
+    } else {
+        $query = "update kladdeliste set tidspkt='', hvem='' where id=$id";
+    }
+    db_modify($query, __FILE__ . ' linje ' . __LINE__);
+}

--- a/index/logud.php
+++ b/index/logud.php
@@ -24,6 +24,9 @@ $s_id=session_id();
 // 20150114 PK - Tilføjet session_unset,session_destroy, som tømmer alle sessions variabler
 // 20230804	LOE Minor modification
 // 20250211 Initialize $css to fix undefined variable in online.php
+// 20260904 Sawaneh WP-1.7: delete the session's nav-stack file on logout (before
+//                  session_destroy, while session_id() is still valid) and sweep
+//                  stale nav files from sessions that never logged out.
 
 $title="logud";
 $css = "";
@@ -44,6 +47,10 @@ if (isset($r['revisor'])) {
 	}	
 }
 db_modify("delete from online where session_id = '$s_id'",__FILE__ . " linje " . __LINE__);
+if (function_exists('nav_forget')) {
+	nav_forget();
+	nav_cleanup_old();
+}
 session_unset();
 session_destroy();
 if(isset($_COOKIE["saldi_std"])) {

--- a/index/main.php
+++ b/index/main.php
@@ -31,6 +31,7 @@
 // 20260730 NTR - Added translation to momsperioder.
 // 20260730 MJ Fjernede Momsperioder-link fra Finans-sidebaren; linket er nu en knap i regnskabsaar.php
 // 20260902 CL/LH Indlejrede chaty_V2 support-chatbot (wuweiworkai.com/chaty-v2) i skallen
+// 20260904 Sawaneh WP-1.6: update_iframe() tags iframe navigations with inframe=1 (context flag for hosted pages)
 @session_start();
 $s_id = session_id();
 
@@ -530,6 +531,12 @@ function brightenColor($color, $amount = 0.2) {
     const baseUrl = (location + "").split("/").splice(0, 4).join("/");
     const targetUrl = baseUrl + (uri.startsWith("/") ? uri : "/" + uri);
     const parsedTargetUrl = new URL(targetUrl);
+    // Context flag for the loaded page: it runs inside the shell's iframe, so
+    // window.close()-based flows (luk.php) can't work and back targets must stay
+    // in-frame. Set centrally here instead of on every menu link.
+    if (!parsedTargetUrl.searchParams.has('inframe')) {
+      parsedTargetUrl.searchParams.set('inframe', '1');
+    }
     const targetPath = parsedTargetUrl.pathname + parsedTargetUrl.search;
 
     if (get_iframe_path() === targetPath) {
@@ -542,7 +549,7 @@ function brightenColor($color, $amount = 0.2) {
       }
     }
 
-    iframe.src = targetUrl
+    iframe.src = parsedTargetUrl.href
   }
 
   const redirect_uri = (uri) => {

--- a/index/menu.php
+++ b/index/menu.php
@@ -35,6 +35,7 @@
 // 20250815 LOE Empty text at 110 changed to 609 for old menu [Goods]
 // 20260904 Sawaneh WP-1.3: popup window.open links now carry popup=1 so the opened
 //                  window is treated as a popup by request, not by user preference.
+// 20260907 CDX/LH Mark the POS launcher as a popup when opening it in a new window.
 
 @session_start();	# Skal angives oeverst i filen??!!
 $s_id=session_id();
@@ -182,7 +183,7 @@ function oldmenu() {
 
 	$qtxt="select id from grupper where art = 'POS' and kodenr = '1' and box1 >= '1'"; #20180807
 	if (db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__))) {
-		if ($popup)	print "<a href=\"../debitor/pos_ordre.php\" target=\"_blank\">$regnskab</a></b></big></big></td></tr>\n";
+		if ($popup)	print "<a href=\"../debitor/pos_ordre.php?popup=1\" target=\"_blank\">$regnskab</a></b></big></big></td></tr>\n";
 		else	print "<a href=\"../debitor/pos_ordre.php\">$regnskab</a></b></big></big></td></tr>\n";
 	} elseif (file_exists('../sager/sager.php')){ // Hvis 'sager.php' eksistere, skal der linkes tilbage til sagstyring
 		print "<a href=\"../sager/sager.php\">$regnskab</a></b></big></big></td></tr>\n";

--- a/index/menu.php
+++ b/index/menu.php
@@ -33,6 +33,8 @@
 // 20240108 LOE Minor modification.
 // 20250414 LOE $_SESSION['UserName'] added to query barcode for app
 // 20250815 LOE Empty text at 110 changed to 609 for old menu [Goods]
+// 20260904 Sawaneh WP-1.3: popup window.open links now carry popup=1 so the opened
+//                  window is treated as a popup by request, not by user preference.
 
 @session_start();	# Skal angives oeverst i filen??!!
 $s_id=session_id();
@@ -221,7 +223,7 @@ function oldmenu() {
 	if ($vis_finans) {
 		$tekst=findtekst(98,$sprog_id);
 		if (substr($rettigheder,2,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:kladdeliste=window.open('../finans/kladdeliste.php?returside=../includes/luk.php','kladdeliste','".$jsvars."');kladdeliste.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(105,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:kladdeliste=window.open('../finans/kladdeliste.php?returside=../includes/luk.php&popup=1','kladdeliste','".$jsvars."');kladdeliste.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(105,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../finans/kladdeliste.php?returside=../index/menu.php\">".findtekst(105,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(105,$sprog_id)."</td>\n";
@@ -230,7 +232,7 @@ function oldmenu() {
 	if ($vis_debitor) {
 		$tekst=findtekst(106,$sprog_id);
 		if (substr($rettigheder,5,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_ordrer=window.open('../debitor/ordreliste.php?menu_entry=1&reset_context=1&valg=ordrer&returside=../includes/luk.php','d_ordrer','".$jsvars."');d_ordrer.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(107,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_ordrer=window.open('../debitor/ordreliste.php?menu_entry=1&reset_context=1&valg=ordrer&returside=../includes/luk.php&popup=1','d_ordrer','".$jsvars."');d_ordrer.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(107,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../debitor/ordreliste.php?menu_entry=1&reset_context=1&valg=ordrer&returside=../index/menu.php\">".findtekst(107,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(107,$sprog_id)."</td>\n";
@@ -239,7 +241,7 @@ function oldmenu() {
 	if ($vis_kreditor) {
 		$tekst=findtekst(108,$sprog_id);
 		if (substr($rettigheder,7,1)) {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_ordrer=window.open('../kreditor/ordreliste.php?returside=../includes/luk.php','k_ordrer','".$jsvars."');k_ordrer.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(107,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_ordrer=window.open('../kreditor/ordreliste.php?returside=../includes/luk.php&popup=1','k_ordrer','".$jsvars."');k_ordrer.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(107,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../kreditor/ordreliste.php?returside=../index/menu.php\">".findtekst(107,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(107,$sprog_id)."</td>\n";
@@ -248,7 +250,7 @@ function oldmenu() {
 
 	if ($produktion) {
 		if (substr($rettigheder,14,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:p_ordrer=window.open('../produktion/ordreliste.php?returside=../includes/luk.php','p_ordrer','".$jsvars."');p_ordrer.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">  ".findtekst(605, $sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:p_ordrer=window.open('../produktion/ordreliste.php?returside=../includes/luk.php&popup=1','p_ordrer','".$jsvars."');p_ordrer.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">  ".findtekst(605, $sprog_id)."</td>\n";
 				else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../produktion/ordreliste.php?returside=../index/menu.php\">".findtekst(107,$sprog_id)."</a></td>\n";
 			} else {
 				print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(605, $sprog_id)."</td>\n";
@@ -257,7 +259,7 @@ function oldmenu() {
 		if ($vis_lager) {
 			$tekst=findtekst(109,$sprog_id);
 			if (substr($rettigheder,9,1)=='1') {
-				if ($popup) print "<td $stor_knap_bg onClick=\"javascript:lager=window.open('../lager/varer.php?returside=../includes/luk.php','lager','".$jsvars."');lager.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(609,$sprog_id)."</td>\n";
+				if ($popup) print "<td $stor_knap_bg onClick=\"javascript:lager=window.open('../lager/varer.php?returside=../includes/luk.php&popup=1','lager','".$jsvars."');lager.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(609,$sprog_id)."</td>\n";
 				else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../lager/varer.php?returside=../index/menu.php\">".findtekst(609,$sprog_id)."</a></td>\n";
 			} else {
 				$row = db_fetch_array(db_select("select ansat_id from brugere where brugernavn = '$brugernavn'",__FILE__ . " linje " . __LINE__));
@@ -270,7 +272,7 @@ function oldmenu() {
 						if ($row= db_fetch_array(db_select("select afd from ansatte where navn = '$ref'",__FILE__ . " linje " . __LINE__))) {
 							if ($row= db_fetch_array(db_select("select beskrivelse, kodenr from grupper where box1='$row[afd]' and art='LG'",__FILE__ . " linje " . __LINE__))) {
 								$lager=$row['kodenr']*1;
-								if ($popup) print "<td $stor_knap_bg onClick=\"javascript:lager=window.open('../lager/beholdningsliste.php?returside=../index/menu.php?returside=../includes/luk.php','lager','".$jsvars."');lager.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" >".findtekst(111,$sprog_id)."</td>\n";
+								if ($popup) print "<td $stor_knap_bg onClick=\"javascript:lager=window.open('../lager/beholdningsliste.php?returside=../index/menu.php?returside=../includes/luk.php&popup=1','lager','".$jsvars."');lager.focus();\"	onMouseOver=\"this.style.cursor = 'pointer'\" >".findtekst(111,$sprog_id)."</td>\n";
 								print "<td $stor_knap_bg><a href=\"../lager/beholdningsliste.php?returside=../index/menu.php\">".findtekst(111,$sprog_id)."</td>\n";
 						}
 					}
@@ -284,7 +286,7 @@ function oldmenu() {
 	}
 	$tekst=findtekst(112,$sprog_id);
 	if (substr($rettigheder,0,1)=='1') {
-		if ($popup) print "<td $stor_knap_bg onClick=\"javascript:kontoplan=window.open('../systemdata/kontoplan.php?returside=../includes/luk.php','kontoplan','".$jsvars."');kontoplan.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(113,$sprog_id)."</td>\n";
+		if ($popup) print "<td $stor_knap_bg onClick=\"javascript:kontoplan=window.open('../systemdata/kontoplan.php?returside=../includes/luk.php&popup=1','kontoplan','".$jsvars."');kontoplan.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(113,$sprog_id)."</td>\n";
 		else  print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../systemdata/kontoplan.php?returside=../index/menu.php\">".findtekst(113,$sprog_id)."</a></td>\n";
 #		print "<td $stor_knap_bg title=\"Paperflow\"><a href=\"../paperpdf/papflowselct.php\">"."Paperflow"."</a></td>\n";
 	} else {
@@ -296,7 +298,7 @@ function oldmenu() {
 	if ($vis_finans) {
 		$tekst=findtekst(114,$sprog_id);
 		if (substr($rettigheder,3,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:regnskab=window.open('../finans/regnskab.php?returside=../includes/luk.php','regnskab','".$jsvars."');regnskab.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(115,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:regnskab=window.open('../finans/regnskab.php?returside=../includes/luk.php&popup=1','regnskab','".$jsvars."');regnskab.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(115,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../finans/regnskab.php?returside=../index/menu.php\">".findtekst(115,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(115,$sprog_id)."</td>\n";
@@ -305,7 +307,7 @@ function oldmenu() {
 	if ($vis_debitor) {
 		$tekst=findtekst(116,$sprog_id);
 		if (substr($rettigheder,6,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_konti=window.open('../debitor/debitor.php?returside=../includes/luk.php','d_konti','".$jsvars."');d_konti.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(117,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_konti=window.open('../debitor/debitor.php?returside=../includes/luk.php&popup=1','d_konti','".$jsvars."');d_konti.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(117,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../debitor/debitor.php?returside=../index/menu.php\">".findtekst(117,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(117,$sprog_id)."</td>\n";
@@ -314,7 +316,7 @@ function oldmenu() {
 	if ($vis_kreditor) {
 		$tekst=findtekst(118,$sprog_id);
 		if (substr($rettigheder,8,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_konti=window.open('../kreditor/kreditor.php?returside=../includes/luk.php','k_konti','".$jsvars."');k_konti.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(117,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_konti=window.open('../kreditor/kreditor.php?returside=../includes/luk.php&popup=1','k_konti','".$jsvars."');k_konti.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(117,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../kreditor/kreditor.php?returside=../index/menu.php\">".findtekst(117,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(117,$sprog_id)."</td>\n";
@@ -323,7 +325,7 @@ function oldmenu() {
 
 	if ($produktion) {
 		if (substr($rettigheder,15,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../tidsreg/index.php?returside=../includes/luk.php','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" >  Tidsreg</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../tidsreg/index.php?returside=../includes/luk.php&popup=1','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" >  Tidsreg</td>\n";
     		else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../tidsreg/index.php?returside=../index/menu.php>Tidsreg</a></td>\n";
 			} else {
 				print "<td $stor_knap_bg><span style=\"color:#999;\"><a onfocus=\"this.style.color='#888888'\" onblur=\"this.style.color='#888888'\">Tidsreg</td>\n";
@@ -332,7 +334,7 @@ function oldmenu() {
 		if ($vis_lager) {
 		$tekst=findtekst(181,$sprog_id);
 			if (substr($rettigheder,10,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:modtageliste=window.open('../lager/modtageliste.php?returside=../includes/luk.php','modtageliste','".$jsvars."');modtageliste.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(182,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:modtageliste=window.open('../lager/modtageliste.php?returside=../includes/luk.php&popup=1','modtageliste','".$jsvars."');modtageliste.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(182,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../lager/modtageliste.php?returside=../index/menu.php\">".findtekst(182,$sprog_id)."</a></td>\n";
 			} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\">".findtekst(182,$sprog_id)."</td>\n";
@@ -340,10 +342,10 @@ function oldmenu() {
 	}
 	$tekst=findtekst(121,$sprog_id);
 	if (substr($rettigheder,1,1)=='1') {
-		if ($popup) print "<td  $stor_knap_bg onClick=\"javascript:syssetup=window.open('../systemdata/syssetup.php?returside=../includes/luk.php','syssetup','".$jsvars."');syssetup.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(122,$sprog_id)."</td>\n";
+		if ($popup) print "<td  $stor_knap_bg onClick=\"javascript:syssetup=window.open('../systemdata/syssetup.php?returside=../includes/luk.php&popup=1','syssetup','".$jsvars."');syssetup.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(122,$sprog_id)."</td>\n";
 		else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../systemdata/syssetup.php?returside=../index/menu.php\">".findtekst(122,$sprog_id)."</a></td>\n";
 	} else {
-		if ($popup) print "<td $stor_knap_bg onClick=\"javascript:brugerdata=window.open('../systemdata/brugerdata.php?returside=../includes/luk.php','brugerdata','".$jsvars."');brugerdata.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(122,$sprog_id)."</td>\n";
+		if ($popup) print "<td $stor_knap_bg onClick=\"javascript:brugerdata=window.open('../systemdata/brugerdata.php?returside=../includes/luk.php&popup=1','brugerdata','".$jsvars."');brugerdata.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(122,$sprog_id)."</td>\n";
 		else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../systemdata/brugerdata.php?returside=../index/menu.php\">".findtekst(122,$sprog_id)."</a></td>\n";
 	}
 	print "</tr>\n";
@@ -352,10 +354,10 @@ function oldmenu() {
 	if ($vis_finans) {
 		$tekst=findtekst(123,$sprog_id);
 		if (substr($rettigheder,4,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:f_rapport=window.open('../finans/rapport.php?returside=../includes/luk.php','f_rapport','".$jsvars."');f_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:f_rapport=window.open('../finans/rapport.php?returside=../includes/luk.php&popup=1','f_rapport','".$jsvars."');f_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../finans/rapport.php?returside=../index/menu.php\">".findtekst(124,$sprog_id)."</a></td>\n";
 		} elseif ($provision) {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:provisionsrapport=window.open('../finans/provisionsrapport.php?returside=../includes/luk.php','provisionsrapport','".$jsvars."');provisionsrapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">  Provision</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:provisionsrapport=window.open('../finans/provisionsrapport.php?returside=../includes/luk.php&popup=1','provisionsrapport','".$jsvars."');provisionsrapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">  Provision</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../finans/provisionsrapport.php?returside=../index/menu.php\">".findtekst(124,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\"><a onfocus=\"this.style.color='#888888'\" onblur=\"this.style.color='#888888'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
@@ -365,7 +367,7 @@ function oldmenu() {
 	if ($vis_debitor) {
 		$tekst=findtekst(125,$sprog_id);
 		if (substr($rettigheder,12,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_rapport=window.open('../debitor/rapport.php?returside=../includes/luk.php','d_rapport','".$jsvars."');d_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:d_rapport=window.open('../debitor/rapport.php?returside=../includes/luk.php&popup=1','d_rapport','".$jsvars."');d_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../debitor/rapport.php?returside=../index/menu.php\">".findtekst(124,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\"><a onfocus=\"this.style.color='#888888'\" onblur=\"this.style.color='#888888'\">".findtekst(124,$sprog_id)."</td>\n";
@@ -375,7 +377,7 @@ function oldmenu() {
 	if ($vis_kreditor) {
 		$tekst=findtekst(126,$sprog_id);
 		if (substr($rettigheder,13,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../kreditor/rapport.php?returside=../includes/luk.php','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../kreditor/rapport.php?returside=../includes/luk.php&popup=1','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../kreditor/rapport.php?returside=../index/menu.php\">".findtekst(124,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\"><a onfocus=\"this.style.color='#888888'\" onblur=\"this.style.color='#888888'\">".findtekst(124,$sprog_id)."</td>\n";
@@ -388,7 +390,7 @@ function oldmenu() {
 	if ($vis_lager) {
 		$tekst=findtekst(127,$sprog_id);
 		if (substr($rettigheder,15,1)=='1') {
-			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../lager/rapport.php?returside=../includes/luk.php','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
+			if ($popup) print "<td $stor_knap_bg onClick=\"javascript:k_rapport=window.open('../lager/rapport.php?returside=../includes/luk.php&popup=1','k_rapport','".$jsvars."');k_rapport.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(124,$sprog_id)."</td>\n";
 			else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../lager/rapport.php?returside=../index/menu.php\">".findtekst(124,$sprog_id)."</a></td>\n";
 		} else {
 			print "<td $stor_knap_bg><span style=\"color:#999;\"><a onfocus=\"this.style.color='#888888'\" onblur=\"this.style.color='#888888'\">".findtekst(124,$sprog_id)."</td>\n";
@@ -396,7 +398,7 @@ function oldmenu() {
 	}
 	$tekst=findtekst(128,$sprog_id);
 	if (substr($rettigheder,11,1)=='1') {
-		if ($popup) print "<td  $stor_knap_bg onClick=\"javascript:backup=window.open('../admin/backup.php?returside=../includes/luk.php','backup','".$jsvars."');backup.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(521,$sprog_id)."</td>\n"; #20210223
+		if ($popup) print "<td  $stor_knap_bg onClick=\"javascript:backup=window.open('../admin/backup.php?returside=../includes/luk.php&popup=1','backup','".$jsvars."');backup.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\" title=\"$tekst\">".findtekst(521,$sprog_id)."</td>\n"; #20210223
 		else print "<td $stor_knap_bg title=\"$tekst\"><a href=\"../admin/backup.php?returside=../index/menu.php\">".findtekst(521,$sprog_id)."</a></td>\n"; #20210223
 	} else {
 		print "<td $stor_knap_bg><span style=\"color:#999;\">Backup</td>\n";
@@ -413,7 +415,7 @@ function oldmenu() {
 	print	"</center></body></html>\n";
 	$query = db_select("select * from grupper where art = 'RA'",__FILE__ . " linje " . __LINE__);
 	if (!$row = db_fetch_array($query)) {
-		if ($popup) print "<body onLoad=\"JavaScript:regnaar=window.open('../systemdata/regnskabsaar.php?returside=../includes/luk.php','regnaar',',.$jsvars.,alwaysraised=yes');regnaar.focus();regnaar.focus();\">\n";
+		if ($popup) print "<body onLoad=\"JavaScript:regnaar=window.open('../systemdata/regnskabsaar.php?returside=../includes/luk.php&popup=1','regnaar',',.$jsvars.,alwaysraised=yes');regnaar.focus();regnaar.focus();\">\n";
 		else print "<meta http-equiv=\"refresh\" content=\"0;URL=../systemdata/regnskabskort.php?returside=../index/menu.php\">\n";
 	}
 }

--- a/lager/modtagelse.php
+++ b/lager/modtagelse.php
@@ -16,6 +16,7 @@
 //
 // Copyright (c) 2004-2008 DANOSOFT ApS
 // ----------------------------------------------------------------------
+// 20260904 Sawaneh WP-1.3c: luk.php returside now set on the popup=1 request flag, not the popup preference
 
 @session_start();
 $s_id = session_id();
@@ -37,7 +38,8 @@ include("../includes/topline_settings.php");
 
 $returside = (if_isset($_GET['returside']));
 if (!$returside) {
-	if ($popup)
+	// 20260904 Sawaneh WP-1.3c: request flag instead of popup preference
+	if (!empty($_GET['popup']))
 		$returside = "../includes/luk.php";
 	else
 		$returside = "modtageliste.php";

--- a/lager/varekort.php
+++ b/lager/varekort.php
@@ -117,6 +117,7 @@
 //             > 0, and unchecking it did nothing since those fields kept their old
 //             values. Now zero the multipliers when the box is unchecked so "off"
 //             actually persists and stops updateProductPrice.php's auto-overwrite too.
+// 20260907 CDX/LH Retain popup context through product-card saves and local navigation.
 ob_start(); //Starts output buffering
 
 @session_start();
@@ -166,6 +167,7 @@ $css = "../css/standard.css";
 include("../includes/connect.php");
 include("../includes/online.php");
 include("../includes/std_func.php");
+$productNavigationQuery = nav_popup_query($_GET, $_POST);
 include("../includes/vareopslag.php"); # 20090514
 include("../includes/stykliste.php");
 include("../includes/fuld_stykliste.php");
@@ -228,7 +230,8 @@ if (!$numberOfStocks)
 
 $opener = if_isset($_GET['opener']);
 $id = if_isset($_GET['id']) * 1;
-if (isset($_GET['returside']) && $returside = $_GET['returside']) {
+$returside = nav_sanitize_returside($_GET['returside'] ?? null);
+if ($returside) {
     $ordre_id = if_isset($_GET['ordre_id']) * 1;
     $fokus = if_isset($_GET['fokus']);
     $vare_lev_id = if_isset($_GET['leverandor']);
@@ -296,10 +299,10 @@ if ($acceptStockChange) {
         lagerreguler($id, $ny_lagerbeh[$x], $cost, $x, date("Y-m-d"), '0');
         #       }
     }
-    print "<meta http-equiv='refresh' content='0;URL=varekort.php?id=$id'>";
+    print "<meta http-equiv='refresh' content='0;URL=varekort.php?{$productNavigationQuery}id=$id'>";
     exit;
 } elseif ($cancelStockChange) {
-    print "<meta http-equiv='refresh' content='0;URL=varekort.php?id=$id'>";
+    print "<meta http-equiv='refresh' content='0;URL=varekort.php?{$productNavigationQuery}id=$id'>";
     exit;
 }
 if (isset($_POST['copy']) && $_POST['copy'])
@@ -365,7 +368,7 @@ if ($saveItem || $submit = trim($submit)) {
     $note_on_orderline = (if_isset($_POST['note_on_orderline']) == 'on') ? true : false;
     $notesInternal = db_escape_string(trim(if_isset($_POST['notesInternal'])));
     $ordre_id = if_isset($_POST['ordre_id']);
-    $returside = if_isset($_POST['returside']);
+    $returside = nav_sanitize_returside($_POST['returside'] ?? null);
     $fokus = if_isset($_POST['fokus']);
     $vare_sprogantal = if_isset($_POST['vare_sprogantal']);
     $vare_sprog_id = if_isset($_POST['vare_sprog_id']);
@@ -827,7 +830,7 @@ if ($saveItem || $submit = trim($submit)) {
             $query = db_select("select id from varer where lower(varenr) = '" . strtolower($varenr) . "' or  upper(varenr) = '" . strtoupper($varenr) . "'", __FILE__ . " linje " . __LINE__);
             $row = db_fetch_array($query);
             if ($row['id']) {
-                print "<meta http-equiv='refresh' content='0;URL=varekort.php?id=$row[id]'>";
+                print "<meta http-equiv='refresh' content='0;URL=varekort.php?{$productNavigationQuery}id=$row[id]'>";
                 exit;
             } elseif ($varenr) {
                 $query = db_select("SELECT var_value FROM settings WHERE var_name = 'min_beholdning' AND var_grp = 'productOptions'", __FILE__ . " linje " . __LINE__);
@@ -1167,10 +1170,9 @@ if ($stockItem) {
     sync_shop_price($id);
 }
 
-if ($popup && !$returside)
-    $returside = "../includes/luk.php";
-elseif (!$returside)
-    $returside = "varer.php";
+if (!$returside) {
+    $returside = $productNavigationQuery !== '' ? "../includes/luk.php?popup=1" : "varer.php";
+}
 $tekst = findtekst('154|Dine ændringer er ikke blevet gemt! Tryk OK for at forlade siden uden at gemme.', $sprog_id);
 
 if ($begin)
@@ -1269,7 +1271,7 @@ if ($menu == 'T') {
         <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $icon_posmenu . "POS menuer" . "</button></a></td>\n";
         }
         # Create new item
-        $confirmNewUrl = htmlspecialchars(json_encode("varekort.php?opener=$opener&returside=$returside&ordre_id=$id"), ENT_QUOTES);
+        $confirmNewUrl = htmlspecialchars(json_encode("varekort.php?{$productNavigationQuery}opener=$opener&returside=$returside&ordre_id=$id"), ENT_QUOTES);
         print "<td width='10%' align='right'>
          <a href=\"javascript:confirmClose($confirmNewUrl,$confirmTekst)\" accesskey=N>
          <button type='button' class='center-btn' style='$buttonStyle; width:100%; justify-content:flex-start' onMouseOver=\"this.style.cursor='pointer'\">" . $add_icon . findtekst('39|Ny', $sprog_id) . "</button></a></td>\n";
@@ -1293,8 +1295,9 @@ if ($menu == 'T') {
         print "<td width=\"10%\" $top_bund align=\"right\"><a href=\"javascript:console.log(getCookie('pos_menu_location'));confirmClose(`../systemdata/posmenuer.php?menu_id=\${getCookie('pos_menu_location').split('-')[0]}&ret_row=\${getCookie('pos_menu_location').split('-')[1]}&ret_col=\${getCookie('pos_menu_location').split('-')[2]}`,'$tekst'); \" accesskey=B>" . "POS menuer" . "</a>\n";
 
     # Create new item
-    if ($id)
-        print "<td width=\"10%\" $top_bund align=\"right\"><a href=\"javascript:confirmClose('varekort.php?opener=$opener&returside=$returside&ordre_id=$id','$tekst')\" accesskey=N>".findtekst('39|Ny', $sprog_id)."</a>\n";
+    if ($id) {
+        print "<td width=\"10%\" $top_bund align=\"right\"><a href=\"javascript:confirmClose('varekort.php?{$productNavigationQuery}opener=$opener&returside=$returside&ordre_id=$id','$tekst')\" accesskey=N>".findtekst('39|Ny', $sprog_id)."</a>\n";
+    }
     print "</td></tbody></table>\n";
     print "</td></tr>\n";
     print "<td align = center valign = center>\n";
@@ -1581,7 +1584,7 @@ if (!isset($varianter))
 if (!isset($ant_be_af))
     $ant_be_af = NULL;
 
-print "<form name='varekort' action='varekort.php?opener=$opener' method='post'>\n";
+print "<form name='varekort' action='varekort.php?{$productNavigationQuery}opener=$opener' method='post'>\n";
 
 print "<input type = 'hidden' name=id value='$id'>\n";
 print "<input type = 'hidden' name=ordre_id value='$ordre_id'>\n";
@@ -1931,7 +1934,7 @@ if (!$varenr) {
     # Vises hvis varen indegår i en stykliste
     if ($delvare == 'on') {
         if ($vis_samlevarer) {
-            print "<tr><td valign=top width=10%><span title='Klik her for at lukke oversigten'><a href=varekort.php?opener=$opener&id=$id&returside=$returside>Indg&aring;r i</a></td><td></td><td><table width=80% border=0><tbody>";
+            print "<tr><td valign=top width=10%><span title='Klik her for at lukke oversigten'><a href=varekort.php?{$productNavigationQuery}opener=$opener&id=$id&returside=$returside>Indg&aring;r i</a></td><td></td><td><table width=80% border=0><tbody>";
             print "<tr><td> Pos.</td><td width=80> V.nr.</td><td width=300> Beskrivelse</td><td> Antal</td></tr>";
             for ($x = 1; $x <= $ant_indg_i; $x++) {
                 print "<tr><td><input class=\"inputbox\" type = 'text' size=2 name=indg_i_ant[$x] value=$x></td><td><a href='?id=$indg_i_id[$x]'>$indg_i_vnr[$x]</a></td><td>$indg_i_beskrivelse[$x]</td><td align=\"right\">$indg_i_ant[$x]</td></tr>";
@@ -1939,7 +1942,7 @@ if (!$varenr) {
             print "<input type=\"hidden\" name=\"vis_samlevarer\" value=\"on\">";
         } else {
             print "<tr><td colspan=3><table width=100% border='0' cellspacing='1'><tbody>";
-            print "<tr><td width=100% align=center><a href=varekort.php?opener=$opener&id=$id&returside=$returside&vis_samlevarer=on>Denne vare indg&aring;r i andre varer - Klik for oversigt</a></td></tr>";
+            print "<tr><td width=100% align=center><a href=varekort.php?{$productNavigationQuery}opener=$opener&id=$id&returside=$returside&vis_samlevarer=on>Denne vare indg&aring;r i andre varer - Klik for oversigt</a></td></tr>";
         }
 
         #   print "<tr><td><input class=\"inputbox\" type = 'text' size=2 name=indg_i_ant[$x] value=$x></td><td colspan=2><SELECT class=\"inputbox\" NAME=indg_i_ant[0]>";
@@ -2099,6 +2102,7 @@ function prisopdat_xx($id)
 
 function kategorier($x, $id, $kat_niveau, $kategori_antal, $kat_id, $kategori, $kat_beskrivelse, $kat_master)
 {
+    $productNavigationQuery = nav_popup_query($_GET, $_POST);
     global $sprog_id;
     $checked = "";
     for ($y = 0; $y <= $kategori_antal; $y++) {
@@ -2116,8 +2120,8 @@ function kategorier($x, $id, $kat_niveau, $kategori_antal, $kat_id, $kategori, $
     $tekst = findtekst('395|Afmærk her for at knytte $firmanavn til denne kategori', $sprog_id);
     #               $tekst=str_replace('$firmanavn',$firmanavn,$tekst); 
     print "<td title=\"$tekst\" align=\"center\"><!--tekst 395--><input type=\"checkbox\" name=\"kat_valg[$x]\" $checked></td>\n";
-    print "<td title=\"".findtekst('396|Klik her for at omdøbe denne kategori', $sprog_id)."\"><!--tekst 396--><a href=\"varekort.php?id=$id&    =$kat_id\" onclick=\"return confirm('Vil du omd&oslash;be denne kategori?')\"><img src=../ikoner/rename.png border=0></a></td>\n";
-    print "<td title=\"".findtekst('397|Klik her for at slette denne kategori', $sprog_id)."\"><!--tekst 396--><a href=\"varekort.php?id=$id&delete_category=$kat_id\" onclick=\"return confirm('Vil du slette denne katagori?')\"><img src=../ikoner/delete.png border=0></a></td>\n";
+    print "<td title=\"".findtekst('396|Klik her for at omdøbe denne kategori', $sprog_id)."\"><!--tekst 396--><a href=\"varekort.php?{$productNavigationQuery}id=$id&    =$kat_id\" onclick=\"return confirm('Vil du omd&oslash;be denne kategori?')\"><img src=../ikoner/rename.png border=0></a></td>\n";
+    print "<td title=\"".findtekst('397|Klik her for at slette denne kategori', $sprog_id)."\"><!--tekst 396--><a href=\"varekort.php?{$productNavigationQuery}id=$id&delete_category=$kat_id\" onclick=\"return confirm('Vil du slette denne katagori?')\"><img src=../ikoner/delete.png border=0></a></td>\n";
     print "</tr>\n";
     print "<input type=\"hidden\" name=\"kat_id[$x]\" value=\"$kat_id\">\n";
 } # endfunc kategorier
@@ -2188,6 +2192,7 @@ function cirkeltjek($vare_id)
 ######################################################################################################################################
 function kontoopslag($sort, $fokus, $id)
 {
+    $productNavigationQuery = nav_popup_query($_GET, $_POST);
     global $bgcolor2;
     global $top_bund;
     global $returside;
@@ -2229,21 +2234,21 @@ function kontoopslag($sort, $fokus, $id)
 
     } else {
         print "<table width='100%'><tbody>";
-        print "<td width=\"10%\" $top_bund><a href=varekort.php?opener=$opener&returside=$returside&ordre_id=$ordre_id&vare_id=$id&id=$id&fokus=$fokus accesskey=L>Luk</a></td>";
+        print "<td width=\"10%\" $top_bund><a href=varekort.php?{$productNavigationQuery}opener=$opener&returside=$returside&ordre_id=$ordre_id&vare_id=$id&id=$id&fokus=$fokus accesskey=L>Luk</a></td>";
         print "<td width=\"80%\" $top_bund align=\"center\">Varekort</td>";
         print "<td width=\"10%\" $top_bund align=\"right\" onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"JavaScript:window.open('../kreditor/kreditorkort.php?returside=../includes/luk.php', '', 'statusbar=no,menubar=no,titlebar=no,toolbar=no,scrollbars=yes,resizable=yes');\"><u>Ny</u></td>";
         print "</tbody></table></td></tr>";
     }
     print "<table width='100%'><tbody>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=kontonr&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Kontonr</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=firmanavn&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Navn</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=addr1&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Adresse</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=addr2&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Adresse2</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=postnr&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Postnr</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=bynavn&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>bynavn</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=land&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>land</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=kontonr&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Kontonr</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=firmanavn&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Navn</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=addr1&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Adresse</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=addr2&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Adresse2</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=postnr&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Postnr</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=bynavn&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>bynavn</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=land&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>land</b></td>";
     #   print"<td><b><a href=varekort.php?opener=$opener&sort=kontakt&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Kontaktperson</b></td>";
-    print "<td><b><a href=varekort.php?opener=$opener&sort=tlf&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Telefon</b></td>";
+    print "<td><b><a href=varekort.php?{$productNavigationQuery}opener=$opener&sort=tlf&funktion=kontoOpslag&id=$id&returside=$returside&ordre_id=$ordre_id&vare_id=$id&$fokus=$fokus>Telefon</b></td>";
     print " </tr>";
 
     if (!isset($_GET['sort']))
@@ -2257,7 +2262,7 @@ function kontoopslag($sort, $fokus, $id)
     while ($row = db_fetch_array($q)) {
         $kontonr = str_replace(" ", "", $row['kontonr']);
         print "<tr>";
-        print "<td><a href=varekort.php?id=$id&konto_id=$row[id]&returside=$returside&vare_lev_id=$row[id]>$row[kontonr]</a></td>";
+        print "<td><a href=varekort.php?{$productNavigationQuery}id=$id&konto_id=$row[id]&returside=$returside&vare_lev_id=$row[id]>$row[kontonr]</a></td>";
         print "<td>$row[firmanavn]</td>";
         print "<td>$row[addr1]</td>";
         print "<td>$row[addr2]</td>";

--- a/lager/varer.php
+++ b/lager/varer.php
@@ -59,6 +59,7 @@
 // 2023.04.14 LOE - Minor modifications
 // 2023.06.03 PHR - php8
 // 2023.09.05	PHR - cookie for saldiProductListStart & saldiProductListLines 
+// 20260907 CDX/LH Carry popup and return context through goods-list searches, sorting and paging.
 
 @session_start();
 $s_id=session_id();
@@ -110,9 +111,14 @@ if ($menu == "S") {
 	
 // 20260904 Sawaneh WP-1.3c: luk.php only when THIS window is a popup (popup=1 flag),
 // not on the user's popup preference — inline/iframe use otherwise ends on luk.php.
-if (!empty($_GET['popup'])) $returside="../includes/luk.php";
-else $returside=(if_isset($_GET['returside']));
-if (!$returside) $returside="../index/menu.php";
+$isPopupRequest = !empty($_GET['popup']);
+$returside = $isPopupRequest ? '../includes/luk.php' : nav_sanitize_returside($_GET['returside'] ?? null);
+if (!$returside) $returside = '../index/menu.php';
+// Keep this context in the URL rather than the session, so inline and popup tabs stay independent.
+$listNavigationQuery = 'returside=' . rawurlencode($returside) . ($isPopupRequest ? '&popup=1' : '');
+$listReturnQuery = rawurlencode('varer.php?' . $listNavigationQuery);
+$listNavigationQuery = htmlspecialchars($listNavigationQuery . '&', ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+$retursideHref = htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
 $lev_id = array();
 /*
 $qtxt="select * from grupper where art='VV' and box1='$brugernavn'";
@@ -399,16 +405,16 @@ if ($menu=='T') {
 	print "<table style='width:100%;height:100%;' border='0' cellspacing='0' cellpadding='0'><tbody>\n";
 	print "<tr><td height = '25' align='center' valign='top'>\n";
 	print "<table width='100%' align='center' border='0' cellspacing='2' cellpadding='0'><tbody>\n";
-	print "<tr><td width='10%'><a href='$returside' accesskey=L>
+	print "<tr><td width='10%'><a href='$retursideHref' accesskey=L>
 		   <button style='$buttonStyle; width:100%' title='$backTitle' onMouseOver=\"this.style.cursor='pointer'\">$txt30</button></a></td>\n";
 	if ($start<$linjeantal) {
 		if ($makeSuggestion) {
-			print "<td width='10%'><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>";
+			print "<td width='10%'><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>";
 			print "<button style='$buttonStyle; width:100%' title='$txt2113' onMouseOver=\"this.style.cursor='pointer'\">";
 			print "$txt159</button></a></td>\n";
 		} else {
 			print "<td width='10%'>
-				   <a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&find=$find'>
+				   <a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&find=$find'>
 				   <button style='$buttonStyle; width:100%' title='$txt3105'
 				   onMouseOver=\"this.style.cursor='pointer'\">
 				   $txt954</button></a></td>\n";
@@ -418,25 +424,25 @@ if ($menu=='T') {
 
 	if ($start<$linjeantal) {
 		if ($stock && !$makeSuggestion) {
-			print "<td width='10%'><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>
+			print "<td width='10%'><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>
 				   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">$txt30</button></a></td>\n";
 		} elseif ($stock && $makeSuggestion && !$alle_varer) {
 			print "<td width='10%'>
-				   <a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&amp;alle_varer=ja'>
+				   <a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&amp;alle_varer=ja'>
 				   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" title='Medtager alle varer fra valgte leverand&amp;oslash;rer, uanset ordrestatus'>$txt955</button></a></td>\n";
 		} elseif ($stock && $makeSuggestion && $alle_varer) {
 			print "<td width='10%'>
-				   <a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse'>
+				   <a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse'>
 				   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" title='Medtager kun varer fra valgte leverand&amp;oslash;rer, som vil komme under minimum udfra ordrer & tilbud'>Kun mangler</button></a></td>\n";
 		} else {
-			print "<td width='10%'><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;beholdning=ja'>
+			print "<td width='10%'><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;beholdning=ja'>
 				   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" title='Viser status for tilbud, salgsordrer og indk&oslash;bsordrer'>$txt953</button></a></td>\n";
 		}
 	} #else print "<td width='80%' $top_bund> Visning</td>\n";
 
 	print "<td width='5%'><a href='varevisning.php'>
 		   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" title='$txt3101'>$txt813</button></a></td>";
-	print "<td width='5%'><a href='varekort.php?returside=varer.php'>
+	print "<td width='5%'><a href='varekort.php?returside={$listReturnQuery}'>
 		   <button style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" title='Opret en ny vare'>Ny</button></a></td>";
 
 	print "</tr>\n";
@@ -446,34 +452,34 @@ if ($menu=='T') {
 	print "<table style=\"width:100%;height:100%;\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\"><tbody>\n";
 	print "<tr><td height = \"25\" align=\"center\" valign=\"top\">\n";
 	print "<table width=\"100%\" align=\"center\" border=\"0\" cellspacing=\"2\" cellpadding=\"0\"><tbody>\n";
-	print "<tr><td width=\"10%\" $top_bund><a href=\"$returside\" accesskey=L><span title='Luk varelisten og g&aring; tilbage til hovedmenuen'>Luk</span></a></td>\n";
+	print "<tr><td width=\"10%\" $top_bund><a href=\"$retursideHref\" accesskey=L><span title='Luk varelisten og g&aring; tilbage til hovedmenuen'>Luk</span></a></td>\n";
 	if ($start<$linjeantal) {
-		if ($makeSuggestion) print "<td width=\"10%\" $top_bund><a href=\"varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal\"><span title='Tilbage til varelisten uden at bestille'>Fortryd</span></a></td>\n";
-		else print "<td width=\"10%\" $top_bund><a href=\"varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse\"><span title='Opret indk&oslash;bsforslag udfra igangv&aelig;rende tilbud og ordrebeholdning'>Indk&oslash;bsforslag</span></a></td>\n";
+		if ($makeSuggestion) print "<td width=\"10%\" $top_bund><a href=\"varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal\"><span title='Tilbage til varelisten uden at bestille'>Fortryd</span></a></td>\n";
+		else print "<td width=\"10%\" $top_bund><a href=\"varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse\"><span title='Opret indk&oslash;bsforslag udfra igangv&aelig;rende tilbud og ordrebeholdning'>Indk&oslash;bsforslag</span></a></td>\n";
 	}	
 	print "<td width=\"60%\" $top_bund> Vareliste</td>\n";
 	if ($start<$linjeantal) {
-		if ($stock && !$makeSuggestion) print "<td width=\"10%\" $top_bund><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>Tilbage</a></td>\n";
-		elseif ($stock && $makeSuggestion && !$alle_varer) print "<td width=\"10%\" $top_bund><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&amp;alle_varer=ja'><span title='Medtager alle varer fra valgte leverand&amp;oslash;rer, uanset ordrestatus'>Alle varer fra lev.</span></a></td>\n"; 
-		elseif ($stock && $makeSuggestion && $alle_varer) print "<td width=\"10%\" $top_bund><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse'><span title='Medtager kun varer fra valgte leverand&amp;oslash;rer, som vil komme under minimum udfra ordrer & tilbud'>Kun mangler</span></a></td>\n"; 
-		else print "<td width=\"10%\" $top_bund><a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;beholdning=ja'><span title='Viser status for tilbud, salgsordrer og indk&oslash;bsordrer'>Ordrebeholdning</span></a></td>\n";
+		if ($stock && !$makeSuggestion) print "<td width=\"10%\" $top_bund><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal'>Tilbage</a></td>\n";
+		elseif ($stock && $makeSuggestion && !$alle_varer) print "<td width=\"10%\" $top_bund><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse&amp;alle_varer=ja'><span title='Medtager alle varer fra valgte leverand&amp;oslash;rer, uanset ordrestatus'>Alle varer fra lev.</span></a></td>\n";
+		elseif ($stock && $makeSuggestion && $alle_varer) print "<td width=\"10%\" $top_bund><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;forslag=ja&amp;beskrivelse=$beskrivelse'><span title='Medtager kun varer fra valgte leverand&amp;oslash;rer, som vil komme under minimum udfra ordrer & tilbud'>Kun mangler</span></a></td>\n";
+		else print "<td width=\"10%\" $top_bund><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;beholdning=ja'><span title='Viser status for tilbud, salgsordrer og indk&oslash;bsordrer'>Ordrebeholdning</span></a></td>\n";
 	} #else print "<td width=\"80%\" $top_bund> Visning</td>\n";
 	if ($popup) {
 		print "<td width=\"5%\"$top_bund onClick=\"javascript:vare_vis=window.open('varevisning.php','vare_vis','scrollbars=1,resizable=1');vare_vis.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\"> <span title='V&aelig;lg hvilke varegrupper og kreditorer som som vises i varelisten'><u>Visning</u></span></td>";
 		print "<td width=\"5%\" $top_bund onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"javascript:window.open('varekort.php?opener=varer.php&amp;returside=../includes/luk.php','varekort','scrollbars=1,resizable=1');ordre.focus();\"><span style=\"text-decoration: underline;\" title='Opret en ny vare'>Ny</a></span></td>";
 	} else {
 		print "<td width=\"5%\" $top_bund><a href=\"varevisning.php\"> <span title='V&aelig;lg hvilke varegrupper og kreditorer som som vises i varelisten'><u>Visning</u></span></a></td>";
-		print "<td width=\"5%\" $top_bund><a href=\"varekort.php?returside=varer.php\"><span title='Opret en ny vare'>Ny</span></a></td>";
+		print "<td width=\"5%\" $top_bund><a href=\"varekort.php?returside={$listReturnQuery}\"><span title='Opret en ny vare'>Ny</span></a></td>";
 	}
 	print "</tr>\n";
 	print "</tbody></table>\n";
 }
 print "<tr><td valign=\"top\">\n";
 if (!$makeSuggestion) {
-	print "<form name=\"vareliste\" action=\"varer.php?sort=$sort&amp;beholdning=$stock&amp;forslag=$makeSuggestion&lev_kto_navn=$lev_kto_navn\" method=\"post\">";
+	print "<form name=\"vareliste\" action=\"varer.php?{$listNavigationQuery}sort=$sort&amp;beholdning=$stock&amp;forslag=$makeSuggestion&lev_kto_navn=$lev_kto_navn\" method=\"post\">";
 	print "<input type=\"hidden\" name=\"valg\">";
 	print "<input type=\"hidden\" name=\"start\" value=\"$start\">";
-} else 	print "<form name=\"vareliste\" action=\"varer.php?sort=$sort\" method=\"post\">";
+} else 	print "<form name=\"vareliste\" action=\"varer.php?{$listNavigationQuery}sort=$sort\" method=\"post\">";
 print "<table cellpadding=\"1\" cellspacing=\"1\" border=\"0\" width=\"100%\"><tbody>\n";
 $x=0;
 $query = db_select("select beskrivelse, kodenr from grupper where art='LG' order by kodenr",__FILE__ . " linje " . __LINE__);
@@ -495,7 +501,7 @@ if (!$makeSuggestion) {
 	print "<tr><td colspan='2' width='20%'>";
 	if ($start>=$linjeantal) {
 		$tmp=$start-$linjeantal;
-		print "<a href='varer.php?sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock'><img src=../ikoner/left.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a>&nbsp;";
+		print "<a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock'><img src=../ikoner/left.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a>&nbsp;";
 	}
 	if ($vis_lev_felt) {
 #		print "<div class=\"ui-widget\">";
@@ -513,7 +519,7 @@ if (!$makeSuggestion) {
 	$colspan=$lagerantal;
 	print "<td colspan='$colspan'></td>";
 	if ($next>=$slut) {
-		print "<td align=right><a href='varer.php?sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;beholdning=$stock'><img src=../ikoner/right.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
+		print "<td align=right><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;beholdning=$stock'><img src=../ikoner/right.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
 	}
 	else print "<td colspan=2></td>";
 	print "</tr>\n";
@@ -522,10 +528,10 @@ if (!$makeSuggestion) {
 if ($csv) fwrite($csvfil,"\"Varenr\";\"Enhed\";\"Varemrk.\";\"Beskrivelse\";");
 else {
 print "<tr>";
-print "<td><b><a href=\"varer.php?sort=varenr&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(917,$sprog_id).".</a></b></td>\n"; #20210401
-print "<td><b><a href=\"varer.php?sort=enhed&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(945,$sprog_id)."</a></b></td>\n";
-print "<td><b><a href=\"varer.php?sort=beskrivelse&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(914,$sprog_id)."</a></b></td>\n";
-if ($showTrademark) print "<td><b><a href=\"varer.php?sort=trademark&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(946,$sprog_id)."</a></b></td>\n";
+print "<td><b><a href=\"varer.php?{$listNavigationQuery}sort=varenr&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(917,$sprog_id).".</a></b></td>\n"; #20210401
+print "<td><b><a href=\"varer.php?{$listNavigationQuery}sort=enhed&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(945,$sprog_id)."</a></b></td>\n";
+print "<td><b><a href=\"varer.php?{$listNavigationQuery}sort=beskrivelse&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(914,$sprog_id)."</a></b></td>\n";
+if ($showTrademark) print "<td><b><a href=\"varer.php?{$listNavigationQuery}sort=trademark&amp;vis_lev=$vis_lev&amp;start=$start&amp;linjeantal=$linjeantal\">".findtekst(946,$sprog_id)."</a></b></td>\n";
 }
 if (!$vis_lev){
 	if ($lagerantal>1 && !$makeSuggestion) {
@@ -541,14 +547,14 @@ if (!$vis_lev){
 			}
 		}
 		if ($csv) fwrite($csvfil,"\"Ialt\";");
-		else print "<td align=right><b><a href=\"varer.php?sort=beholdning&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(947,$sprog_id)."</a></b></td>\n";
+		else print "<td align=right><b><a href=\"varer.php?{$listNavigationQuery}sort=beholdning&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(947,$sprog_id)."</a></b></td>\n";
 	} else {
 		if ($stock) {	
 			print "<td align=right><b> I tilbud</b></td>\n";
 			print "<td align=right><b> I ordre</b></td>\n";
 			print "<td align=right><b> Bestilt</b></td>\n";
 		}
-		print "<td align=right><b><a href=\"varer.php?sort=beholdning&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(948,$sprog_id)."</a></b></td>\n";
+		print "<td align=right><b><a href=\"varer.php?{$listNavigationQuery}sort=beholdning&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(948,$sprog_id)."</a></b></td>\n";
 	}
 }
 if ($makeSuggestion) {
@@ -558,9 +564,9 @@ if ($makeSuggestion) {
 	if ($csv) fwrite($csvfil,"\"Kostpris\";\"Salgspris\"\n");
 	else {
 		($vatOnItemCard)?$tekst="<br>(incl.moms)":$tekst="";
-		print "<td align=\"right\" valign=\"top\" rowspan=\"2\"><b><a href=\"varer.php?sort=salgspris&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(949,$sprog_id)."</a></b>$tekst</td>\n";
+		print "<td align=\"right\" valign=\"top\" rowspan=\"2\"><b><a href=\"varer.php?{$listNavigationQuery}sort=salgspris&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">".findtekst(949,$sprog_id)."</a></b>$tekst</td>\n";
 		if ($vis_kostpriser) print "<td align=\"right\" valign=\"top\" rowspan=\"2\"><b>".findtekst(950,$sprog_id)."</b></td>\n";
-		if ($show_dg) print "<td align=\"right\" valign=\"top\" rowspan=\"2\"><b><a href=\"varer.php?sort=dg_percentage". ($sort == "dg_percentage" ? " desc":"") ."&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">DG</a></b></td>\n";
+		if ($show_dg) print "<td align=\"right\" valign=\"top\" rowspan=\"2\"><b><a href=\"varer.php?{$listNavigationQuery}sort=dg_percentage". ($sort == "dg_percentage" ? " desc":"") ."&amp;vis_lev=$vis_lev&amp;linjeantal=$linjeantal\">DG</a></b></td>\n";
 	}
 }
 if ($vis_lev) {
@@ -639,20 +645,20 @@ if ($csv) {
 	if ($next > 25 && $linjeantal > 25) {
 		if ($start>=$linjeantal){
 			$tmp=$start-$linjeantal;
-			print "<tr><td><a href='varer.php?sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock'><img src=../ikoner/left.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
+			print "<tr><td><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock'><img src=../ikoner/left.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
 		}
 		else print  "<td></td>";
 		print "<td colspan=3></td>";
 		$tmp=$start+$linjeantal;
 		if ($showTrademark) $colspan++;
 		if ($next>=$slut && !$makeSuggestion) {
-			print "<td colspan='$colspan' align=right><a href='varer.php?sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;beholdning=$stock'><img src=../ikoner/right.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
+			print "<td colspan='$colspan' align=right><a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$tmp&amp;linjeantal=$linjeantal&amp;beholdning=$stock'><img src=../ikoner/right.png style=\"border: 0px solid; width: 15px; height: 15px;\"></a></td>";
 		}
 		else print  "<td></td>"; 
 		print "</tr>\n";
 	}
 	print "<tr><td colspan='3'>";
-	print "<a href='varer.php?sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock&amp;csv=1'>csv</a>";
+	print "<a href='varer.php?{$listNavigationQuery}sort=$sort&amp;start=$start&amp;linjeantal=$linjeantal&amp;varenummer=$varenummer&amp;beskrivelse=$beskrivelse&amp;beholdning=$stock&amp;csv=1'>csv</a>";
 }
 print "</td></tr>";
 print "</tbody></table>";

--- a/lager/varer.php
+++ b/lager/varer.php
@@ -23,6 +23,7 @@
 //
 // Copyright (c) 2003-2023 Saldi.dk ApS
 // ----------------------------------------------------------------------
+// 20260904 Sawaneh WP-1.3c: luk.php returside now set on the popup=1 request flag, not the popup preference
 
 // 2013.01.15 Wildcard forsvinder efter søgning - tak til Henrik Thomsen fra Basslab for rettelse - søg 20130115
 // 2014.07.28 Timeout ændret fra 30 til 60 - Søg timeout.
@@ -107,7 +108,9 @@ if ($menu == "S") {
 	exit;
 }
 	
-if ($popup) $returside="../includes/luk.php";
+// 20260904 Sawaneh WP-1.3c: luk.php only when THIS window is a popup (popup=1 flag),
+// not on the user's popup preference — inline/iframe use otherwise ends on luk.php.
+if (!empty($_GET['popup'])) $returside="../includes/luk.php";
 else $returside=(if_isset($_GET['returside']));
 if (!$returside) $returside="../index/menu.php";
 $lev_id = array();

--- a/lager/varer.php
+++ b/lager/varer.php
@@ -60,6 +60,7 @@
 // 2023.06.03 PHR - php8
 // 2023.09.05	PHR - cookie for saldiProductListStart & saldiProductListLines 
 // 20260907 CDX/LH Carry popup and return context through goods-list searches, sorting and paging.
+// 20260907 CDX/LH Mark new and existing product-card windows as popups.
 
 @session_start();
 $s_id=session_id();
@@ -466,7 +467,7 @@ if ($menu=='T') {
 	} #else print "<td width=\"80%\" $top_bund> Visning</td>\n";
 	if ($popup) {
 		print "<td width=\"5%\"$top_bund onClick=\"javascript:vare_vis=window.open('varevisning.php','vare_vis','scrollbars=1,resizable=1');vare_vis.focus();\" onMouseOver=\"this.style.cursor = 'pointer'\"> <span title='V&aelig;lg hvilke varegrupper og kreditorer som som vises i varelisten'><u>Visning</u></span></td>";
-		print "<td width=\"5%\" $top_bund onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"javascript:window.open('varekort.php?opener=varer.php&amp;returside=../includes/luk.php','varekort','scrollbars=1,resizable=1');ordre.focus();\"><span style=\"text-decoration: underline;\" title='Opret en ny vare'>Ny</a></span></td>";
+		print "<td width=\"5%\" $top_bund onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"javascript:var productWindow=window.open('varekort.php?popup=1&amp;opener=varer.php&amp;returside=../includes/luk.php','varekort','scrollbars=1,resizable=1');if(productWindow){productWindow.focus();}\"><span style=\"text-decoration: underline;\" title='Opret en ny vare'>Ny</a></span></td>";
 	} else {
 		print "<td width=\"5%\" $top_bund><a href=\"varevisning.php\"> <span title='V&aelig;lg hvilke varegrupper og kreditorer som som vises i varelisten'><u>Visning</u></span></a></td>";
 		print "<td width=\"5%\" $top_bund><a href=\"varekort.php?returside={$listReturnQuery}\"><span title='Opret en ny vare'>Ny</span></a></td>";
@@ -842,7 +843,7 @@ for ($v=0;$v<count($varenr);$v++) {
 			print "<tr bgcolor=\"$linjebg\">";
 			if ($popup) { #20170920
 				$kort="kort".$id[$v];
-				$js="onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"javascript:$kort=window.open('varekort.php?opener=varer.php&amp;id=$id[$v]&amp;returside=../includes/luk.php','".$jsvars."');$kort.focus();\"";
+				$js="onMouseOver=\"this.style.cursor = 'pointer'\"; onClick=\"javascript:$kort=window.open('varekort.php?popup=1&amp;opener=varer.php&amp;id=$id[$v]&amp;returside=../includes/luk.php','".$jsvars."');$kort.focus();\"";
 			} elseif ($href_vnr) $js=NULL; 
 			else $js="onMouseOver=\"this.style.cursor = 'pointer'\"; onclick=\"javascript:location.href='varekort.php?id=$id[$v]'\"";
 #			if ($popup) print "<td </td>";

--- a/tests/characterization/includes/NavReturnTargetRegressionTest.test.php
+++ b/tests/characterization/includes/NavReturnTargetRegressionTest.test.php
@@ -1,5 +1,6 @@
 <?php
 // 20260907 CDX/LH Reject attribute and URI-scheme payloads while retaining encoded internal return URLs.
+// 20260907 CDX/LH Exercise raw request arrays at the navigation boundary and popup query propagation.
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -8,6 +9,29 @@ require_once dirname(__DIR__, 3) . '/includes/stdFunc/navStack.php';
 
 final class NavReturnTargetRegressionTest extends TestCase
 {
+    public function testArrayReturnParameterUsesTheNormalFallback(): void
+    {
+        parse_str('returside[]=x', $query);
+        self::assertSame(nav_back_url(null), nav_back_url($query['returside']));
+    }
+
+    public static function popupRequests(): array
+    {
+        return [
+            [[], [], ''],
+            [['popup' => '1'], [], 'popup=1&'],
+            [[], ['popup' => '1'], 'popup=1&'],
+            [['popup' => '0'], [], ''],
+            [['popup' => '0'], ['popup' => '1'], 'popup=1&'],
+        ];
+    }
+
+    #[DataProvider('popupRequests')]
+    public function testPopupContextFollowsTheRequest(array $get, array $post, string $expected): void
+    {
+        self::assertSame($expected, nav_popup_query($get, $post));
+    }
+
     public static function unsafeTargets(): array
     {
         return [

--- a/tests/characterization/includes/NavReturnTargetRegressionTest.test.php
+++ b/tests/characterization/includes/NavReturnTargetRegressionTest.test.php
@@ -1,0 +1,46 @@
+<?php
+// 20260907 CDX/LH Reject attribute and URI-scheme payloads while retaining encoded internal return URLs.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 3) . '/includes/stdFunc/navStack.php';
+
+final class NavReturnTargetRegressionTest extends TestCase
+{
+    public static function unsafeTargets(): array
+    {
+        return [
+            ['x onclick=alert(1)'], ["x\tonclick=alert(1)"], ["x\nonclick=alert(1)"],
+            ["java\tscript:alert(1)"], ["java\nscript:alert(1)"], ['javascript:alert(1)'],
+            ['javascript&colon;alert(1)'], ['javascript&#58;alert(1)'], ['javascript&#58alert(1)'],
+            ['java&Tab;script:alert(1)'], ['&#47;&#47;example.com'],
+            ['https://example.com'], ['//example.com'], ["\\\\example.com"], ['/\\example.com'],
+            ['data:text/html,payload'], ["x' onclick='alert(1)"], ['x`onclick=alert(1)'],
+            ["x\0onclick=alert(1)"], ["x\x7f"], [['debitorkort.php']], [null], [42],
+        ];
+    }
+
+    #[DataProvider('unsafeTargets')]
+    public function testRejectsUnsafeOrNonStringReturnTargets($target): void
+    {
+        self::assertSame('', nav_sanitize_returside($target));
+    }
+
+    public static function safeTargets(): array
+    {
+        return [
+            ['debitorkort.php?id=2110'], ['../includes/luk.php'],
+            ['/saldi/debitor/rapport.php?konto_fra=100&konto_til=200'],
+            ['varer.php?beskrivelse=blue%20chair&sort=varenr'],
+            ['rapport.php?filter=a%26b%3Bc&returside=debitorkort.php%3Fid%3D2110'],
+            ['../index/menu.php#finans'],
+        ];
+    }
+
+    #[DataProvider('safeTargets')]
+    public function testKeepsEncodedInternalTargets(string $target): void
+    {
+        self::assertSame($target, nav_sanitize_returside($target));
+    }
+}

--- a/tests/characterization/includes/UnlockRecordRegressionTest.test.php
+++ b/tests/characterization/includes/UnlockRecordRegressionTest.test.php
@@ -1,0 +1,64 @@
+<?php
+// 20260907 CDX/LH Verify unlock-table authorization and retained sales-order responsibility.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class UnlockRecordRegressionTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite is required for the isolated unlock fixtures.');
+        }
+        require_once __DIR__ . '/support/unlock_record_database.php';
+        require_once dirname(__DIR__, 3) . '/includes/stdFunc/unlockRecord.php';
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $GLOBALS['unlockRecordTestDb'] = $this->db;
+        foreach (['kladdeliste', 'ordrer', 'ordrelinjer'] as $table) {
+            $this->db->exec("CREATE TABLE $table (id INTEGER, art TEXT, tidspkt TEXT, hvem TEXT)");
+            $this->db->exec("INSERT INTO $table VALUES (1, 'DO', '123', 'salesperson'), (2, 'KO', '456', 'buyer'), (3, 'DK', '789', 'salesperson')");
+        }
+    }
+
+    public static function rejectedTables(): array
+    {
+        return [['ordrelinjer'], ['brugere'], ['ORDRER'], ['ordrer;drop'], [['ordrer']], [null], ['']];
+    }
+
+    #[DataProvider('rejectedTables')]
+    public function testUnsupportedTablesCannotBeUnlocked($table): void
+    {
+        unlock_record($table, 1);
+        self::assertSame(['123', 'salesperson'], $this->db->query('SELECT tidspkt,hvem FROM ordrelinjer WHERE id=1')->fetch(PDO::FETCH_NUM));
+        self::assertSame('123', $this->db->query('SELECT tidspkt FROM ordrer WHERE id=1')->fetchColumn());
+    }
+
+    public function testJournalUnlockAffectsOnlyTheSelectedRecord(): void
+    {
+        unlock_record('kladdeliste', 1);
+        self::assertSame(['', ''], $this->db->query('SELECT tidspkt,hvem FROM kladdeliste WHERE id=1')->fetch(PDO::FETCH_NUM));
+        self::assertSame('456', $this->db->query('SELECT tidspkt FROM kladdeliste WHERE id=2')->fetchColumn());
+    }
+
+    public function testOrderUnlockPreservesSalesResponsibility(): void
+    {
+        foreach ([1, 2, 3] as $id) {
+            unlock_record('ordrer', $id);
+        }
+        self::assertSame([['', 'salesperson'], ['', ''], ['', 'salesperson']], $this->db->query('SELECT tidspkt,hvem FROM ordrer ORDER BY id')->fetchAll(PDO::FETCH_NUM));
+    }
+
+    public function testMissingIdDoesNotUnlockRecords(): void
+    {
+        unlock_record('ordrer', 0);
+        self::assertSame(3, (int)$this->db->query("SELECT count(*) FROM ordrer WHERE tidspkt<>''")->fetchColumn());
+    }
+}

--- a/tests/characterization/includes/support/unlock_record_database.php
+++ b/tests/characterization/includes/support/unlock_record_database.php
@@ -1,0 +1,10 @@
+<?php
+// 20260907 CDX/LH Execute unlock statements against disposable in-memory fixture tables.
+
+/**
+ * @return int Number of rows affected in the isolated fixture database.
+ */
+function db_modify(string $query, string $source): int
+{
+    return $GLOBALS['unlockRecordTestDb']->exec($query);
+}


### PR DESCRIPTION
nav_back_url() now prefers the explicit returside over the session nav stack (report filters survive Tilbage), with a bare-script guard, and honours a luk.php returside first so a popup's Luk actually closes. Popup semantics move from the user preference to a popup=1 request flag: menu.php's window.open links carry it, nav_push() skips only flagged requests, luk.php closes on either, and varer/modtagelse/historikkort/ pos_ordre set their luk.php returside on the flag instead. luk.php: returside sanitised via new central nav_sanitize_returside() (reflected XSS / open redirect fixed), unlock SQL cast and whitelisted, blocked-close fallback goes to the returside instead of the login page. Print pages (udskriv/formularprint/koekkenprint) are excluded from the nav stack; dedup compares path only and keeps the newest query; nav files are deleted on logout plus an age-based sweep. update_iframe() tags iframe navigations with inframe=1. Same-PR link fixes: debitorkort Historik/Opgaveliste and ansatte header icons now pass urlencoded, id-carrying retursides; kladdeliste hands its GET returside to the topline and casts exitDraft.

## What are the changes about?
Provide a brief explanation of the changes you have made


## What are the changes about?
Work package 1 of the return-link audit (Requirements_return_link_fixes_EN.md, 2026-09-03) — the navigation infrastructure everything else builds on:

- **`nav_back_url()` priority flip:** the explicit `returside` now beats the session nav stack (report pages render from POST, which the stack never records — filters survive Tilbage), with a guard that keeps the stack entry when the returside is a bare script name and the stack holds the same script with a query (the id). A `luk.php` returside is honoured before the stack, so a popup's Luk actually closes.
- **Popup flag (1.3):** popup semantics move from the user *preference* (grupper USET box2) to a `popup=1` request flag. menu.php's window.open links carry it; `nav_push()` skips only flagged requests (popup-preference users get a working nav stack for the first time); luk.php closes on either preference or flag; varer/modtagelse/historikkort/pos_ordre set their luk.php returside on the flag so inline/iframe use no longer dead-ends.
- **luk.php hardening (1.5):** returside sanitised via new central `nav_sanitize_returside()` — fixes a reflected XSS / open redirect; root-relative paths still accepted. Unlock SQL params cast/whitelisted. Blocked-close fallback now goes to the returside instead of the login page.
- **Print pages (1.2):** udskriv/formularprint/koekkenprint are excluded from the nav stack (back can never re-print); dedup compares path only and keeps the newest query.
- **Cleanup (1.7):** nav files deleted on logout + 48h age sweep. Per-tab stacks remain a documented limitation.
- **iframe flag (1.6):** `update_iframe()` tags navigations with `inframe=1` centrally.
- **Same-PR link fixes required by the flip (1.1):** debitorkort's Historik/Opgaveliste links and ansatte's header icons pass urlencoded, id-carrying retursides (previously id-less, masked by the stack); kladdeliste hands its GET returside to topLineFinans (never plumbed before) and casts exitDraft.

**Manual test (done on ssl12):** filtered report → kontokort → Tilbage returns the filtered report; print → back → list, back again never re-prints; popup-preference kassekladde popup closes on Luk; `luk.php?returside=https://evil.example` and `"><b>x</b>` inert; iframe back/Luk never shows the login page; logout removes the session's `temp/nav_*.json`; debitorkort Historik/Opgaveliste round-trips to the same customer.

WP-2–6 follow as separate PRs per the spec. `finans/bogfor.php` untouched; no DB schema changes.


## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved return navigation so pages preserve the correct record, list, search, sort, and popup context.
  - Popup windows now close or return to the appropriate originating page more reliably.
  - Improved iframe behavior by preserving embedded-page context.
  - Secured return links by rejecting unsafe destinations and safely handling navigation parameters.
  - Navigation history now handles reloads, filtering, printing, and logout cleanup more consistently.
- **Security**
  - Added validation and escaping for return URLs and related navigation values to prevent unsafe redirects or markup injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->