### PR TITLE
SST-761: restore the debtor ledger undo-reconciliation link

### DIFF
--- a/debitor/generalLedger.php
+++ b/debitor/generalLedger.php
@@ -1,5 +1,6 @@
 <?php
 // --- debitor/generalLedger.php --- patch 5.0.0 --- 2026-03-19 ---
+// 20260908 CDX/LH Restored the reconciled credit entry link for undoing reconciliation.
 
 function debitorGeneralLedgerEscape($value)
 {
@@ -429,7 +430,7 @@ print "</div>";
 					'oppId' => (int)$entry['id'],
 					'unAlignAccount' => $accountId
 				)));
-				$creditCell = "<a class='debitor-ledger-balanced-link' I have merged and tested, and backgrounds in test_12 are displayed, so no problems here.href='" . debitorGeneralLedgerEscape($unAlignUrl) . "' title='Udlign id=" . (int)$entry['udlign_id'] . ". Klik for at ophæve udligningen' onclick=\"return confirm('Vil du ophæve udligningen af dette beløb samt modstående med udlign id " . (int)$entry['udlign_id'] . "?')\">$displayAmount</a>";
+				$creditCell = "<a class='debitor-ledger-balanced-link' href='" . debitorGeneralLedgerEscape($unAlignUrl) . "' title='Udlign id=" . (int)$entry['udlign_id'] . ". Klik for at ophæve udligningen' onclick=\"return confirm('Vil du ophæve udligningen af dette beløb samt modstående med udlign id " . (int)$entry['udlign_id'] . "?')\">$displayAmount</a>";
 			}
 		}
 


### PR DESCRIPTION
## What are the changes about?

[SST-761](https://saldi-team.atlassian.net/browse/SST-761): the reconciled credit amount on the debtor account ledger had review text embedded before `href`, so the browser rendered an anchor without a working destination. Remove the stray text to restore the undo-reconciliation link and its existing confirmation dialog.

Only `debitor/generalLedger.php` changes, including its history entry.

## Validation

- PHP 8.2 syntax check and `git diff --check` passed.
- Executed the actual debit/credit link construction with warnings enabled and parsed the resulting anchors. Reconciliation, account, entry, filter, and quoted return-URL parameters are preserved.
- Executed the confirmation handler with both acceptance and cancellation; debit/credit link behavior matches.
- Scanned the file for similar review-text contamination; none remains.

## Manual regression checks before release

On a disposable account with a reconciled invoice/payment pair:

1. Click the reconciled credit amount in the customer ledger and check the reconciliation ID in the confirmation dialog.
2. Cancel and verify the ledger is unchanged.
3. Accept and verify the intended entries reopen while unrelated accounts remain unchanged.
4. Repeat from the debit amount; verify date filters and return navigation are preserved.

Full browser/database validation passed on 2026-09-08 in a disposable, defanged test tenant: cancel preserved reconciliation; accepting either the credit or debit link reopened only the intended customer entries, while another account sharing the reconciliation ID stayed unchanged. Date/account filters were preserved. Customer deployment remains outstanding.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored the undo link for reconciled credit entries.
  - Corrected the link markup so it functions as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->