### PR TITLE
SALDI Assist: read saved journals and invoice status with scoped tools

### DIFF
--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -107,6 +107,7 @@
 // 20260818 Sawaneh Credit notes: only cap the quantity when the line points the wrong way or more
 //                  is credited than invoiced, so it can be reduced. Handles invoice lines that are
 //                  themselves negative. Shows the max in the alert. Removed debug_kreditnota logging.
+// 20260907 CDX/LH Share the invoice payment gate with the assistant's saved-state reader.
 
 @session_start();
 $s_id = session_id();
@@ -131,6 +132,8 @@ $valgt = $varenr[0] = $valuta = $vis_lev_addr = $vis_projekt = NULL;
 $width = NULL;
 $fast_db = array();
 $sletslut = $sletstart = 0;
+
+require_once __DIR__ . '/../includes/assist/RecordRules.php';
 
 $modulnr = 5;
 
@@ -6342,12 +6345,8 @@ function ordreside($id, $regnskab)
 					$disabled = '';
 					
 					$lockPayment = get_settings_value("lockedInvoiceButton", "debitor", "");
-					if(!$betalt && $vis_betalingslink && $lockPayment == "on"){
-						$disabled = "disabled";
-					}
-					// Made for Havemøbelshoppen
-					if ($ref == "Magento" || $felt_1 == "Konto" || $felt_1 == "Kontant") {
-						$disabled = '';
+					if (saldi_assist_invoice_payment_locked($betalt, (bool)($vis_betalingslink ?? false), (string)$lockPayment, (string)$ref, (string)$felt_1)) {
+						$disabled = 'disabled';
 					}
 					
 					$txt = findtekst('2374|Fakturér', $sprog_id);

--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -133,7 +133,7 @@ $width = NULL;
 $fast_db = array();
 $sletslut = $sletstart = 0;
 
-require_once __DIR__ . '/../includes/assist/RecordRules.php';
+require_once dirname(__DIR__, 1) . '/includes/assist/RecordRules.php';
 
 $modulnr = 5;
 

--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -62,7 +62,10 @@
 // 20260822 Sawaneh Show journal id and note in heading and above movements so output identifies the journal;
 //                  print icon on the simulation/posting view prints just the report
 // 20260907 CDX/PHR Update following fiscal years' opening balances within the journal posting transaction.
+// 20260907 CDX/LH Share the difference predicate with the read-only assistant checks.
 
+
+require_once __DIR__ . '/../includes/assist/RecordRules.php';
 
 @session_start();
 $s_id=session_id();
@@ -560,7 +563,7 @@ for ($y=1;$y<=$posteringer;$y++) {
 if (afrund($b_sum[$x],2)) $diffbilag[$y-1]=afrund($b_sum[$x],2);
 # <- 20131115
 $fejl=0; #20140228
-if (abs($diff)>=0.01 || count($diffbilag))  { #20131115 ( || count($diffbilag))
+if (saldi_assist_has_differences((float)$diff, $diffbilag)) { #20131115 ( || count($diffbilag))
 	print "<tr><td colspan=6><br>";
 	print "<table width=100% border=1><tbody>"; 
 	print "<tr><td align=center colspan=2>Der er differencer p&aring; følgende bilag</td></tr>";

--- a/finans/bogfor.php
+++ b/finans/bogfor.php
@@ -65,7 +65,7 @@
 // 20260907 CDX/LH Share the difference predicate with the read-only assistant checks.
 
 
-require_once __DIR__ . '/../includes/assist/RecordRules.php';
+require_once dirname(__DIR__, 1) . '/includes/assist/RecordRules.php';
 
 @session_start();
 $s_id=session_id();

--- a/includes/assist/README.md
+++ b/includes/assist/README.md
@@ -59,7 +59,8 @@ Special auditor/superuser arrangements need installation-specific verification.
 
 Calls use independent READ ONLY, REPEATABLE READ transactions with timeouts,
 prepared statements and bounded snapshots. Revisions cover saved data and
-relevant configuration. Stale reads return 409. Highlighting rechecks the
+relevant configuration. Bearer reads must include the revision returned with the
+grant; missing, invalid or stale revisions return 409. Highlighting rechecks the
 revision and refuses dirty/different records. `tmpkassekl` triggers a saved-draft
 warning; journals exceeding 2,000 saved rows fail explicitly.
 

--- a/includes/assist/README.md
+++ b/includes/assist/README.md
@@ -1,0 +1,75 @@
+# Saved-record assistant service
+
+Opt-in JSON service for the saved journal or sales document selected in SALDI.
+The bot uses HTTP; no MCP server or accounting schema migration is required.
+
+| Operation | Result |
+| --- | --- |
+| `get_journal_context` | Saved rows, journal state, draft warning and content revision |
+| `validate_journal` | Preliminary findings with row IDs and domestic voucher differences |
+| `get_invoice_status` | Saved sales-document state, known blockers and explicit unknown checks |
+
+The service never posts, saves, simulates, sends invoices or runs page controllers.
+Journal checks do not reproduce VAT calculations, FX conversion/tolerances,
+customer/supplier posting, dimensions or open-item matching. `coverage.can_post`
+is always null. Invoice delivery batches, terminal/card choices and other unsaved
+form gates remain unknown; `actions[].enabled` is null unless a definite blocker
+is established. SALDI remains responsible for final validation.
+
+## Installation
+
+Requires PHP 8.0+, PDO PostgreSQL and mbstring. Master and enabled tenant
+databases must be on the same PostgreSQL host. MySQL needs a connection adapter.
+Deploy with a chatbot release supporting these operations and `X-Saldi-Record`.
+The existing signed context-token integration must be configured on both sides.
+
+Provision a separate PostgreSQL login with CONNECT/USAGE and SELECT only:
+
+- Master: `online`, `regnskab`, and `settings` when present.
+- Enabled tenants: `brugere`, `kladdeliste`, `kassekladde`, `tmpkassekl`,
+  `kontoplan`, `grupper`, `adresser`, `valuta`, `ordrer`, `ordrelinjer`, plus
+  `moms_periode_luk` and `settings` when present.
+
+Do not give this login write permissions or grant access to other companies.
+Supply credentials from the installation's secret store, never tracked files.
+
+| SALDI environment | Value |
+| --- | --- |
+| `SALDI_ASSIST_RECORDS_ENABLED` | `1` after both sides are installed; default off |
+| `SALDI_ASSIST_DB_HOST`, `SALDI_ASSIST_DB_PORT` | PostgreSQL host/port; port defaults to 5432 |
+| `SALDI_ASSIST_DB_MASTER` | Master database name |
+| `SALDI_ASSIST_DB_USER`, `SALDI_ASSIST_DB_PASSWORD` | Dedicated read-only login |
+| `SALDI_ASSIST_CONTEXT_SECRET`, `SALDI_ASSIST_KID` | Existing context signing key (at least 32 characters) and its ID |
+| `SALDI_ASSIST_HOST_ORIGIN` | Exact public SALDI origin, including a nonstandard port; set explicitly behind a proxy |
+
+Configure the chatbot's `SALDI_RECORD_API_URL` to the fixed HTTPS URL ending in
+`/includes/saldi_assist_record.php`, match `CONTEXT_TOKEN_KEYS` to SALDI's key/ID,
+and enable `SALDI_RECORDS_ENABLED=true`. Local HTTP requires the chatbot's
+explicit `SALDI_RECORD_ALLOW_HTTP=true`; leave it false in production.
+
+## Access and data flow
+
+The browser reads only record ID and dirty state, never unsaved form values.
+A same-origin JSON POST using the live login obtains a five-minute `r1` grant
+bound to company, user, widget session and record. The grant contains no raw
+login cookie or database name. The bot verifies it alongside the existing `v1`
+context token; each PHP tool call rechecks the live session, company and tenant
+module rights. Unknown/blank rights and users missing from `brugere` fail closed.
+Special auditor/superuser arrangements need installation-specific verification.
+
+Calls use independent READ ONLY, REPEATABLE READ transactions with timeouts,
+prepared statements and bounded snapshots. Revisions cover saved data and
+relevant configuration. Stale reads return 409. Highlighting rechecks the
+revision and refuses dirty/different records. `tmpkassekl` triggers a saved-draft
+warning; journals exceeding 2,000 saved rows fail explicitly.
+
+Saved descriptions, amounts and findings can enter model context and retained
+chat answers. The widget discloses this saved-data flow. Include it in the
+installation's existing model-provider and retention configuration.
+
+## Verification and rollback
+
+See [tests and manual checks](../../tests/assist/README.md). Disable both feature
+flags to return to documentation-only chat. Shared predicates preserve the
+existing balance/payment conditions and can stay installed. No migration needs
+reversing.

--- a/includes/assist/RecordAuth.php
+++ b/includes/assist/RecordAuth.php
@@ -1,0 +1,171 @@
+<?php
+// 20260907 CDX/LH Scoped, short-lived access to saved assistant records.
+// 20260908 CDX/LH Read authorization headers across Apache and CGI SAPIs.
+
+final class SaldiAssistFailure extends RuntimeException
+{
+    public function __construct(string $reason, public int $status = 403)
+    {
+        parent::__construct($reason);
+    }
+}
+
+final class SaldiAssistRecordAuth
+{
+    public const TTL = 300;
+
+    public static function encode(string $bytes): string
+    {
+        return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+    }
+
+    /** @param array<string,mixed> $claims */
+    public static function sign(array $claims, string $kid, string $secret): string
+    {
+        if (strlen($secret) < 32 || !preg_match('/^[A-Za-z0-9_-]{1,32}$/D', $kid)) {
+            throw new SaldiAssistFailure('not_configured', 503);
+        }
+        ksort($claims);
+        $input = 'r1.' . $kid . '.' . self::encode(json_encode($claims, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        return $input . '.' . self::encode(hash_hmac('sha256', $input, $secret, true));
+    }
+
+    /** @return array<string,mixed> */
+    public static function verify(string $token, string $kid, string $secret, int $now): array
+    {
+        $parts = explode('.', $token);
+        if (strlen($token) > 2048 || count($parts) !== 4 || $parts[0] !== 'r1' || $parts[1] !== $kid) {
+            throw new SaldiAssistFailure('invalid_grant');
+        }
+        $input = implode('.', array_slice($parts, 0, 3));
+        if (strlen($secret) < 32 || !hash_equals(self::encode(hash_hmac('sha256', $input, $secret, true)), $parts[3])) {
+            throw new SaldiAssistFailure('invalid_grant');
+        }
+        $json = base64_decode(strtr($parts[2], '-_', '+/'), true);
+        $c = $json === false ? null : json_decode($json, true);
+        if (!is_array($c) || ($c['aud'] ?? '') !== 'saldi-assist-record' || ($c['iss'] ?? '') !== 'saldi'
+            || !is_int($c['iat'] ?? null) || !is_int($c['exp'] ?? null)
+            || $c['iat'] > $now + 30 || $c['exp'] <= $now || $c['exp'] <= $c['iat']
+            || $c['exp'] - $c['iat'] > self::TTL
+            || !in_array($c['kind'] ?? '', ['journal', 'invoice'], true)
+            || !is_int($c['record_id'] ?? null) || $c['record_id'] < 1) {
+            throw new SaldiAssistFailure('invalid_grant');
+        }
+        foreach (['tenant_hash', 'user_hash', 'embed_session', 'session_locator'] as $field) {
+            if (!is_string($c[$field] ?? null) || !preg_match('/^[0-9a-f]{32}$/D', $c[$field])) {
+                throw new SaldiAssistFailure('invalid_grant');
+            }
+        }
+        if (!is_string($c['session_tag'] ?? null) || !preg_match('/^[0-9a-f]{64}$/D', $c['session_tag'])) {
+            throw new SaldiAssistFailure('invalid_grant');
+        }
+        return $c;
+    }
+
+    /** @param array<string,mixed> $online
+     *  @return array<string,mixed> */
+    public static function claims(array $online, string $kind, int $id, string $embed, string $secret, int $now): array
+    {
+        return [
+            'iss' => 'saldi', 'aud' => 'saldi-assist-record', 'iat' => $now, 'exp' => $now + self::TTL,
+            'kind' => $kind, 'record_id' => $id,
+            // Lookup only; the HMAC below authenticates the live session. SALDI online has no primary key.
+            'session_locator' => md5($online['session_id']),
+            'tenant_hash' => substr(hash('sha256', 'saldi-tenant:' . $online['db']), 0, 32),
+            'user_hash' => substr(hash('sha256', 'saldi-user:' . $online['db'] . ':' . $online['brugernavn']), 0, 32),
+            'embed_session' => $embed,
+            'session_tag' => hash_hmac('sha256', 'saldi-record-session:' . $online['session_id'], $secret),
+        ];
+    }
+
+    /** Match the live login, including company switches and session revocation.
+     *  @param array<string,mixed> $claims
+     *  @param array<string,mixed> $online */
+    public static function assertSession(array $claims, array $online, string $secret): void
+    {
+        $current = self::claims($online, $claims['kind'], $claims['record_id'], $claims['embed_session'], $secret, time());
+        foreach (['tenant_hash', 'user_hash', 'session_tag'] as $field) {
+            if (!hash_equals($claims[$field], $current[$field])) {
+                throw new SaldiAssistFailure('session_changed');
+            }
+        }
+    }
+}
+
+/**
+ * Apache can expose Authorization only through getallheaders(), unlike CGI.
+ * Conflicting values fail closed; forwarded authorization headers are ignored.
+ *
+ * @param array<string,mixed> $server
+ * @param array<string,mixed> $headers
+ * @return string The request's authorization value, or empty when absent/ambiguous.
+ */
+function saldi_assist_authorization(array $server, array $headers): string
+{
+    $values = [];
+    if (isset($server['HTTP_AUTHORIZATION']) && is_string($server['HTTP_AUTHORIZATION'])) {
+        $values[] = $server['HTTP_AUTHORIZATION'];
+    }
+    foreach ($headers as $name => $value) {
+        if (strcasecmp($name, 'Authorization') === 0 && is_string($value)) {
+            $values[] = $value;
+        }
+    }
+    $values = array_values(array_unique($values));
+    return count($values) === 1 ? $values[0] : '';
+}
+
+/** An independent PostgreSQL connection: no online.php, migrations or logging writes. */
+function saldi_assist_read_connection(string $database): PDO
+{
+    if (!preg_match('/^[A-Za-z0-9_-]{1,63}$/D', $database)) {
+        throw new SaldiAssistFailure('not_configured', 503);
+    }
+    $host = getenv('SALDI_ASSIST_DB_HOST');
+    $user = getenv('SALDI_ASSIST_DB_USER');
+    $password = getenv('SALDI_ASSIST_DB_PASSWORD');
+    $port = (int)(getenv('SALDI_ASSIST_DB_PORT') ?: 5432);
+    if (!$host || !$user || $password === false) {
+        throw new SaldiAssistFailure('not_configured', 503);
+    }
+    $pdo = new PDO("pgsql:host=$host;port=$port;dbname=$database;connect_timeout=3", $user, $password, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+    $pdo->exec("SET statement_timeout = '3000ms'");
+    $pdo->exec("SET client_encoding = 'UTF8'");
+    $pdo->exec('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY');
+    return $pdo;
+}
+
+/** @param array<int,mixed> $parameters
+ *  @return array<string,mixed>|null */
+function saldi_assist_one(PDO $pdo, string $sql, array $parameters = []): ?array
+{
+    $query = $pdo->prepare($sql);
+    $query->execute($parameters);
+    return $query->fetch() ?: null;
+}
+
+/** @param array<string,mixed> $online */
+function saldi_assist_authorize(PDO $master, PDO $tenant, array $online, string $kind): void
+{
+    $zone = 'Europe/Copenhagen';
+    if (saldi_assist_one($master, "SELECT to_regclass('settings') AS name")['name']) {
+        $setting = saldi_assist_one($master, "SELECT var_value FROM settings WHERE var_name = 'timezone' LIMIT 1");
+        $zone = (string)($setting['var_value'] ?? '') ?: $zone;
+    }
+    $today = (new DateTimeImmutable('now', new DateTimeZone($zone)))->format('Y-m-d');
+    $company = saldi_assist_one($master, 'SELECT lukket, lukkes FROM regnskab WHERE db = ?', [$online['db']]);
+    if (!$company || $company['lukket'] === 'on'
+        || (!empty($company['lukkes']) && $company['lukkes'] <= $today)) {
+        throw new SaldiAssistFailure('company_unavailable');
+    }
+    $user = saldi_assist_one($tenant, 'SELECT rettigheder FROM brugere WHERE brugernavn = ?', [$online['brugernavn']]);
+    // The same module positions used by kassekladde.php and debitor/ordre.php.
+    $position = $kind === 'journal' ? 2 : 5;
+    $rights = (string)($user['rettigheder'] ?? '');
+    if (!preg_match('/^[0-9]+$/D', $rights) || (int)substr($rights, $position, 1) < 1) {
+        throw new SaldiAssistFailure('record_forbidden');
+    }
+}

--- a/includes/assist/RecordAuth.php
+++ b/includes/assist/RecordAuth.php
@@ -1,9 +1,11 @@
 <?php
 // 20260907 CDX/LH Scoped, short-lived access to saved assistant records.
 // 20260908 CDX/LH Read authorization headers across Apache and CGI SAPIs.
+// 20260908 CDX/LH Document grant helper contracts.
 
 final class SaldiAssistFailure extends RuntimeException
 {
+    /** Pair a public error code with the HTTP status returned by the endpoint. */
     public function __construct(string $reason, public int $status = 403)
     {
         parent::__construct($reason);
@@ -14,6 +16,7 @@ final class SaldiAssistRecordAuth
 {
     public const TTL = 300;
 
+    /** @return string Unpadded URL-safe base64 for a signed grant component. */
     public static function encode(string $bytes): string
     {
         return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');

--- a/includes/assist/RecordRules.php
+++ b/includes/assist/RecordRules.php
@@ -1,0 +1,176 @@
+<?php
+// 20260907 CDX/LH Pure preliminary journal checks and invoice button predicates.
+
+/** This predicate is also used by the existing posting preview.
+ *  @param array<int,mixed> $voucherDifferences */
+function saldi_assist_has_differences(float $difference, array $voucherDifferences): bool
+{
+    return abs($difference) >= 0.01 || count($voucherDifferences) > 0;
+}
+
+/** Mirrors the final payment gate on the Fakturér button, including its exceptions. */
+function saldi_assist_invoice_payment_locked($paid, bool $paymentLink, string $lock, string $reference, string $method): bool
+{
+    return !$paid && $paymentLink && $lock === 'on'
+        && $reference !== 'Magento' && !in_array($method, ['Konto', 'Kontant'], true);
+}
+
+/** Database decimals are parsed at SALDI's stored three-decimal precision. */
+function saldi_assist_milli($value): int
+{
+    if (!preg_match('/^(-?)([0-9]{1,12})(?:\.([0-9]{1,3}))?$/D', (string)$value, $parts)) {
+        throw new InvalidArgumentException('invalid_decimal');
+    }
+    $milli = (int)$parts[2] * 1000 + (int)str_pad($parts[3] ?? '', 3, '0');
+    return ($parts[1] === '-') ? -$milli : $milli;
+}
+
+function saldi_assist_decimal(int $milli): string
+{
+    return ($milli < 0 ? '-' : '') . intdiv(abs($milli), 1000) . '.' . str_pad((string)(abs($milli) % 1000), 3, '0', STR_PAD_LEFT);
+}
+
+/** @param array<string,mixed> $header
+ *  @param array<int,array<string,mixed>> $rows
+ *  @param array<string,mixed> $reference
+ *  @return array{status:string,issues:array,issue_count:int,issues_truncated:bool,differences:array,difference_count:int,differences_truncated:bool,coverage:array} */
+function saldi_assist_validate_journal(array $header, array $rows, array $reference): array
+{
+    $issues = [];
+    $add = static function (string $code, string $message, array $ids = [], string $severity = 'error') use (&$issues): void {
+        $issues[] = ['code' => $code, 'message' => $message, 'row_ids' => $ids, 'severity' => $severity];
+    };
+    if (($header['bogfort'] ?? '') === 'V') {
+        $add('journal_posted', 'Kladden er allerede bogført.');
+    }
+    if (!$rows) {
+        $add('journal_empty', 'Den gemte kladde har ingen linjer.');
+    }
+    if (!empty($reference['has_draft'])) {
+        $add('saved_draft_differs', 'SALDI har midlertidige kladdelinjer. Kontrollen gælder kun de gemte linjer.', [], 'warning');
+    }
+    $period = $reference['period'] ?? null;
+    if (!$period) {
+        $add('fiscal_year_missing', 'Regnskabsårets start og slutning kunne ikke bestemmes.');
+    }
+    $vouchers = [];
+    $unsupported = [];
+    $total = 0;
+    $active = 0;
+    foreach ($rows as $row) {
+        $id = (int)$row['id'];
+        try {
+            $amount = saldi_assist_milli($row['amount'] ?? '');
+        } catch (InvalidArgumentException $error) {
+            $add('invalid_amount', 'Beløbet kan ikke kontrolleres.', [$id]);
+            continue;
+        }
+        if (!$amount) {
+            continue; // Posting ignores zero-amount saved lines.
+        }
+        $active++;
+        $date = (string)($row['transdate'] ?? '');
+        if (!preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/D', $date)
+            || !checkdate((int)substr($date, 5, 2), (int)substr($date, 8, 2), (int)substr($date, 0, 4))) {
+            $add('invalid_date', 'Bogføringsdato mangler eller er ugyldig.', [$id]);
+        } elseif ($period && ($date < $period['start'] || $date > $period['end'])) {
+            $add('outside_fiscal_year', 'Datoen ligger uden for det valgte regnskabsår.', [$id]);
+        }
+        if (in_array(substr($date, 0, 7), $reference['closed_months'] ?? [], true)) {
+            $add('period_closed', 'Perioden ' . substr($date, 0, 7) . ' er lukket for bogføring.', [$id]);
+        }
+        if (empty($row['debet']) && empty($row['kredit'])) {
+            $add('accounts_missing', 'Linjen har et beløb, men hverken debet- eller kreditkonto.', [$id]);
+        }
+        foreach (['debet' => 'd_type', 'kredit' => 'k_type'] as $side => $typeField) {
+            $number = (string)($row[$side] ?? '');
+            if (!$number || $number === '0') {
+                continue;
+            }
+            $type = trim((string)($row[$typeField] ?? ''));
+            if (!in_array($type, ['F', 'D', 'K'], true)) {
+                $add('account_type_invalid', 'Kontotype skal være F, D eller K.', [$id]);
+                continue;
+            }
+            $account = $reference['accounts'][$type . ':' . $number] ?? null;
+            if (!$account) {
+                $add('account_missing', 'Konto ' . $type . ' ' . $number . ' findes ikke i det valgte regnskabsår/kartotek.', [$id]);
+                continue;
+            }
+            if ($type === 'F' && (!empty($account['lukket']) || in_array($account['kontotype'] ?? '', ['H', 'Z'], true))) {
+                $add('account_unavailable', 'Finanskonto ' . $number . ' er lukket eller kan ikke bruges til postering.', [$id]);
+            }
+            if ($type !== 'F') {
+                $unsupported['customer_supplier_posting'] = true;
+                $group = $reference['groups'][($type === 'D' ? 'DG' : 'KG') . ':' . ($account['gruppe'] ?? '')] ?? null;
+                if (!$group || empty($reference['accounts']['F:' . ($group['box2'] ?? '')])) {
+                    $add('control_account_missing', 'Kontoens gruppe mangler en gyldig samlekonto.', [$id]);
+                }
+            }
+            $override = trim((string)($row[$side . 'vat'] ?? ''));
+            $otherOverride = trim((string)($row[($side === 'debet' ? 'kredit' : 'debet') . 'vat'] ?? ''));
+            // A confirmed override on one side leaves the other side intentionally blank (bogfor.php).
+            $vat = ($override !== '' || $otherOverride !== '') ? $override : trim((string)($account['moms'] ?? ''));
+            if (empty($row['momsfri']) && $vat) {
+                $unsupported['vat_calculation'] = true;
+                $vatGroup = $reference['groups'][substr($vat, 0, 1) . 'M:' . substr($vat, 1)] ?? null;
+                if (!$vatGroup || !is_numeric($vatGroup['box2'] ?? null)
+                    || empty($reference['accounts']['F:' . ($vatGroup['box1'] ?? '')])) {
+                    $add('vat_setup_missing', 'Momskode ' . $vat . ' mangler sats eller en gyldig momskonto.', [$id]);
+                }
+            }
+        }
+        $currency = (int)($row['valuta'] ?? 0);
+        if ($currency) {
+            $unsupported['currency_conversion'] = true;
+            $rate = $reference['rates'][$currency . ':' . $date] ?? null;
+            $group = $reference['groups']['VK:' . $currency] ?? null;
+            if (!$rate || (float)$rate <= 0) {
+                $add('exchange_rate_missing', 'Valutakurs mangler på bogføringsdatoen.', [$id]);
+            }
+            if (!$group || empty($reference['accounts']['F:' . ($group['box3'] ?? '')])) {
+                $add('currency_account_missing', 'Valutaen mangler en gyldig differencekonto.', [$id]);
+            }
+        }
+        $voucher = (string)($row['bilag'] ?? '');
+        if (!isset($vouchers[$voucher])) {
+            $vouchers[$voucher] = ['voucher' => $voucher, 'milli' => 0, 'row_ids' => [], 'foreign' => false];
+        }
+        $signed = (!empty($row['debet']) ? $amount : 0) - (!empty($row['kredit']) ? $amount : 0);
+        $vouchers[$voucher]['milli'] += $signed;
+        $vouchers[$voucher]['row_ids'][] = $id;
+        $vouchers[$voucher]['foreign'] = $vouchers[$voucher]['foreign'] || $currency !== 0;
+        $total += $signed;
+        foreach (['afd', 'projekt', 'ansat'] as $dimension) {
+            if (!empty($row[$dimension])) {
+                $unsupported['dimensions'] = true;
+            }
+        }
+    }
+    if (!$active && $rows) {
+        $add('no_postings', 'Kladden har ingen gemte linjer med et beløb.');
+    }
+    $differences = [];
+    foreach ($vouchers as $voucher) {
+        // Do not sum mixed currencies as if they were DKK or apply invented FX tolerances.
+        if (!$voucher['foreign'] && round($voucher['milli'] / 1000, 2) != 0) {
+            $differences[] = ['voucher' => $voucher['voucher'], 'difference' => saldi_assist_decimal($voucher['milli']), 'currency' => 'DKK', 'row_ids' => $voucher['row_ids']];
+            $add('voucher_unbalanced', 'Bilag ' . $voucher['voucher'] . ' har en difference på ' . saldi_assist_decimal($voucher['milli']) . ' DKK.', $voucher['row_ids']);
+        }
+    }
+    if (!isset($unsupported['currency_conversion']) && saldi_assist_has_differences($total / 1000, [])) {
+        $add('journal_unbalanced', 'Kladdens samlede difference er ' . saldi_assist_decimal($total) . ' DKK.');
+    }
+    $errors = array_filter($issues, static fn(array $issue): bool => $issue['severity'] === 'error');
+    return [
+        'status' => $errors ? 'blocked' : ($unsupported ? 'incomplete' : 'checks_passed'),
+        'issues' => array_slice($issues, 0, 100), 'issue_count' => count($issues), 'issues_truncated' => count($issues) > 100,
+        'differences' => array_slice($differences, 0, 100),
+        'difference_count' => count($differences), 'differences_truncated' => count($differences) > 100,
+        'coverage' => [
+            'checked' => ['saved_rows', 'accounts', 'fiscal_dates', 'closed_periods', 'domestic_voucher_balance', 'vat_and_currency_setup'],
+            'not_checked' => array_merge(['posting_transaction', 'open_item_matching'], array_keys($unsupported)),
+            'can_post' => null,
+        ],
+    ];
+}

--- a/includes/assist/RecordRules.php
+++ b/includes/assist/RecordRules.php
@@ -1,5 +1,6 @@
 <?php
 // 20260907 CDX/LH Pure preliminary journal checks and invoice button predicates.
+// 20260908 CDX/LH Document the separate legacy voucher and grand-total checks.
 
 /** This predicate is also used by the existing posting preview.
  *  @param array<int,mixed> $voucherDifferences */
@@ -25,6 +26,7 @@ function saldi_assist_milli($value): int
     return ($parts[1] === '-') ? -$milli : $milli;
 }
 
+/** @return string Signed decimal with exactly three fractional digits. */
 function saldi_assist_decimal(int $milli): string
 {
     return ($milli < 0 ? '-' : '') . intdiv(abs($milli), 1000) . '.' . str_pad((string)(abs($milli) % 1000), 3, '0', STR_PAD_LEFT);
@@ -153,6 +155,8 @@ function saldi_assist_validate_journal(array $header, array $rows, array $refere
     $differences = [];
     foreach ($vouchers as $voucher) {
         // Do not sum mixed currencies as if they were DKK or apply invented FX tolerances.
+        // bogfor.php populates diffbilag from rounded voucher balances before the shared
+        // grand-total predicate: a 0.005 voucher difference must not be ignored here.
         if (!$voucher['foreign'] && round($voucher['milli'] / 1000, 2) != 0) {
             $differences[] = ['voucher' => $voucher['voucher'], 'difference' => saldi_assist_decimal($voucher['milli']), 'currency' => 'DKK', 'row_ids' => $voucher['row_ids']];
             $add('voucher_unbalanced', 'Bilag ' . $voucher['voucher'] . ' har en difference på ' . saldi_assist_decimal($voucher['milli']) . ' DKK.', $voucher['row_ids']);

--- a/includes/assist/RecordService.php
+++ b/includes/assist/RecordService.php
@@ -1,5 +1,6 @@
 <?php
 // 20260907 CDX/LH Bounded snapshots of saved journal and sales-invoice records.
+// 20260908 CDX/LH Document snapshot construction requirements.
 require_once __DIR__ . '/RecordAuth.php';
 require_once __DIR__ . '/RecordRules.php';
 
@@ -7,6 +8,7 @@ final class SaldiAssistRecordService
 {
     public const MAX_ROWS = 2000;
 
+    /** Use an authorized tenant's read-only transaction and selected fiscal year. */
     public function __construct(private PDO $pdo, private int $year)
     {
     }

--- a/includes/assist/RecordService.php
+++ b/includes/assist/RecordService.php
@@ -1,0 +1,198 @@
+<?php
+// 20260907 CDX/LH Bounded snapshots of saved journal and sales-invoice records.
+require_once __DIR__ . '/RecordAuth.php';
+require_once __DIR__ . '/RecordRules.php';
+
+final class SaldiAssistRecordService
+{
+    public const MAX_ROWS = 2000;
+
+    public function __construct(private PDO $pdo, private int $year)
+    {
+    }
+
+    /** @param array<int,mixed> $parameters
+     *  @return array<int,array<string,mixed>> */
+    private function rows(string $sql, array $parameters = [], int $limit = self::MAX_ROWS): array
+    {
+        $query = $this->pdo->prepare($sql . ' LIMIT ' . ($limit + 1));
+        $query->execute($parameters);
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+        if (count($rows) > $limit) {
+            throw new SaldiAssistFailure('record_too_large', 413);
+        }
+        return $rows;
+    }
+
+    /** @return array<string,array<string,mixed>> */
+    private function groups(): array
+    {
+        $groups = [];
+        foreach ($this->rows("SELECT art, kodenr, kode, box1, box2, box3, box4, box5 FROM grupper WHERE fiscal_year = ? OR art = 'VK' OR (art = 'RA' AND kodenr = ?) OR (art = 'DIV' AND kodenr = 3) ORDER BY id", [$this->year, $this->year], 10000) as $group) {
+            $groups[$group['art'] . ':' . $group['kodenr']] = $group;
+        }
+        return $groups;
+    }
+
+    /** @param array<string,mixed> $data */
+    private function revision(array $data): string
+    {
+        return hash('sha256', json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /** @return array{header:array,rows:array,reference:array} */
+    private function journal(int $id): array
+    {
+        $header = saldi_assist_one($this->pdo, 'SELECT id, kladdenote, bogfort, kladdedate FROM kladdeliste WHERE id = ?', [$id]);
+        if (!$header) {
+            throw new SaldiAssistFailure('record_not_found', 404);
+        }
+        // SELECT * internally tolerates releases predating per-line VAT overrides. Nothing is returned without projection below.
+        $rows = $this->rows('SELECT * FROM kassekladde WHERE kladde_id = ? ORDER BY id', [$id]);
+        $groups = $this->groups();
+        $accounts = [];
+        foreach ($this->rows('SELECT kontonr, kontotype, lukket, moms FROM kontoplan WHERE regnskabsaar = ? ORDER BY kontonr, id', [$this->year], 10000) as $account) {
+            $accounts['F:' . $account['kontonr']] = $account;
+        }
+        $numbers = [];
+        foreach ($rows as $row) {
+            foreach (['debet' => 'd_type', 'kredit' => 'k_type'] as $side => $field) {
+                if (in_array(trim((string)$row[$field]), ['D', 'K'], true) && !empty($row[$side])) {
+                    $numbers[(string)$row[$side]] = (string)$row[$side];
+                }
+            }
+        }
+        if ($numbers) {
+            $placeholders = implode(',', array_fill(0, count($numbers), '?'));
+            foreach ($this->rows("SELECT kontonr, art, gruppe FROM adresser WHERE kontonr IN ($placeholders) AND art IN ('D','K') ORDER BY id", array_values($numbers), 4000) as $account) {
+                $accounts[$account['art'] . ':' . $account['kontonr']] = $account;
+            }
+        }
+        $fiscal = $groups['RA:' . $this->year] ?? [];
+        $period = null;
+        if (checkdate((int)($fiscal['box1'] ?? 0), 1, (int)($fiscal['box2'] ?? 0))
+            && checkdate((int)($fiscal['box3'] ?? 0), 1, (int)($fiscal['box4'] ?? 0))) {
+            $start = sprintf('%04d-%02d-01', $fiscal['box2'], $fiscal['box1']);
+            $end = new DateTimeImmutable(sprintf('%04d-%02d-01', $fiscal['box4'], $fiscal['box3']));
+            $period = ['start' => $start, 'end' => $end->format('Y-m-t')];
+        }
+        $closed = [];
+        if (saldi_assist_one($this->pdo, "SELECT to_regclass('moms_periode_luk') AS name")['name']) {
+            foreach ($this->rows("SELECT kalender_aar, kalender_maaned FROM moms_periode_luk WHERE status = 'closed' ORDER BY kalender_aar, kalender_maaned") as $month) {
+                $closed[] = sprintf('%04d-%02d', $month['kalender_aar'], $month['kalender_maaned']);
+            }
+        }
+        $rates = [];
+        foreach ($this->rows('SELECT dates.valuta, dates.transdate, rate.kurs FROM
+            (SELECT DISTINCT valuta, transdate FROM kassekladde WHERE kladde_id = ? AND valuta <> 0 AND transdate IS NOT NULL) dates
+            LEFT JOIN LATERAL (SELECT kurs FROM valuta WHERE gruppe = dates.valuta AND valdate <= dates.transdate ORDER BY valdate DESC, id DESC LIMIT 1) rate ON true
+            ORDER BY dates.valuta, dates.transdate', [$id]) as $rate) {
+            $rates[$rate['valuta'] . ':' . $rate['transdate']] = $rate['kurs'];
+        }
+        $draft = saldi_assist_one($this->pdo, 'SELECT 1 FROM tmpkassekl WHERE kladde_id = ? LIMIT 1', [$id]) !== null;
+        return ['header' => $header, 'rows' => $rows, 'reference' => [
+            'period' => $period, 'closed_months' => $closed, 'accounts' => $accounts,
+            'groups' => $groups, 'rates' => $rates, 'has_draft' => $draft,
+        ]];
+    }
+
+    /** @param array<int,int> $rowIds
+     *  @return array<string,mixed> */
+    public function execute(string $operation, string $kind, int $id, array $rowIds = []): array
+    {
+        $allowed = $kind === 'journal' ? ['get_journal_context', 'validate_journal'] : ['get_invoice_status'];
+        if (!in_array($operation, $allowed, true)) {
+            throw new SaldiAssistFailure('operation_forbidden');
+        }
+        if ($kind === 'invoice') {
+            return $this->invoice($id);
+        }
+        $data = $this->journal($id);
+        $result = [
+            'kind' => $kind, 'record_id' => $id, 'basis' => 'saved', 'revision' => $this->revision($data),
+            'checked_at' => gmdate('c'), 'operation' => $operation,
+            'status' => match ($data['header']['bogfort']) { 'V' => 'posted', 'S' => 'simulated', default => 'draft' },
+            'row_count' => count($data['rows']), 'has_saved_draft' => $data['reference']['has_draft'],
+        ];
+        if ($operation === 'validate_journal') {
+            return array_merge($result, saldi_assist_validate_journal($data['header'], $data['rows'], $data['reference']));
+        }
+        $selected = $rowIds ? array_filter($data['rows'], static fn(array $row): bool => in_array((int)$row['id'], $rowIds, true)) : $data['rows'];
+        $result['rows'] = [];
+        foreach (array_slice(array_values($selected), 0, 60) as $row) {
+            $result['rows'][] = [
+                'row_id' => (int)$row['id'], 'voucher' => $row['bilag'], 'date' => $row['transdate'],
+                'description' => mb_substr((string)$row['beskrivelse'], 0, 300),
+                'debit_type' => $row['d_type'], 'debit' => $row['debet'], 'credit_type' => $row['k_type'], 'credit' => $row['kredit'],
+                'amount' => $row['amount'], 'currency_id' => (int)($row['valuta'] ?? 0),
+                'vat_exempt' => !empty($row['momsfri']), 'debit_vat' => $row['debetvat'] ?? null, 'credit_vat' => $row['kreditvat'] ?? null,
+            ];
+        }
+        $result['rows_truncated'] = count($selected) > 60;
+        $result['note'] = mb_substr((string)$data['header']['kladdenote'], 0, 300);
+        return $result;
+    }
+
+    /** @return array<string,mixed> */
+    private function invoice(int $id): array
+    {
+        // No customer addresses, emails, bank details or unrestricted order columns leave this reader.
+        $order = saldi_assist_one($this->pdo, "SELECT id, art, status, kontonr, ordrenr, fakturanr, fakturadate, sum, moms, valuta, betalt, felt_1, ref, afd FROM ordrer WHERE id = ? AND art IN ('DO', 'DK')", [$id]);
+        if (!$order) {
+            throw new SaldiAssistFailure('record_not_found', 404);
+        }
+        $rows = $this->rows('SELECT id, antal, leveret, leveres, vare_id, samlevare, folgevare FROM ordrelinjer WHERE ordre_id = ? ORDER BY id', [$id]);
+        $groups = $this->groups();
+        $settings = $this->rows("SELECT var_name, var_grp, var_value, pos_id FROM settings WHERE (var_name = 'lockedInvoiceButton' AND var_grp = 'debitor') OR (var_name = 'showPaymentLink' AND var_grp = 'deb_ordre') ORDER BY id");
+        $closedPeriod = null;
+        if ($order['fakturadate'] && saldi_assist_one($this->pdo, "SELECT to_regclass('moms_periode_luk') AS name")['name']) {
+            $closedPeriod = saldi_assist_one($this->pdo, "SELECT kalender_aar, kalender_maaned FROM moms_periode_luk WHERE status = 'closed' AND kalender_aar = ? AND kalender_maaned = ? LIMIT 1",
+                [(int)substr($order['fakturadate'], 0, 4), (int)substr($order['fakturadate'], 5, 2)]);
+        }
+        $data = ['order' => $order, 'rows' => $rows, 'groups' => $groups, 'settings' => $settings, 'closed_period' => $closedPeriod];
+        $reasons = [];
+        $add = static function (string $code, string $message) use (&$reasons): void {
+            $reasons[] = ['code' => $code, 'message' => $message, 'row_ids' => [], 'severity' => 'error'];
+        };
+        $status = (int)$order['status'];
+        if ($status >= 3) {
+            $add('already_invoiced', 'Dokumentet er allerede faktureret.');
+        } elseif (!$rows) {
+            $add('invoice_empty', 'Der er ingen gemte ordrelinjer at fakturere.');
+        } elseif (empty($order['kontonr'])) {
+            $add('customer_missing', 'Salgsdokumentet mangler en kundekonto.');
+        }
+        if ($status < 3 && $closedPeriod) {
+            $add('period_closed', 'Perioden for den gemte fakturadato er lukket for bogføring.');
+        }
+        $lock = '';
+        $paymentLinkConfigured = false;
+        foreach ($settings as $setting) {
+            if ($setting['var_name'] === 'lockedInvoiceButton') {
+                $lock = (string)$setting['var_value'];
+            } elseif ((int)$setting['pos_id'] === (int)$order['afd'] && $setting['var_value'] === 'on') {
+                $paymentLinkConfigured = true;
+            }
+        }
+        $possiblePaymentLock = saldi_assist_invoice_payment_locked($order['betalt'], $paymentLinkConfigured, $lock, (string)$order['ref'], (string)$order['felt_1']);
+        // The page also depends on the chosen terminal, card setup, delivery batches and unsaved form choices.
+        // A potential gate is not evidence that its button is disabled in this user's form.
+        return [
+            'kind' => 'invoice', 'record_id' => $id, 'basis' => 'saved', 'revision' => $this->revision($data),
+            'checked_at' => gmdate('c'), 'operation' => 'get_invoice_status',
+            'status' => $reasons ? 'blocked' : 'incomplete',
+            'document_state' => $status >= 3 ? 'invoiced' : ($status === 0 ? 'offer' : 'order'),
+            'state_note' => $status === 0 ? 'Gemt tilbudsstatus. Knapperne afhænger også af leveringer og hurtigfakturering.' : null,
+            'document_type' => $order['art'] === 'DK' ? 'credit_note' : 'sales_order',
+            'saved_status' => $status, 'invoice_number' => $order['fakturanr'], 'invoice_date' => $order['fakturadate'],
+            'net' => $order['sum'], 'vat' => $order['moms'], 'currency' => $order['valuta'] ?: 'DKK',
+            'payment_recorded' => !empty($order['betalt']),
+            'payment_gate_requires_form_check' => $possiblePaymentLock,
+            'fast_invoicing' => ($groups['DIV:3']['box4'] ?? '') === 'on',
+            'row_count' => count($rows), 'issues' => $reasons,
+            'actions' => [['action' => 'invoice', 'enabled' => $reasons ? false : null, 'reasons' => $reasons]],
+            'coverage' => ['checked' => ['saved_document_state', 'saved_lines', 'customer_selected', 'saved_invoice_period', 'payment_lock_policy'],
+                'not_checked' => ['delivery_batches', 'terminal_and_card_selection', 'unsaved_form', 'posting_transaction'], 'can_post' => null],
+        ];
+    }
+}

--- a/includes/saldi_assist_record.php
+++ b/includes/saldi_assist_record.php
@@ -1,6 +1,7 @@
 <?php
 // 20260907 CDX/LH Read-only assistant record endpoint. Opt-in, scoped to the active SALDI login.
 // 20260908 CDX/LH Accept the native Apache authorization header.
+// 20260908 CDX/LH Require snapshot revisions on every bearer record read.
 require_once __DIR__ . '/assist/RecordService.php';
 
 header('Content-Type: application/json; charset=utf-8');
@@ -65,7 +66,8 @@ try {
         throw new SaldiAssistFailure('invalid_rows', 400);
     }
     $result = $service->execute($operation === 'grant' ? ($kind === 'journal' ? 'get_journal_context' : 'get_invoice_status') : $operation, $kind, $id, $rowIds);
-    if (isset($body['revision']) && (!is_string($body['revision']) || !hash_equals($result['revision'], $body['revision']))) {
+    if (($operation !== 'grant' || isset($body['revision']))
+        && (!is_string($body['revision'] ?? null) || !hash_equals($result['revision'], $body['revision']))) {
         throw new SaldiAssistFailure('record_changed', 409);
     }
     if ($operation === 'grant') {

--- a/includes/saldi_assist_record.php
+++ b/includes/saldi_assist_record.php
@@ -1,0 +1,88 @@
+<?php
+// 20260907 CDX/LH Read-only assistant record endpoint. Opt-in, scoped to the active SALDI login.
+// 20260908 CDX/LH Accept the native Apache authorization header.
+require_once __DIR__ . '/assist/RecordService.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+header('X-Content-Type-Options: nosniff');
+
+try {
+    if (getenv('SALDI_ASSIST_RECORDS_ENABLED') !== '1') {
+        throw new SaldiAssistFailure('records_disabled', 503);
+    }
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        header('Allow: POST');
+        throw new SaldiAssistFailure('method_not_allowed', 405);
+    }
+    $input = file_get_contents('php://input', false, null, 0, 8193);
+    $body = strlen($input) <= 8192 ? json_decode($input, true) : null;
+    if (!is_array($body)) {
+        throw new SaldiAssistFailure('invalid_request', 400);
+    }
+    $kid = getenv('SALDI_ASSIST_KID') ?: 'k2026a';
+    $secret = getenv('SALDI_ASSIST_CONTEXT_SECRET') ?: '';
+    if (strlen($secret) < 32) {
+        throw new SaldiAssistFailure('not_configured', 503);
+    }
+    $masterName = getenv('SALDI_ASSIST_DB_MASTER') ?: '';
+    $master = saldi_assist_read_connection($masterName);
+    $operation = $body['operation'] ?? '';
+    if ($operation === 'grant') {
+        // JSON POST and exact Origin prevent cross-site minting. No CORS is exposed.
+        $origin = getenv('SALDI_ASSIST_HOST_ORIGIN') ?: ((empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off' ? 'http://' : 'https://') . $_SERVER['HTTP_HOST']);
+        if (($_SERVER['HTTP_ORIGIN'] ?? '') !== $origin) {
+            throw new SaldiAssistFailure('origin_forbidden');
+        }
+        session_start(['read_and_close' => true, 'use_strict_mode' => true]);
+        $online = saldi_assist_one($master, 'SELECT * FROM online WHERE session_id = ? ORDER BY logtime DESC LIMIT 1', [session_id()]);
+        $kind = $body['kind'] ?? '';
+        $id = $body['record_id'] ?? null;
+        $embed = $body['embed_session'] ?? '';
+        if (!in_array($kind, ['journal', 'invoice'], true) || !is_int($id) || $id < 1 || $id > 2147483647
+            || !is_string($embed) || !preg_match('/^[0-9a-f]{32}$/D', $embed)) {
+            throw new SaldiAssistFailure('invalid_record', 400);
+        }
+    } else {
+        $authorization = saldi_assist_authorization($_SERVER, function_exists('getallheaders') ? getallheaders() : []);
+        $token = str_starts_with($authorization, 'Bearer ') ? substr($authorization, 7) : '';
+        $claims = SaldiAssistRecordAuth::verify($token, $kid, $secret, time());
+        $online = saldi_assist_one($master, 'SELECT * FROM online WHERE md5(session_id) = ? ORDER BY logtime DESC LIMIT 1', [$claims['session_locator']]);
+        if ($online) {
+            SaldiAssistRecordAuth::assertSession($claims, $online, $secret);
+        }
+        $kind = $claims['kind'];
+        $id = $claims['record_id'];
+    }
+    if (!$online || empty($online['db']) || empty($online['brugernavn']) || $online['db'] === $masterName) {
+        throw new SaldiAssistFailure('session_expired', 401);
+    }
+    $tenant = saldi_assist_read_connection($online['db']);
+    saldi_assist_authorize($master, $tenant, $online, $kind);
+    $service = new SaldiAssistRecordService($tenant, (int)$online['regnskabsaar']);
+    $rowIds = $body['row_ids'] ?? [];
+    if (!is_array($rowIds) || count($rowIds) > 20 || array_filter($rowIds, static fn($id): bool => !is_int($id) || $id < 1)) {
+        throw new SaldiAssistFailure('invalid_rows', 400);
+    }
+    $result = $service->execute($operation === 'grant' ? ($kind === 'journal' ? 'get_journal_context' : 'get_invoice_status') : $operation, $kind, $id, $rowIds);
+    if (isset($body['revision']) && (!is_string($body['revision']) || !hash_equals($result['revision'], $body['revision']))) {
+        throw new SaldiAssistFailure('record_changed', 409);
+    }
+    if ($operation === 'grant') {
+        $claims = SaldiAssistRecordAuth::claims($online, $kind, $id, $embed, $secret, time());
+        $result = ['kind' => $kind, 'recordId' => $id, 'revision' => $result['revision'],
+            'grant' => SaldiAssistRecordAuth::sign($claims, $kid, $secret), 'expiresAt' => $claims['exp'],
+            'hasSavedDraft' => $result['has_saved_draft'] ?? false];
+    }
+    // No accounting mutation is possible inside either READ ONLY transaction.
+    $tenant->rollBack();
+    $master->rollBack();
+    echo json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+} catch (SaldiAssistFailure $error) {
+    http_response_code($error->status);
+    echo json_encode(['error' => $error->getMessage()]);
+} catch (Throwable $error) {
+    // PDO messages can contain tenant names and SQL. Keep them out of responses and assistant logs.
+    http_response_code(503);
+    echo json_encode(['error' => 'records_unavailable']);
+}

--- a/index/main.php
+++ b/index/main.php
@@ -34,6 +34,7 @@
 // 20260904 Sawaneh WP-1.6: update_iframe() tags iframe navigations with inframe=1 (context flag for hosted pages)
 // 20260907 CDX/LH Fjernede gammel widget-loader, saa SALDI Assist kun indlaeses en gang
 // 20260907 CDX/LH Preserve iframe navigation while merging the current shell integration.
+// 20260907 CDX/LH Enable the saved-record bridge when the installation opts in.
 @session_start();
 $s_id = session_id();
 
@@ -691,4 +692,11 @@ $assistVersion = isset($version) ? (string)$version : '';
 </script>
 <script src="<?= htmlspecialchars($assistWidgetUrl, ENT_QUOTES, 'UTF-8') ?>" data-widget-id="saldi" data-brand="SALDI" data-lang="da" data-app-version="<?= htmlspecialchars($assistVersion, ENT_QUOTES, 'UTF-8') ?>" defer></script>
 <script>window.SaldiAssist = { appVersion: <?= json_encode($assistVersion) ?>, correlationId: <?= json_encode($assist_correlation_id ?? null) ?>, errorCategory: <?= json_encode($assist_error_category ?? null) ?>, getContextToken: function (sessionHash) { return fetch('../includes/saldi_assist_token.php?embed_session=' + encodeURIComponent(sessionHash), {credentials:'same-origin'}).then(function (r) { return r.ok ? r.json() : null }).then(function (j) { return j && j.token ? j.token : null }) }, navigate: window.SaldiAssistNavigate };</script>
+<?php if (getenv('SALDI_ASSIST_RECORDS_ENABLED') === '1') { ?>
+<script src="../javascript/saldi-assist-records.js"></script>
+<script>
+  window.SaldiAssist.getRecordContext = window.SaldiAssistRecords.getRecordContext;
+  window.SaldiAssist.highlightRows = window.SaldiAssistRecords.highlightRows;
+</script>
+<?php } ?>
 </html>

--- a/javascript/saldi-assist-records.js
+++ b/javascript/saldi-assist-records.js
@@ -1,0 +1,94 @@
+// 20260907 CDX/LH Saved-record bridge. Reads identifiers and dirty state, never form values.
+(function () {
+  'use strict';
+  var endpoint = new URL('../includes/saldi_assist_record.php', document.currentScript.src).href;
+  var dirtyDocuments = new WeakSet();
+  var observedDocuments = new WeakSet();
+
+  function active() {
+    try {
+      var frame = document.querySelector('iframe[name="iframe_a"]');
+      var win = frame ? frame.contentWindow : window;
+      var doc = win.document;
+      var url = new URL(win.location.href);
+      var kind = /\/finans\/kassekladde\.php$/.test(url.pathname) ? 'journal' :
+        (/\/debitor\/ordre\.php$/.test(url.pathname) ? 'invoice' : null);
+      if (!kind) return null;
+      var input = doc.querySelector(kind === 'journal' ? 'input[name="kladde_id"]' : 'input[name="id"]');
+      var rawId = input ? input.value : url.searchParams.get(kind === 'journal' ? 'kladde_id' : 'id');
+      if (!/^[1-9][0-9]{0,9}$/.test(rawId || '')) return null;
+      var id = Number(rawId);
+      if (id > 2147483647) return null;
+      if (!observedDocuments.has(doc)) {
+        observedDocuments.add(doc);
+        var mark = function () {
+          if (!dirtyDocuments.has(doc)) {
+            dirtyDocuments.add(doc);
+            window.dispatchEvent(new Event('saldi:record-changed'));
+          }
+          doc.querySelectorAll('[data-saldi-assist-highlight]').forEach(function (row) {
+            row.removeAttribute('data-saldi-assist-highlight');
+          });
+        };
+        doc.addEventListener('input', mark, true);
+        doc.addEventListener('change', mark, true);
+      }
+      return { kind: kind, recordId: id, doc: doc, unsavedChanges: dirtyDocuments.has(doc) || win.docChange === true };
+    } catch (_) { return null; }
+  }
+
+  async function getRecordContext(sessionHash) {
+    var before = active();
+    if (!before || !/^[0-9a-f]{32}$/.test(sessionHash || '')) return null;
+    var controller = new AbortController();
+    var timeout = setTimeout(function () { controller.abort(); }, 4000);
+    try {
+      var response = await fetch(endpoint, {
+        method: 'POST', credentials: 'same-origin', cache: 'no-store', signal: controller.signal,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operation: 'grant', kind: before.kind, record_id: before.recordId, embed_session: sessionHash })
+      });
+      if (!response.ok) return null;
+      var record = await response.json();
+      var after = active();
+      if (!after || after.doc !== before.doc || after.kind !== before.kind || after.recordId !== before.recordId) return null;
+      return Object.assign(record, { unsavedChanges: after.unsavedChanges || record.hasSavedDraft === true });
+    } catch (_) { return null; }
+    finally { clearTimeout(timeout); }
+  }
+
+  async function highlightRows(payload, sessionHash) {
+    if (!payload || payload.kind !== 'journal' || !Array.isArray(payload.rowIds) || payload.rowIds.length > 100 ||
+        payload.rowIds.some(function (id) { return !Number.isInteger(id) || id <= 0; })) return false;
+    var record = await getRecordContext(sessionHash);
+    var selected = active();
+    if (!record || !selected || record.unsavedChanges || selected.unsavedChanges || record.kind !== payload.kind ||
+        record.recordId !== payload.recordId || record.revision !== payload.revision) return false;
+    var doc = selected.doc;
+    var style = doc.getElementById('saldi-assist-highlight-style');
+    if (!style) {
+      style = doc.createElement('style');
+      style.id = 'saldi-assist-highlight-style';
+      style.textContent = '[data-saldi-assist-highlight] { outline: 3px solid #b45309; outline-offset: -3px; background-color: #fef3c7 !important; }';
+      doc.head.appendChild(style);
+    }
+    doc.querySelectorAll('[data-saldi-assist-highlight]').forEach(function (row) { row.removeAttribute('data-saldi-assist-highlight'); });
+    var first = null;
+    doc.querySelectorAll('.delete-line-btn[data-id]').forEach(function (button) {
+      if (payload.rowIds.indexOf(Number(button.getAttribute('data-id'))) === -1) return;
+      var row = button.closest('tr');
+      if (row) { row.setAttribute('data-saldi-assist-highlight', ''); first = first || row; }
+    });
+    if (first) first.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    return Boolean(first);
+  }
+
+  document.addEventListener('load', function (event) {
+    if (event.target && event.target.name === 'iframe_a') {
+      active();
+      window.dispatchEvent(new Event('saldi:record-changed'));
+    }
+  }, true);
+  active();
+  window.SaldiAssistRecords = { getRecordContext: getRecordContext, highlightRows: highlightRows };
+})();

--- a/tests/assist/README.md
+++ b/tests/assist/README.md
@@ -7,6 +7,7 @@
 ```bash
 docker run --rm --entrypoint php -v "$PWD:/work:ro" saldi-web /work/tests/assist/records_test.php
 python3 tests/assist/run_records_integration.py
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests/assist -p 'test_*.py' -v
 ```
 
 Use the chatbot repository's virtual environment and pass `--chaty-source /path/to/chaty_V2` to also verify PHP/Python signatures and the real tool adapter. No model-provider call is made.
@@ -15,7 +16,8 @@ See [installation and scope](../../includes/assist/README.md) for the read-only 
 
 ## Verification report — 2026-09-08
 
-- Pure PHP checks: 152 assertions passed, with warnings raised as exceptions.
+- Pure PHP checks: 176 assertions passed, with warnings raised as exceptions.
+- Cleanup failure injection: two checks passed; container/database failures do not skip later cleanup, database drops disconnect leftover sessions, and errors do not print sensitive details.
 - Disposable PostgreSQL/PHP integration including the real Python adapter: passed; fixture rows unchanged and write attempts denied.
 - Local Apache and normal SALDI login: all three operations passed with matching revisions.
 - Local embedded widget: selected saved context received, live model called journal validation, and the result card rendered.
@@ -31,3 +33,23 @@ No posting, invoice sending or accounting form submission was performed by these
 | `RecordService.php` | Change a saved row or relevant period/account setting; old revisions must return 409. Compare saved-draft disclosure and the 2,000-row limit. |
 | `index/main.php`, `saldi-assist-records.js` | Open a saved journal, ask for a check and highlight an affected row; edit without saving and confirm highlighting is refused. Change company/record and ensure previous findings cannot target it. |
 | Feature flags | Disable both host and bot flags and verify the existing documentation chat still works. |
+
+## Review follow-up
+
+All three bearer operations now require the supplied revision to match their
+snapshot. Integration cases cover missing, null, invalid-type, empty and mismatched
+revisions, including omitted revisions after an actual journal/invoice change.
+The chatbot already sends the revision, so no chatbot deployment change is needed.
+
+The suggested voucher-tolerance change was not applied. `finans/bogfor.php`
+rounds amounts into voucher balances and populates `diffbilag` before calling
+`saldi_assist_has_differences($diff, $diffbilag)`. Its second argument can block
+posting even when `abs($diff) < 0.01`. For example, debit 100.005 and credit 100.000
+produce a rounded 0.01 voucher difference; changing the assistant to compare the
+raw 0.005 against 0.01 would incorrectly discard that finding. Added positive and
+negative 0.004/0.005/0.009/0.010 boundary cases preserve the existing behavior.
+These cases do not claim full parity with posting's per-line rounding or FX rules.
+
+Cleanup now attempts every created resource even after a previous cleanup failure,
+uses `DROP DATABASE ... WITH (FORCE)` on the disposable PostgreSQL databases, and
+reports failure without replacing an original test exception or printing secrets.

--- a/tests/assist/README.md
+++ b/tests/assist/README.md
@@ -1,0 +1,33 @@
+# Assistant record service tests
+
+`records_test.php` runs pure journal/authentication checks and characterizes the two predicates extracted from the legacy posting preview and invoice button.
+
+`run_records_integration.py` exercises the actual PHP endpoint with disposable PostgreSQL databases, a temporary SELECT-only login and a temporary PHP container. It removes its resources afterward and never resets an existing company. Defaults use Docker image `saldi-web`, container `saldi-postgres-1` and network `saldi_testnet`; flags can override these names.
+
+```bash
+docker run --rm --entrypoint php -v "$PWD:/work:ro" saldi-web /work/tests/assist/records_test.php
+python3 tests/assist/run_records_integration.py
+```
+
+Use the chatbot repository's virtual environment and pass `--chaty-source /path/to/chaty_V2` to also verify PHP/Python signatures and the real tool adapter. No model-provider call is made.
+
+See [installation and scope](../../includes/assist/README.md) for the read-only database grants and environment settings. The service is disabled by default. The combined chatbot report is in its repository under `integration/saldi-host/RECORD_TOOLS_TEST_REPORT.md`.
+
+## Verification report — 2026-09-08
+
+- Pure PHP checks: 152 assertions passed, with warnings raised as exceptions.
+- Disposable PostgreSQL/PHP integration including the real Python adapter: passed; fixture rows unchanged and write attempts denied.
+- Local Apache and normal SALDI login: all three operations passed with matching revisions.
+- Local embedded widget: selected saved context received, live model called journal validation, and the result card rendered.
+- PHP syntax checks passed for the new service and three changed legacy pages.
+
+No posting, invoice sending or accounting form submission was performed by these checks.
+
+| Affected code | Manual regression scenario before enabling a company |
+| --- | --- |
+| `RecordRules.php`, `finans/bogfor.php` | Compare balanced one-sided entries, one voucher difference and opposite differences across two vouchers; simulation should retain the existing difference condition. |
+| `RecordRules.php`, `debitor/ordre.php` | Compare payment-lock button conditions for an unpaid card order, paid order and Magento/Konto/Kontant exceptions; verify saved facts separately from delivery/terminal choices. |
+| `RecordAuth.php`, `saldi_assist_record.php` | Obtain a grant through the real proxy/Apache configuration, then revoke rights or log out; subsequent reads must fail. Anonymous and wrong-origin grants must fail. |
+| `RecordService.php` | Change a saved row or relevant period/account setting; old revisions must return 409. Compare saved-draft disclosure and the 2,000-row limit. |
+| `index/main.php`, `saldi-assist-records.js` | Open a saved journal, ask for a check and highlight an affected row; edit without saving and confirm highlighting is refused. Change company/record and ensure previous findings cannot target it. |
+| Feature flags | Disable both host and bot flags and verify the existing documentation chat still works. |

--- a/tests/assist/records_test.php
+++ b/tests/assist/records_test.php
@@ -1,11 +1,13 @@
 <?php
 // 20260907 CDX/LH Pure checks and characterization of the extracted legacy predicates.
 // 20260908 CDX/LH Cover Apache/CGI header handling and conflicting credentials.
+// 20260908 CDX/LH Characterize sub-cent voucher differences independently of totals.
 require_once __DIR__ . '/../../includes/assist/RecordRules.php';
 require_once __DIR__ . '/../../includes/assist/RecordAuth.php';
 
 set_error_handler(static function (int $severity, string $message): void { throw new RuntimeException($message); });
 $checks = 0;
+/** Count an assertion and stop immediately with its non-sensitive test label. */
 function expect_assist(bool $ok, string $label): void
 {
     global $checks;
@@ -47,6 +49,21 @@ $validation = saldi_assist_validate_journal(['bogfort' => '-'], $bad, $reference
 expect_assist(count($validation['differences']) === 2, 'opposite voucher differences must not cancel');
 expect_assist($validation['differences'][0]['row_ids'] === [1], 'stable affected row IDs');
 expect_assist($validation['differences'][0]['difference'] === '100.005', 'stored three-decimal amount preserved');
+// bogfor.php rounds individual amounts with afrund(..., 2), then passes diffbilag
+// to the final predicate. These simple two-row vouchers establish its boundaries.
+foreach (['004' => false, '005' => true, '009' => true, '010' => true] as $fraction => $blocked) {
+    foreach ([1, -1] as $sign) {
+        $boundaryRows = $rows;
+        $boundaryRows[0]['amount'] = $sign > 0 ? '100.' . $fraction : '100.000';
+        $boundaryRows[1]['amount'] = $sign < 0 ? '100.' . $fraction : '100.000';
+        $result = saldi_assist_validate_journal(['bogfort' => '-'], $boundaryRows, $reference);
+        $difference = $sign * (int)$fraction / 1000;
+        $legacyVoucherDifferences = $blocked ? [1 => $sign * 0.01] : [];
+        expect_assist(saldi_assist_has_differences($difference, $legacyVoucherDifferences) === $blocked, 'legacy sub-cent voucher decision');
+        expect_assist(($result['status'] === 'blocked') === $blocked, 'assistant preserves sub-cent voucher decision');
+        expect_assist($result['difference_count'] === ($blocked ? 1 : 0), 'voucher finding at rounding boundary');
+    }
+}
 $reference['closed_months'] = ['2026-09'];
 expect_assist(in_array('period_closed', array_column(saldi_assist_validate_journal([], $rows, $reference)['issues'], 'code'), true), 'period lock');
 $reference['closed_months'] = [];

--- a/tests/assist/records_test.php
+++ b/tests/assist/records_test.php
@@ -1,0 +1,86 @@
+<?php
+// 20260907 CDX/LH Pure checks and characterization of the extracted legacy predicates.
+// 20260908 CDX/LH Cover Apache/CGI header handling and conflicting credentials.
+require_once __DIR__ . '/../../includes/assist/RecordRules.php';
+require_once __DIR__ . '/../../includes/assist/RecordAuth.php';
+
+set_error_handler(static function (int $severity, string $message): void { throw new RuntimeException($message); });
+$checks = 0;
+function expect_assist(bool $ok, string $label): void
+{
+    global $checks;
+    $checks++;
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+}
+foreach ([0, 0.009, 0.01, -0.01, 10] as $difference) {
+    foreach ([[], [4 => 1.0]] as $vouchers) {
+        expect_assist(saldi_assist_has_differences($difference, $vouchers) === (abs($difference) >= 0.01 || count($vouchers)), 'legacy balance predicate');
+    }
+}
+foreach ([null, '', '0', '1', '25.00'] as $paid) {
+    foreach ([false, true] as $link) {
+        foreach (['', 'on'] as $lock) {
+            foreach (['', 'Magento'] as $reference) {
+                foreach (['Konto', 'Kontant', 'Kort'] as $method) {
+                    $disabled = '';
+                    if (!$paid && $link && $lock === 'on') { $disabled = 'disabled'; }
+                    if ($reference === 'Magento' || $method === 'Konto' || $method === 'Kontant') { $disabled = ''; }
+                    expect_assist(saldi_assist_invoice_payment_locked($paid, $link, $lock, $reference, $method) === (bool)$disabled, 'legacy payment predicate');
+                }
+            }
+        }
+    }
+}
+$reference = ['period' => ['start' => '2026-01-01', 'end' => '2026-12-31'], 'closed_months' => [],
+    'accounts' => ['F:1000' => ['kontotype' => 'D', 'lukket' => '', 'moms' => ''], 'F:2000' => ['kontotype' => 'S', 'lukket' => '', 'moms' => '']],
+    'groups' => [], 'rates' => []];
+$row = ['id' => 1, 'bilag' => 1, 'transdate' => '2026-09-01', 'amount' => '100.005', 'debet' => 1000, 'kredit' => 0, 'd_type' => 'F', 'k_type' => 'F'];
+$rows = [$row, array_merge($row, ['id' => 2, 'debet' => 0, 'kredit' => 2000])];
+$valid = saldi_assist_validate_journal(['bogfort' => '-'], $rows, $reference);
+expect_assist($valid['status'] === 'checks_passed', 'one-sided rows balance per voucher');
+expect_assist($valid['coverage']['can_post'] === null, 'preliminary check is not posting approval');
+$bad = $rows;
+$bad[1]['bilag'] = 2;
+$validation = saldi_assist_validate_journal(['bogfort' => '-'], $bad, $reference);
+expect_assist(count($validation['differences']) === 2, 'opposite voucher differences must not cancel');
+expect_assist($validation['differences'][0]['row_ids'] === [1], 'stable affected row IDs');
+expect_assist($validation['differences'][0]['difference'] === '100.005', 'stored three-decimal amount preserved');
+$reference['closed_months'] = ['2026-09'];
+expect_assist(in_array('period_closed', array_column(saldi_assist_validate_journal([], $rows, $reference)['issues'], 'code'), true), 'period lock');
+$reference['closed_months'] = [];
+$rows[0]['valuta'] = 1;
+expect_assist(in_array('exchange_rate_missing', array_column(saldi_assist_validate_journal([], $rows, $reference)['issues'], 'code'), true), 'missing FX rate');
+$rows[0]['valuta'] = 0;
+$rows[0]['debetvat'] = 'S1';
+expect_assist(in_array('vat_setup_missing', array_column(saldi_assist_validate_journal([], $rows, $reference)['issues'], 'code'), true), 'missing VAT configuration');
+expect_assist(saldi_assist_milli('-12.003') === -12003, 'negative decimals');
+
+$secret = bin2hex(random_bytes(32));
+$online = ['session_id' => bin2hex(random_bytes(16)), 'db' => 'test_company', 'brugernavn' => 'test_user'];
+$claims = SaldiAssistRecordAuth::claims($online, 'journal', 17, str_repeat('a', 32), $secret, time());
+$token = SaldiAssistRecordAuth::sign($claims, 'test', $secret);
+expect_assist(saldi_assist_authorization(['HTTP_AUTHORIZATION' => $token], []) === $token, 'CGI authorization');
+expect_assist(saldi_assist_authorization([], ['Authorization' => $token]) === $token, 'Apache authorization');
+expect_assist(saldi_assist_authorization([], ['authorization' => $token]) === $token, 'lowercase authorization');
+expect_assist(saldi_assist_authorization(['HTTP_AUTHORIZATION' => $token], ['Authorization' => $token]) === $token, 'same header through both APIs');
+expect_assist(saldi_assist_authorization(['HTTP_AUTHORIZATION' => $token], ['Authorization' => $token . 'x']) === '', 'conflicting headers fail closed');
+expect_assist(saldi_assist_authorization([], ['X-Forwarded-Authorization' => $token]) === '', 'forwarded header does not authenticate');
+expect_assist(SaldiAssistRecordAuth::verify($token, 'test', $secret, time()) === $claims ||
+    SaldiAssistRecordAuth::verify($token, 'test', $secret, time()) == $claims, 'grant round trip');
+expect_assist(strpos($token, $online['session_id']) === false, 'no raw session cookie in grant');
+foreach (['signature', 'expired', 'company', 'user', 'session'] as $case) {
+    try {
+        if ($case === 'signature') { SaldiAssistRecordAuth::verify($token . 'x', 'test', $secret, time()); }
+        elseif ($case === 'expired') { SaldiAssistRecordAuth::verify($token, 'test', $secret, time() + 300); }
+        else {
+            $changed = $online;
+            $field = ['company' => 'db', 'user' => 'brugernavn', 'session' => 'session_id'][$case];
+            $changed[$field] .= '_changed';
+            SaldiAssistRecordAuth::assertSession($claims, $changed, $secret);
+        }
+        expect_assist(false, 'grant must reject ' . $case);
+    } catch (SaldiAssistFailure $error) { expect_assist(true, 'grant rejected ' . $case); }
+}
+echo "PASS $checks assertions\n";

--- a/tests/assist/run_records_integration.py
+++ b/tests/assist/run_records_integration.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Exercise the real PHP endpoint in disposable PostgreSQL databases and a PHP container.
+
+Uses the existing local SALDI Docker image/network. Never bootstraps or resets an
+existing company. Every name and credential is generated and removed in finally.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def command(args, data=None):
+    result = subprocess.run(args, input=data, text=True, capture_output=True)
+    if result.returncode:
+        # SQL/env failures can echo credentials. Do not print subprocess streams.
+        raise RuntimeError(f"{args[0]} failed (exit {result.returncode})")
+    return result.stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--postgres", default="saldi-postgres-1")
+    parser.add_argument("--image", default="saldi-web")
+    parser.add_argument("--network", default="saldi_testnet")
+    parser.add_argument("--chaty-source", type=Path)
+    args = parser.parse_args()
+    source = Path(__file__).resolve().parents[2]
+    suffix = secrets.token_hex(5)
+    master, tenant, reader = [f"assist_test_{suffix}_{part}" for part in ("master", "tenant", "reader")]
+    password, secret, sid = secrets.token_hex(32), secrets.token_hex(32), secrets.token_hex(16)
+    databases, role_created, container = [], False, None
+
+    def sql(database, text):
+        return command(["docker", "exec", "-i", args.postgres, "sh", "-c",
+            'PGPASSWORD="$POSTGRES_PASSWORD" exec psql -X -v ON_ERROR_STOP=1 -At -U "$POSTGRES_USER" -d "$1"', "sh", database], text)
+
+    def snapshot(database, tables):
+        return [sql(database, f"SELECT md5(COALESCE(string_agg(row_to_json(t)::text, '' ORDER BY row_to_json(t)::text), '')) FROM {table} t;") for table in tables]
+
+    def expect(value, label):
+        if not value:
+            raise AssertionError(label)
+
+    try:
+        sql("postgres", f"CREATE ROLE {reader} LOGIN PASSWORD '{password}';")
+        role_created = True
+        for database in [master, tenant]:
+            sql("postgres", f"CREATE DATABASE {database};")
+            databases.append(database)
+        sql(master, f"""
+            CREATE TABLE online (session_id text, db text, brugernavn text, regnskabsaar integer, logtime text);
+            CREATE TABLE regnskab (db text, lukket text, lukkes date);
+            CREATE TABLE settings (var_name text, var_value text);
+            INSERT INTO online VALUES ('{sid}', '{tenant}', 'assist_user', 1, '1');
+            INSERT INTO regnskab VALUES ('{tenant}', '', '2099-12-31');
+            INSERT INTO settings VALUES ('timezone', 'Europe/Copenhagen');
+        """)
+        sql(tenant, """
+            CREATE TABLE brugere (brugernavn text, rettigheder text);
+            INSERT INTO brugere VALUES ('assist_user', '111111');
+            CREATE TABLE kladdeliste (id integer PRIMARY KEY, kladdenote text, bogfort text, kladdedate date);
+            INSERT INTO kladdeliste VALUES (7, 'Kontrolkladden', '-', '2026-09-01');
+            CREATE TABLE kassekladde (id integer PRIMARY KEY, kladde_id integer, bilag integer, transdate date, beskrivelse text,
+                d_type text, debet numeric(15,0), k_type text, kredit numeric(15,0), amount numeric(15,3), momsfri text,
+                debetvat text, kreditvat text, valuta integer, afd integer, projekt text, ansat text);
+            INSERT INTO kassekladde VALUES
+                (10, 7, 1, '2026-09-01', 'Debet', 'F', 1000, 'F', 0, 100.005, '', '', '', 0, 0, '', ''),
+                (11, 7, 2, '2026-09-01', 'Kredit', 'F', 0, 'F', 2000, 100.005, '', '', '', 0, 0, '', '');
+            CREATE TABLE tmpkassekl (kladde_id integer);
+            CREATE TABLE kontoplan (id integer, kontonr numeric(15,0), regnskabsaar integer, kontotype text, lukket text, moms text);
+            INSERT INTO kontoplan VALUES (1,1000,1,'D','',''), (2,2000,1,'S','','');
+            CREATE TABLE grupper (id integer, art text, kodenr integer, kode text, box1 text, box2 text, box3 text, box4 text, box5 text, fiscal_year integer);
+            INSERT INTO grupper VALUES (1,'RA',1,'','1','2026','12','2026','',NULL), (2,'DIV',3,'','','','','on','',NULL);
+            CREATE TABLE adresser (id integer, kontonr text, art text, gruppe integer);
+            CREATE TABLE valuta (id integer, gruppe integer, valdate date, kurs numeric(15,3));
+            CREATE TABLE moms_periode_luk (kalender_aar integer, kalender_maaned integer, status text);
+            CREATE TABLE ordrer (id integer PRIMARY KEY, art text, status integer, kontonr text, ordrenr integer, fakturanr text, fakturadate date,
+                sum numeric(15,3), moms numeric(15,3), valuta text, betalt text, felt_1 text, ref text, afd integer);
+            INSERT INTO ordrer VALUES
+                (12,'DO',3,'100',12,'10012','2026-09-01',100,25,'DKK','0','Konto','',0),
+                (13,'DO',0,'',13,'',NULL,100,25,'DKK','0','Konto','',0),
+                (14,'DO',2,'100',14,'',NULL,100,25,'DKK','0','Kort','',0);
+            CREATE TABLE ordrelinjer (id integer, ordre_id integer, antal numeric, leveret numeric, leveres numeric, vare_id integer, samlevare text, folgevare integer);
+            INSERT INTO ordrelinjer VALUES (21,12,1,1,0,1,'',0), (22,13,1,0,1,1,'',0), (23,14,1,1,0,1,'',0);
+            CREATE TABLE settings (id integer, var_name text, var_grp text, var_value text, pos_id integer);
+            INSERT INTO settings VALUES (1,'lockedInvoiceButton','debitor','on',0), (2,'showPaymentLink','deb_ordre','on',0);
+        """)
+        for database in databases:
+            sql(database, f"GRANT CONNECT ON DATABASE {database} TO {reader}; GRANT USAGE ON SCHEMA public TO {reader}; GRANT SELECT ON ALL TABLES IN SCHEMA public TO {reader};")
+        with tempfile.TemporaryDirectory(prefix="saldi-assist-test-") as temporary:
+            env_path = Path(temporary) / "reader.env"
+            env_path.write_text("\n".join(f"{key}={value}" for key, value in {
+                "SALDI_ASSIST_RECORDS_ENABLED": "1", "SALDI_ASSIST_KID": "integration",
+                "SALDI_ASSIST_CONTEXT_SECRET": secret, "SALDI_ASSIST_DB_HOST": args.postgres,
+                "SALDI_ASSIST_DB_USER": reader, "SALDI_ASSIST_DB_PASSWORD": password,
+                "SALDI_ASSIST_DB_MASTER": master,
+            }.items()) + "\n")
+            os.chmod(env_path, 0o600)
+            container = command(["docker", "run", "-d", "--rm", "--network", args.network, "--env-file", str(env_path),
+                "-v", f"{source}:/work:ro", "-p", "127.0.0.1::8080", "--entrypoint", "php", args.image,
+                "-d", "display_errors=0", "-S", "0.0.0.0:8080", "-t", "/work"])
+        # saldi_testnet is internal; an ordinary bridge is required to publish the loopback port.
+        command(["docker", "network", "connect", "bridge", container])
+        port = command(["docker", "port", container, "8080/tcp"]).split(":")[-1]
+        origin = f"http://127.0.0.1:{port}"
+        url = origin + "/includes/saldi_assist_record.php"
+        command(["docker", "exec", container, "php", "-r", 'session_id($argv[1]); session_start(); $_SESSION["assist_test"] = true; session_write_close();', sid])
+
+        def call(body, token=None, cookie=True, request_origin=origin):
+            headers = {"Content-Type": "application/json", "Origin": request_origin}
+            if cookie:
+                headers["Cookie"] = f"PHPSESSID={sid}"
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            request = Request(url, data=json.dumps(body).encode(), headers=headers)
+            for attempt in range(30):
+                try:
+                    with urlopen(request, timeout=8) as response:
+                        return response.status, json.load(response)
+                except HTTPError as error:
+                    return error.code, json.load(error)
+                except URLError:
+                    if attempt == 29:
+                        raise
+                    time.sleep(0.1)
+
+        def grant(kind="journal", record_id=7):
+            status, data = call({"operation": "grant", "kind": kind, "record_id": record_id, "embed_session": "a" * 32})
+            expect(status == 200, f"grant failed: {status} {data}")
+            return data
+
+        tenant_tables = ["brugere", "kladdeliste", "kassekladde", "tmpkassekl", "kontoplan", "grupper", "adresser", "valuta", "moms_periode_luk", "ordrer", "ordrelinjer", "settings"]
+        before = snapshot(tenant, tenant_tables), snapshot(master, ["online", "regnskab", "settings"])
+        expect(call({"operation": "grant", "kind": "journal", "record_id": 7, "embed_session": "a" * 32}, cookie=False)[0] == 401, "anonymous grant denied")
+        expect(call({"operation": "grant"}, request_origin="https://elsewhere.example")[0] == 403, "cross-origin grant denied")
+        journal = grant()
+        status, validation = call({"operation": "validate_journal", "revision": journal["revision"]}, journal["grant"], cookie=False)
+        expect(status == 200 and len(validation["differences"]) == 2, "opposite voucher differences")
+        expect(validation["differences"][0]["row_ids"] == [10], "stable row IDs")
+        status, context = call({"operation": "get_journal_context", "revision": journal["revision"], "row_ids": [11, 999]}, journal["grant"], cookie=False)
+        expect(status == 200 and [row["row_id"] for row in context["rows"]] == [11], "row scope enforced")
+        expect(call({"operation": "get_invoice_status"}, journal["grant"])[0] == 403, "operation scope enforced")
+        for record_id, reason in [(12, "already_invoiced"), (13, "customer_missing")]:
+            invoice = grant("invoice", record_id)
+            status, data = call({"operation": "get_invoice_status", "revision": invoice["revision"]}, invoice["grant"], cookie=False)
+            expect(status == 200 and data["actions"][0]["enabled"] is False and data["issues"][0]["code"] == reason, "invoice action reason")
+        pending = grant("invoice", 14)
+        _, data = call({"operation": "get_invoice_status"}, pending["grant"])
+        expect(data["payment_gate_requires_form_check"] and data["actions"][0]["enabled"] is None, "form-dependent payment gate stays unknown")
+        expect(before == (snapshot(tenant, tenant_tables), snapshot(master, ["online", "regnskab", "settings"])), "all reads leave all fixture tables identical")
+
+        if args.chaty_source:
+            sys.path.insert(0, str(args.chaty_source.resolve()))
+            from backend.app.config import settings
+            from backend.app.record_tools import RecordContext, RecordToolSession
+            settings.saldi_records_enabled = True
+            settings.saldi_record_api_url = url
+            settings.saldi_record_allow_http = True
+            settings.context_token_keys_raw = json.dumps({"integration": secret})
+            resolved = SimpleNamespace(access=True, screen_id="finans/kassekladde.php", claims=SimpleNamespace(
+                tenant_hash=hashlib.sha256(f"saldi-tenant:{tenant}".encode()).hexdigest()[:32],
+                user_hash=hashlib.sha256(f"saldi-user:{tenant}:assist_user".encode()).hexdigest()[:32], embed_session="a" * 32))
+            tools = RecordToolSession.create(RecordContext(kind="journal", recordId=7, revision=journal["revision"]), journal["grant"], resolved)
+            expect(tools is not None and tools.execute("validate_journal", {})["status"] == "blocked", "real Python to PHP transport and signature interoperability")
+
+        sql(tenant, "INSERT INTO moms_periode_luk VALUES (2026, 9, 'closed'); UPDATE ordrer SET fakturadate = '2026-09-01' WHERE id = 14;")
+        period_grant = grant("invoice", 14)
+        _, period_result = call({"operation": "get_invoice_status"}, period_grant["grant"])
+        expect(period_result["issues"][0]["code"] == "period_closed", "closed invoice period")
+        expect(call({"operation": "validate_journal", "revision": journal["revision"]}, journal["grant"])[0] == 409, "reference-setting change invalidates revision")
+        sql(tenant, "DELETE FROM moms_periode_luk; INSERT INTO tmpkassekl VALUES (7);")
+        draft_grant = grant()
+        expect(draft_grant["hasSavedDraft"], "temporary draft is disclosed")
+        sql(tenant, "DELETE FROM tmpkassekl;")
+        sql(tenant, "INSERT INTO kladdeliste VALUES (9, '', '-', '2026-09-01'); INSERT INTO kassekladde (id, kladde_id, amount) SELECT id, 9, 0 FROM generate_series(1000, 3000) id;")
+        expect(call({"operation": "grant", "kind": "journal", "record_id": 9, "embed_session": "a" * 32})[0] == 413, "oversized journal is refused in full")
+
+        sql(tenant, "UPDATE kassekladde SET amount = amount + 0.001 WHERE id = 10;")
+        expect(call({"operation": "validate_journal", "revision": journal["revision"]}, journal["grant"])[0] == 409, "stale revision refused")
+        fresh = grant()
+        expect(fresh["revision"] != journal["revision"], "revision changes with saved content")
+        sql(tenant, "UPDATE brugere SET rettigheder = '000000';")
+        expect(call({"operation": "validate_journal"}, fresh["grant"])[0] == 403, "live rights revocation")
+        sql(tenant, "UPDATE brugere SET rettigheder = '111111';")
+        sql(master, "UPDATE online SET db = 'company_changed';")
+        expect(call({"operation": "validate_journal"}, fresh["grant"])[0] == 403, "company switch invalidates grant")
+        sql(master, f"UPDATE online SET db = '{tenant}'; DELETE FROM online;")
+        expect(call({"operation": "validate_journal"}, fresh["grant"])[0] == 401, "logout invalidates grant")
+        denied = command(["docker", "exec", container, "php", "-r",
+            'require "/work/includes/assist/RecordAuth.php"; $p=saldi_assist_read_connection($argv[1]); try { $p->exec("DELETE FROM kassekladde"); exit(1); } catch (PDOException $e) { echo $e->getCode(); }', tenant])
+        expect(denied in ("25006", "42501"), "database enforces read-only access")
+        adapter = ", Python adapter" if args.chaty_source else ""
+        print(f"PASS: PHP endpoints{adapter}, scoped grants, revisions, invoice reasons, unchanged snapshots and database read-only enforcement")
+    finally:
+        if container:
+            command(["docker", "rm", "-f", container])
+        for database in reversed(databases):
+            sql("postgres", f"DROP DATABASE {database};")
+        if role_created:
+            sql("postgres", f"DROP ROLE {reader};")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/assist/run_records_integration.py
+++ b/tests/assist/run_records_integration.py
@@ -20,6 +20,7 @@ from urllib.request import Request, urlopen
 
 
 def command(args, data=None):
+    """Run a subprocess without exposing credential-bearing stderr on failure."""
     result = subprocess.run(args, input=data, text=True, capture_output=True)
     if result.returncode:
         # SQL/env failures can echo credentials. Do not print subprocess streams.
@@ -27,7 +28,28 @@ def command(args, data=None):
     return result.stdout.strip()
 
 
+def cleanup_resources(container, databases, reader, sql, run=command):
+    """Attempt every generated resource cleanup, returning the number of failures."""
+    steps = []
+    if container:
+        steps.append((run, (["docker", "rm", "-f", container],)))
+    for database in reversed(databases):
+        steps.append((sql, ("postgres", f"DROP DATABASE {database} WITH (FORCE);")))
+    if reader:
+        steps.append((sql, ("postgres", f"DROP ROLE {reader};")))
+    failures = 0
+    for action, arguments in steps:
+        try:
+            action(*arguments)
+        except Exception as error:
+            failures += 1
+            # Exception messages can include credentials; retain only their type.
+            print(f"cleanup step failed: {type(error).__name__}", file=sys.stderr)
+    return failures
+
+
 def main():
+    """Provision disposable fixtures, verify the HTTP contract, and remove them."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--postgres", default="saldi-postgres-1")
     parser.add_argument("--image", default="saldi-web")
@@ -41,13 +63,16 @@ def main():
     databases, role_created, container = [], False, None
 
     def sql(database, text):
+        """Execute fixture SQL using credentials already inside the test container."""
         return command(["docker", "exec", "-i", args.postgres, "sh", "-c",
             'PGPASSWORD="$POSTGRES_PASSWORD" exec psql -X -v ON_ERROR_STOP=1 -At -U "$POSTGRES_USER" -d "$1"', "sh", database], text)
 
     def snapshot(database, tables):
+        """Hash table contents deterministically to detect writes during read tests."""
         return [sql(database, f"SELECT md5(COALESCE(string_agg(row_to_json(t)::text, '' ORDER BY row_to_json(t)::text), '')) FROM {table} t;") for table in tables]
 
     def expect(value, label):
+        """Fail with a named contract assertion instead of printing fixture data."""
         if not value:
             raise AssertionError(label)
 
@@ -117,6 +142,7 @@ def main():
         command(["docker", "exec", container, "php", "-r", 'session_id($argv[1]); session_start(); $_SESSION["assist_test"] = true; session_write_close();', sid])
 
         def call(body, token=None, cookie=True, request_origin=origin):
+            """POST JSON and return status/body, retrying only server-startup failures."""
             headers = {"Content-Type": "application/json", "Origin": request_origin}
             if cookie:
                 headers["Cookie"] = f"PHPSESSID={sid}"
@@ -135,6 +161,7 @@ def main():
                     time.sleep(0.1)
 
         def grant(kind="journal", record_id=7):
+            """Mint a scoped grant and retain its saved snapshot revision."""
             status, data = call({"operation": "grant", "kind": kind, "record_id": record_id, "embed_session": "a" * 32})
             expect(status == 200, f"grant failed: {status} {data}")
             return data
@@ -155,8 +182,13 @@ def main():
             status, data = call({"operation": "get_invoice_status", "revision": invoice["revision"]}, invoice["grant"], cookie=False)
             expect(status == 200 and data["actions"][0]["enabled"] is False and data["issues"][0]["code"] == reason, "invoice action reason")
         pending = grant("invoice", 14)
-        _, data = call({"operation": "get_invoice_status"}, pending["grant"])
+        _, data = call({"operation": "get_invoice_status", "revision": pending["revision"]}, pending["grant"])
         expect(data["payment_gate_requires_form_check"] and data["actions"][0]["enabled"] is None, "form-dependent payment gate stays unknown")
+        for record, operations in [(journal, ["get_journal_context", "validate_journal"]), (pending, ["get_invoice_status"])]:
+            for operation in operations:
+                for fields in [{}, {"revision": None}, {"revision": 42}, {"revision": []}, {"revision": ""}, {"revision": "0" * 64}]:
+                    status, error = call({"operation": operation, **fields}, record["grant"], cookie=False)
+                    expect(status == 409 and error["error"] == "record_changed", f"{operation} requires a matching revision")
         expect(before == (snapshot(tenant, tenant_tables), snapshot(master, ["online", "regnskab", "settings"])), "all reads leave all fixture tables identical")
 
         if args.chaty_source:
@@ -174,8 +206,10 @@ def main():
             expect(tools is not None and tools.execute("validate_journal", {})["status"] == "blocked", "real Python to PHP transport and signature interoperability")
 
         sql(tenant, "INSERT INTO moms_periode_luk VALUES (2026, 9, 'closed'); UPDATE ordrer SET fakturadate = '2026-09-01' WHERE id = 14;")
+        expect(call({"operation": "get_invoice_status", "revision": pending["revision"]}, pending["grant"])[0] == 409, "stale invoice revision refused")
+        expect(call({"operation": "get_invoice_status"}, pending["grant"])[0] == 409, "omitting a stale invoice revision does not bypass the check")
         period_grant = grant("invoice", 14)
-        _, period_result = call({"operation": "get_invoice_status"}, period_grant["grant"])
+        _, period_result = call({"operation": "get_invoice_status", "revision": period_grant["revision"]}, period_grant["grant"])
         expect(period_result["issues"][0]["code"] == "period_closed", "closed invoice period")
         expect(call({"operation": "validate_journal", "revision": journal["revision"]}, journal["grant"])[0] == 409, "reference-setting change invalidates revision")
         sql(tenant, "DELETE FROM moms_periode_luk; INSERT INTO tmpkassekl VALUES (7);")
@@ -186,7 +220,9 @@ def main():
         expect(call({"operation": "grant", "kind": "journal", "record_id": 9, "embed_session": "a" * 32})[0] == 413, "oversized journal is refused in full")
 
         sql(tenant, "UPDATE kassekladde SET amount = amount + 0.001 WHERE id = 10;")
-        expect(call({"operation": "validate_journal", "revision": journal["revision"]}, journal["grant"])[0] == 409, "stale revision refused")
+        for operation in ["get_journal_context", "validate_journal"]:
+            expect(call({"operation": operation, "revision": journal["revision"]}, journal["grant"])[0] == 409, "stale journal revision refused")
+            expect(call({"operation": operation}, journal["grant"])[0] == 409, "omitting a stale journal revision does not bypass the check")
         fresh = grant()
         expect(fresh["revision"] != journal["revision"], "revision changes with saved content")
         sql(tenant, "UPDATE brugere SET rettigheder = '000000';")
@@ -199,15 +235,12 @@ def main():
         denied = command(["docker", "exec", container, "php", "-r",
             'require "/work/includes/assist/RecordAuth.php"; $p=saldi_assist_read_connection($argv[1]); try { $p->exec("DELETE FROM kassekladde"); exit(1); } catch (PDOException $e) { echo $e->getCode(); }', tenant])
         expect(denied in ("25006", "42501"), "database enforces read-only access")
-        adapter = ", Python adapter" if args.chaty_source else ""
-        print(f"PASS: PHP endpoints{adapter}, scoped grants, revisions, invoice reasons, unchanged snapshots and database read-only enforcement")
     finally:
-        if container:
-            command(["docker", "rm", "-f", container])
-        for database in reversed(databases):
-            sql("postgres", f"DROP DATABASE {database};")
-        if role_created:
-            sql("postgres", f"DROP ROLE {reader};")
+        failures = cleanup_resources(container, databases, reader if role_created else None, sql)
+        if failures and sys.exc_info()[0] is None:
+            raise RuntimeError(f"{failures} cleanup steps failed")
+    adapter = ", Python adapter" if args.chaty_source else ""
+    print(f"PASS: PHP endpoints{adapter}, scoped grants, revisions, invoice reasons, unchanged snapshots and database read-only enforcement")
 
 
 if __name__ == "__main__":

--- a/tests/assist/test_integration_cleanup.py
+++ b/tests/assist/test_integration_cleanup.py
@@ -1,0 +1,47 @@
+"""Failure-injection checks for cleanup of disposable integration resources."""
+import contextlib
+import io
+import unittest
+
+from run_records_integration import cleanup_resources
+
+
+class CleanupTests(unittest.TestCase):
+    """One failed cleanup must not strand the remaining databases or reader."""
+
+    def test_container_and_database_failures_do_not_skip_remaining_resources(self):
+        """Attempt every resource, force-disconnect DB sessions, and redact errors."""
+        attempted = []
+
+        def remove_container(args):
+            """Simulate a Docker failure whose detail must not reach stderr."""
+            attempted.append("container")
+            raise RuntimeError("sensitive subprocess detail")
+
+        def sql(database, statement):
+            """Leave the first drop failing while recording all later attempts."""
+            self.assertEqual(database, "postgres")
+            attempted.append(statement)
+            if statement == "DROP DATABASE fixture_tenant WITH (FORCE);":
+                raise RuntimeError("sensitive database detail")
+
+        output = io.StringIO()
+        with contextlib.redirect_stderr(output):
+            failures = cleanup_resources("fixture_container", ["fixture_master", "fixture_tenant"], "fixture_reader", sql, remove_container)
+        self.assertEqual(failures, 2)
+        self.assertEqual(attempted, ["container", "DROP DATABASE fixture_tenant WITH (FORCE);",
+                                    "DROP DATABASE fixture_master WITH (FORCE);", "DROP ROLE fixture_reader;"])
+        self.assertNotIn("sensitive", output.getvalue())
+        self.assertEqual(output.getvalue().count("cleanup step failed: RuntimeError"), 2)
+
+    def test_only_created_resources_are_cleaned(self):
+        """An early provisioning failure leaves no role/container to remove."""
+        statements = []
+        failures = cleanup_resources(None, ["fixture_master"], None,
+                                     lambda database, statement: statements.append(statement))
+        self.assertEqual(failures, 0)
+        self.assertEqual(statements, ["DROP DATABASE fixture_master WITH (FORCE);"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When a user asks about an open journal or sales document, SALDI Assist currently has documentation and screen context but no saved-record facts. This adds three scoped read-only operations: `get_journal_context`, `validate_journal`, and `get_invoice_status`, plus the opt-in browser bridge for selecting a record and highlighting affected journal rows.

Access requires a five-minute grant bound to the live login, company, user, widget session and record. Every read rechecks company/module rights, uses independent READ ONLY transactions and SELECT-only credentials, and rejects stale revisions. Unsaved field values are never captured. Journal validation is explicitly preliminary: VAT/FX/posting parity and several invoice form gates remain outside coverage. The existing balance and payment-lock predicates are shared with their legacy callers and characterized by tests.

Disabled by default; no accounting migration. Requires the matching chatbot release and PHP 8+/PDO PostgreSQL/mbstring. Configuration, table grants, data flow and rollback: [`includes/assist/README.md`](https://github.com/DANOSOFT/saldi/blob/feature/saldi-assistant-tools/includes/assist/README.md).

Validation: 176 PHP assertions, disposable PostgreSQL/PHP/Python integration (including write denial and unchanged snapshots), PHP lint, and a real local Apache/SALDI/widget smoke all pass. A live local model turn called journal validation and rendered the result card. Rebased onto current master; the shell smoke passed again, preserving the recent iframe-navigation and duplicate-loader fixes. No posting or invoice sending was exercised.

The file-by-file manual regression checklist is in `tests/assist/README.md`; verify local delivery/payment arrangements and full posting behavior before enabling a company.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in assistant service for securely viewing saved journal and invoice records.
  - Added journal validation results, including balance differences and blocking issues.
  - Added invoice payment-status details and explanations when payment actions are locked.
  - Added support for highlighting relevant journal rows and detecting unsaved changes.
  - Added revision checks to prevent displaying outdated record information.

- **Bug Fixes**
  - Centralized journal difference and invoice-locking behavior for more consistent results.

- **Documentation**
  - Added setup, security, usage, and rollback guidance for the assistant service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Review findings verified against the implementation:

- All three bearer operations now require a matching revision; integration tests cover omitted/null/malformed/stale revisions, including after journal and invoice changes. Existing bot calls already send the revision.
- Integration cleanup attempts every created resource, force-drops only its disposable databases, reports cleanup failures without exposing exception details, and preserves an original test failure. Two failure-injection checks pass. Missing helper documentation was added.
- The suggested change to treat a 0.005 voucher difference as balanced was not applied: `finans/bogfor.php` builds `diffbilag` from rounded voucher balances before the shared final predicate. Debit 100.005 / credit 100.000 therefore produces a voucher finding even though the raw grand total is below 0.01. Eight signed boundary cases (24 assertions) preserve that behavior. Full per-line posting/FX parity remains outside this preliminary reader's scope.
