### PR TITLE
Fix duplicate SALDI Assist widget loader

### DIFF
--- a/index/main.php
+++ b/index/main.php
@@ -31,6 +31,7 @@
 // 20260730 NTR - Added translation to momsperioder.
 // 20260730 MJ Fjernede Momsperioder-link fra Finans-sidebaren; linket er nu en knap i regnskabsaar.php
 // 20260902 CL/LH Indlejrede chaty_V2 support-chatbot (wuweiworkai.com/chaty-v2) i skallen
+// 20260907 CDX/LH Fjernede gammel widget-loader, saa SALDI Assist kun indlaeses en gang
 @session_start();
 $s_id = session_id();
 
@@ -665,18 +666,6 @@ function brightenColor($color, $amount = 0.2) {
     }
   }
 </style>
-
-<?php
-// Chat-widget serveres lokalt fra chaty_V2's docker-compose ved udvikling paa localhost
-$chatyHost = strtolower((string) parse_url('http://' . ($_SERVER['HTTP_HOST'] ?? ''), PHP_URL_HOST));  
-$chatyBase = in_array($chatyHost, ['localhost', '127.0.0.1'], true)	? 'http://localhost:3000' : 'https://wuweiworkai.com/chaty-v2';
-?>
-<script async
-  src="<?php print $chatyBase; ?>/widget.js"
-  data-widget-id="saldi-erp"
-  data-brand="SALDI.dk"
-  data-lang="<?php print ($sprog_id == 2) ? 'en' : 'da'; ?>"
-  data-theme-color="#2872fa"></script>
 
 <?php
 /* SALDI Assist (support-chatbot). Loaderen hentes fra chatbottens server; token-


### PR DESCRIPTION
## What are the changes about?

The shell loads both the legacy `saldi-erp` widget and the new SALDI Assist widget. Their competing initialization can leave the old instance active without the intended context integration. Remove the obsolete loader and its unused URL variables so the shell loads SALDI Assist once.

This is the same single-file patch already applied on `ssl3/master` and confirmed working by Lui. Keeping it in master prevents the next deployment from restoring the duplicate loader. The signing configuration remains outside Git.

Validation: PHP lint and `git diff --check` passed; this file is byte-for-byte identical to the tested live patch. The live shell has one widget loader and retains `window.update_iframe` exposure.

Manual regression checks:
- `index/main.php`: refresh a logged-in SALDI page and confirm one launcher and one widget iframe.
- Context endpoint/loader: open Finans → Kassekladde and confirm the request to `includes/saldi_assist_token.php` succeeds and the answer recognises the current screen.
- Navigation hook/`update_iframe`: open a suggested screen; verify an unsaved-change warning is still respected when leaving an edited screen.

## Have you checked the following?
- [ ] Wiki updated — not applicable; this removes a duplicate integration.
- [x] External resources reviewed — no new external resources; the existing SALDI Assist loader remains.
- [ ] Linked developer guidelines — not independently re-read for this patch; repository AGENTS.md and doc/ai conventions were followed.
