### PR TITLE
SST-767: distinguish missing stock from zero in the item grid

### DIFF
--- a/lager/lister/vareliste.php
+++ b/lager/lister/vareliste.php
@@ -28,6 +28,7 @@
 // 20250617 PBLM - Fixed bug where you could not search for leverandør in vareliste.
 // 20260213 LOE  - Added returside as variable used in topLineVarer.php and optimized search with supplied varenr.
 // 20260415 LOE  - Added Categories column with search functionality in vareliste. 
+// 20260908 CDX/LH Keep missing stock blank while preserving numeric stock search and sorting (SST-767).
 
 @session_start();
 $s_id = session_id();
@@ -291,7 +292,9 @@ $lagere = array();
 
 $q = db_select($query, __FILE__ . " line " . __LINE__);
 while ($row = db_fetch_array($q)) {
+    // Keep COALESCE selected for DISTINCT sorting and retain NULL separately for display.
     $SQLLagerFetch .= "COALESCE(ls$row[kodenr].beholdning, 0) AS lager$row[kodenr],\n";
+    $SQLLagerFetch .= "ls$row[kodenr].beholdning AS lager$row[kodenr]_raw,\n";
     $SQLLagerJoin .= "LEFT JOIN lagerstatus_grouped ls$row[kodenr] ON v.id = ls$row[kodenr].vare_id AND ls$row[kodenr].lager = $row[kodenr]\n";
     $lagere[] = "lager" . $row['kodenr'];
 
@@ -306,6 +309,10 @@ while ($row = db_fetch_array($q)) {
         "render" => function ($value, $row, $column) {
             if ($row["samlevare"] == "on") {
                 return "<td></td>";
+            }
+            // The grid formats missing stock as zero; use the nullable SQL value for display.
+            if ($row[$column['field'] . '_raw'] === null) {
+                return "<td align='$column[align]'></td>";
             }
             if (!$value) {
                 return "<td align='$column[align]'>0,00</td>";
@@ -332,6 +339,9 @@ $columns[] = array(
     "render" => function ($value, $row, $column) {
         if ($row["samlevare"] == "on") {
             return "<td></td>";
+        }
+        if ($row['lager_total_raw'] === null) {
+            return "<td align='$column[align]'></td>";
         }
         if (!$value) {
             return "<td align='$column[align]'>0,00</td>";
@@ -509,6 +519,7 @@ SELECT DISTINCT
     v.samlevare AS samlevare,
     $SQLLagerFetch
     COALESCE(lt.lager_total, 0) AS lager_total,  
+    lt.lager_total AS lager_total_raw,
     v.salgspris AS salgspris,       
     v.kostpris AS kostpris, 
     (


### PR DESCRIPTION
## What are the changes about?

[SST-767](https://saldi-team.atlassian.net/browse/SST-767): the item grid showed `0,00` both for products without stock records and products with an actual zero balance. Preserve nullable stock values alongside the numeric query fields, and render missing stock as blank in warehouse columns and the total column. Actual zero remains `0,00`; nonzero quantities retain their transfer links.

Only `lager/lister/vareliste.php` changes. Keeping the existing COALESCE fields and SQL overrides preserves filtering/sorting, including PostgreSQL's SELECT DISTINCT ordering requirements; nullable aliases are used only to decide whether a cell should be blank.

## Validation

- PHP 8.3 syntax check and `git diff --check` passed.
- PostgreSQL 16 fixtures exercised the actual page query/configuration and shared grid rendering: absent/zero/fractional/negative stock, grouped warehouse rows, two warehouses, composite items, offsetting quantities, numeric highlighting, zero/range filters, counts, and ascending/descending sorting.
- Original code fails the missing-stock regression assertion; the patch passes.
- Test database was isolated and removed after verification. Two pre-existing shared-grid parameter-order deprecations remained visible; no new warnings.

Existing limitation: the shared grid ignores a literal `0` search due to its truthiness checks. That behavior is unchanged. `0,00`, `0:0`, ranges, and the generated numeric-zero predicate retain their prior behavior. The shared grid is not changed in this ticket.

## Manual regression checks before release

1. Open Lager > Varer in the grid layout. Compare a product without a stock row, a product with an explicit zero row, and products with positive and negative stock.
2. Inspect each warehouse column and the total; an absent warehouse is blank even if another warehouse holds stock. Offsetting quantities must show an explicit zero total. Composite products stay blank.
3. Click the nonzero warehouse quantities and verify the warehouse/item transfer destination.
4. Search `0,00`, `0:0`, `1:10`, and a negative range; verify results and pagination counts. Sort each stock column both ways, checking missing stock is grouped numerically with zero.

Full browser validation passed on 2026-09-08 in a disposable, defanged test tenant: absent/zero/fractional/negative/offsetting/composite stock, two warehouse columns and totals, transfer-link parameters, both sort directions for all three stock columns, and 0,00 / 0:0 / 1:10 / -2:0 filters. Customer deployment remains outstanding.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
