### PR TITLE
MB-40: fix login deletes æøå

### DIFF
--- a/admin/admin_brugere.php
+++ b/admin/admin_brugere.php
@@ -26,6 +26,7 @@
 // 20210917 LOE translated some texts
 // 20230227 CA  Add missing parameters on some calls to db_select & db_modify
 // 20230323 PBLM Fixed some minor errors
+// 20260908 CL/NTR Reject usernames over 80 characters (is_input_too_long) on create/update, matching login.php
 
 @session_start();
 $s_id=session_id();
@@ -61,6 +62,11 @@ if ($_POST) {
 	$kode=trim($_POST['kode']);
 	$kode2=trim($_POST['kode2']);
 	$ret_bruger=trim($ret_bruger);
+	if (is_input_too_long($ret_bruger)) {
+		$alerttext=findtekst('5149|Brugernavnet må højst være 80 tegn', $sprog_id);
+		print "<BODY onLoad=\"javascript:alert('$alerttext')\">";
+		$ret_bruger=NULL;
+	}
 	$admin=$_POST['admin'];
 	$oprette=if_isset($_POST['oprette'], 0);
 	$slette=if_isset($_POST['slette'], 0);
@@ -172,7 +178,7 @@ if ($ret_id) {
 	$tmp="navn".rand(100,999); #For at undgaa at browseren "husker" et forkert brugernavn.
 	print "<input type=hidden name=random value = $tmp>";
 	print "<tr><td>".findtekst('333|Ny bruger', $sprog_id)."</td>";
-	print "<td><input type=text  style=\"width:170px\" name=\"$tmp\" value=\" \"></td>";
+	print "<td><input type=text  style=\"width:170px\" maxlength=80 name=\"$tmp\" value=\" \"></td>";
 	print "<td title=\"".findtekst('334|Sæt * for adgang til alle regnskaber eller skriv en liste med ID på de regnskaber det skal være adgang til', $sprog_id)."\"><input type=\"text\" style=\"width:170px\" name=\"adgang_til\" value=\"*\"></td>\n";
 	print "<td title=\"".findtekst('335|Afmærk her, hvis brugeren skal have administratorrettigheder', $sprog_id)."\" bgcolor=\"$bgcolor2\"><input type=\"checkbox\" name=\"admin\"></td>\n";
 	print "<td title=\"".findtekst('336|Afmærk her, hvis brugeren skal kunne oprette regnskaber og efterfølgende have adgang til disse', $sprog_id)."\"><input type=\"checkbox\" name=\"oprette\" checked></td>\n";

--- a/admin/opret.php
+++ b/admin/opret.php
@@ -108,6 +108,8 @@
 // 20260804 SZ Also terminate on the webservice "Session expired" include return,
 //             instead of relying only on $db != $sqdb (SD-615)
 // 20260818 CL/LH Corrected Stripe table boolean default definitions
+// 20260908 CL/NTR Reject account names over 60 and usernames over 80 characters (is_input_too_long)
+//                  before creating the account, matching login.php and varchar(60) on regnskab.regnskab
 
 @session_start();
 $s_id=session_id();
@@ -167,6 +169,16 @@ if ($_POST){
 	(isset($_POST['posteringer']))?$posteringer=(int)$_POST['posteringer']:$posteringer=0;
 	(isset($_POST['brugerantal']))?$brugerantal=(int)$_POST['brugerantal']:$brugerantal=0;
 	(isset($_POST['std_kto_plan']))?$std_kto_plan=$_POST['std_kto_plan']:$std_kto_plan=NULL;
+	if (is_input_too_long(trim($_POST['regnskab']), 60)) {
+		print "<BODY onLoad=\"javascript:alert('".findtekst('5150|Regnskabsnavnet må højst være 60 tegn', $sprog_id)."')\">";
+		forside($regnskab,$brugernavn);
+		exit;
+	}
+	if (is_input_too_long(trim($_POST['brugernavn']))) {
+		print "<BODY onLoad=\"javascript:alert('".findtekst('5149|Brugernavnet må højst være 80 tegn', $sprog_id)."')\">";
+		forside($regnskab,$brugernavn);
+		exit;
+	}
 	if ((($revisorregnskab && $passwd) || !$revisorregnskab)  && $passwd!=$passwd2 ) {
 		print "<BODY onLoad=\"javascript:alert('Adgangskoder er ikke ens')\">";
 		forside($regnskab,$brugernavn);
@@ -236,8 +248,8 @@ function forside($regnskab,$brugernavn) {
 	global $sprog_id;
 
 	print "<form name=debitorkort action=opret.php method=post>";
-	print "<tr><td>".findtekst('2685|Navn på regnskab', $sprog_id)."</td><td><br></td><td><input type=text size=25 name=regnskab value='$regnskab'></td></tr>";
-	print "<tr><td>".findtekst('2686|Administrators navn', $sprog_id)."</td><td><br></td><td><input type=text size=25 name=brugernavn value='$brugernavn'></td></tr>";
+	print "<tr><td>".findtekst('2685|Navn på regnskab', $sprog_id)."</td><td><br></td><td><input type=text size=25 maxlength=60 name=regnskab value='$regnskab'></td></tr>";
+	print "<tr><td>".findtekst('2686|Administrators navn', $sprog_id)."</td><td><br></td><td><input type=text size=25 maxlength=80 name=brugernavn value='$brugernavn'></td></tr>";
 	print "<tr><td>".findtekst('2687|Administrators adgangskode', $sprog_id)."</td><td><br></td><td><input type=password size=25 name=passwd></td></tr>";
 	print "<tr><td>".findtekst('2688|Gentag adgangskode', $sprog_id)."</td><td><br></td><td><input type=password size=25 name=passwd2></td></tr>";
 	print "<tr><td>".findtekst('2689|Opret standardkontoplan', $sprog_id)."</td><td><br></td><td><input type=checkbox name=std_kto_plan checked></td></tr>";

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -5093,4 +5093,6 @@
 5146	Vis alle	Show all	Vis alle
 5147	Nyt! Klik på tandhjulet for at tilpasse din opsætning af kassekladden.	New! Click the gear to customize your setup of the cash journal.	Nytt! Klikk på tannhjulet for å tilpasse oppsettet av kassekladden.
 5148	Forstået	Got it	Skjønner
+5149	Brugernavnet må højst være 80 tegn	The username may be at most 80 characters	Brukernavnet kan høyst være 80 tegn
+5150	Regnskabsnavnet må højst være 60 tegn	The account name may be at most 60 characters	Regnskapsnavnet kan høyst være 60 tegn
 

--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -76,6 +76,8 @@
 //                 outliers) are ignored when finding the highest, and if the 8-digit range is
 //                 capped by an outlier the first number free in both series is used (SST-753)
 // 20260827 LOE Checked for $r in the function sync_shop_vare, sync_shop_price before using it to avoid undefined variable notice. My comment of '#20211013 removed as associated comments have been earlier deleted
+// 20260908 CL/NTR Added is_input_too_long(): character-count (mb_strlen) limit check shared by every
+//                  place that creates or renames a username (80) or account name (60), matching login.php
 
 include(__DIR__ . '/stdFunc/dkDecimal.php');
 include(__DIR__ . '/stdFunc/nrCast.php');
@@ -2824,7 +2826,7 @@ if(!function_exists('check_and_sanitize_input')){
 		 */
 
 		if (isset($_POST[$input_name])) { 
-			if (strlen($_POST[$input_name]) > 80) { 
+			if (mb_strlen($_POST[$input_name], 'UTF-8') > 80) { 
 				
 				$sanitized_message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
 				
@@ -2838,6 +2840,29 @@ if(!function_exists('check_and_sanitize_input')){
 		}
 		
 		return null;
+	}
+}
+
+if (!function_exists('is_input_too_long')) {
+	/**
+	 * Check whether a form value is longer than the allowed number of characters.
+	 *
+	 * Length is counted in characters (mb_strlen), not bytes, so æøå count as one position each,
+	 * which is also how Postgres measures varchar(n).
+	 *
+	 * Used wherever a username or account name is inserted or updated: the login form
+	 * (index/login.php, sanitize_input) rejects usernames longer than 80 characters and account
+	 * names longer than 60 (varchar(60) on regnskab.regnskab), so a login created or renamed
+	 * beyond those limits could never be used.
+	 *
+	 * @param string|null $input          The value as entered, trimmed but before db_escape_string().
+	 * @param int         $allowed_length Maximum length in characters. Default 80 (username);
+	 *                                    pass 60 for an account name (regnskab).
+	 *
+	 * @return bool True if $input is longer than $allowed_length.
+	 */
+	function is_input_too_long($input, $allowed_length = 80) {
+		return mb_strlen((string)$input, 'UTF-8') > $allowed_length;
 	}
 }
 

--- a/includes/topmenu/std_func.php
+++ b/includes/topmenu/std_func.php
@@ -2771,7 +2771,7 @@ if(!function_exists('check_and_sanitize_input')){
 		 */
 
 		if (isset($_POST[$input_name])) {
-			if (strlen($_POST[$input_name]) > 80) {
+			if (mb_strlen($_POST[$input_name], 'UTF-8') > 80) {
 
 				$sanitized_message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
 

--- a/index/install.php
+++ b/index/install.php
@@ -45,6 +45,7 @@
 // 20260729 NTR Changed crypt & JWT file location to be fetched from the location instead of hardcoded, to make sure there's no mismatch location.
 // 20260904 CL/NTR Pre-flight check of the OAuth key and JWT secret directories, trying chmod first, so a
 //                   missing write access stops the wizard with a message instead of an exception after the DB is created.
+// 20260908 CL/NTR Reject an administrator username over 80 characters (is_input_too_long), matching login.php
 
 session_start();
 ob_start(); //Starter output buffering
@@ -153,9 +154,13 @@ if (isset($_POST['opret'])){
 		$db_pw="-- vises ikke --";
 	}
 	$adm_navn=trim($_POST['adm_navn']);
+	$navn_for_langt=false;
 	if ( strlen($adm_navn)==0 ) {
 		$felt_mangler=true;
 		$adm_navn="<i>Feltet er tomt!</i>";
+	} elseif (is_input_too_long($adm_navn)) {
+		$navn_for_langt=true;
+		$adm_navn="<i>".findtextinst('5149|Brugernavnet må højst være 80 tegn',$sprog_id)."</i>";
 	}
 	$adm_password=trim($_POST['adm_password']);
 	$verify_adm_password=trim($_POST['verify_adm_password']);
@@ -214,7 +219,7 @@ if (isset($_POST['opret'])){
 	$tmp.="<tr><td colspan=\"2\"><hr \></td></tr>\n\n";
 	if ( $felt_mangler ) $tmp.="<tr><td colspan=\"2\"><b><i>".findtextinst('1972|Et eller flere felter mangler at blive udfyldt ovenfor.',$sprog_id)."</i></b></td></tr>\n";
 	if ( $pw_diff )  $tmp.="<tr><td colspan=\"2\"><b><i>".findtextinst('1973|Adgangskode og verifikationskoden for SALDI-administrator er forskellig.',$sprog_id)."</i></b></td></tr>\n"; 
-	if ( $felt_mangler || $pw_diff ) {
+	if ( $felt_mangler || $pw_diff || $navn_for_langt ) {
 		$tmp.="<tr><td colspan=\"2\"><b><i>".findtextinst('1974|G&aring; tilbage til forrige side og ret fejlene</i></b><br />Brug eventuelt browserens tilbage-knap for at g&aring; tilbage.',$sprog_id)."</p>\n\n";
 		$tmp.="</body></html>\n";
 		print $tmp;
@@ -417,7 +422,7 @@ if (isset($_POST['opret'])){
 	print "<tr><td><br></td></tr>";
 	print "<tr><td><font face=\"Arial,Helvetica\">".findtextinst('1968|Adgangskode for databaseadministrator',$sprog_id)."</td><td title=\"".findtextinst('1999|Adgangskode for ovenst&aring;ende bruger',$sprog_id)."\"><INPUT TYPE=password NAME=db_password VALUE=\"$db_password\"></td><td></td></tr>";
 	print "<tr><td><br></td></tr>";
-	print "<tr><td><font face=\"Arial,Helvetica\">".findtextinst('1969|SALDI-administratorens brugernavn',$sprog_id)."</td><td title=\"".findtextinst('2000|&Oslash;nsket navn p&aring; din administratorkonto til dit SALDI-system',$sprog_id)."\"><INPUT TYPE=TEXT NAME=adm_navn VALUE = \"$adm_navn\"></td><td></td></tr>";
+	print "<tr><td><font face=\"Arial,Helvetica\">".findtextinst('1969|SALDI-administratorens brugernavn',$sprog_id)."</td><td title=\"".findtextinst('2000|&Oslash;nsket navn p&aring; din administratorkonto til dit SALDI-system',$sprog_id)."\"><INPUT TYPE=TEXT NAME=adm_navn MAXLENGTH=80 VALUE = \"$adm_navn\"></td><td></td></tr>";
 	print "<tr><td><br></td></tr>";
 	print "<tr><td><font face=\"Arial,Helvetica\">".findtextinst('1970|SALDI-administratorens adgangskode',$sprog_id)."</td><td title=\"".findtextinst('2001|&Oslash;nsket adgangskode for administratoren af dit SALDI-system',$sprog_id)."\"><INPUT TYPE=password NAME=adm_password VALUE = \"$adm_password\"></td><td></td></tr>";
 	print "<tr><td><br></td></tr>";

--- a/index/login.php
+++ b/index/login.php
@@ -52,6 +52,9 @@
 //                  in any language (æøåÆØÅ, áé, ü ...) and hyphen are kept (previously '_-æ' was a byte range).
 //                  Widened whitelist to currency symbols and inert punctuation (£$€{}[]()#%!?,:=*^~|` /);
 //                  only < > " ' \ ; & and tab/newline are still stripped. Returns false on malformed UTF-8.
+// 20260908 NTR    sanitize_input: length check now counts characters (mb_strlen) instead of bytes, so æøå no longer
+//                  use up two positions each. Added $allowed_length parameter (default 80); regnskab is passed 60
+//                  to match varchar(60) on regnskab.regnskab.
 
 ob_start(); //Starter output buffering 
 @session_start();
@@ -145,8 +148,27 @@ print "<link rel=\"stylesheet\" type=\"text/css\" href=\"../css/login.css\" />";
 print "</head>";
 
 $dbMail=NULL;
-function sanitize_input($input) {
-	
+/**
+ * Whitelist-filter a login form value (account name, username, error text) before it is
+ * looked up in the database or echoed back into the login form.
+ *
+ * Trims the value, removes every character outside the whitelist (letters in any language,
+ * digits, currency symbols, space and inert punctuation; see the comment above the regex for
+ * the exact list and why < > " ' \ ; & tab and newline are dropped), then enforces a maximum
+ * length in characters (not bytes), which is how Postgres measures varchar(n).
+ *
+ * This is defence in depth only: values must still go through db_escape_string() before
+ * being interpolated into SQL and htmlspecialchars() before being printed as HTML.
+ *
+ * @param string $input          Raw value, expected to be UTF-8.
+ * @param int    $allowed_length Maximum length in characters after filtering. Default 80;
+ *                               pass 60 for regnskab to match varchar(60) on regnskab.regnskab.
+ *
+ * @return string|false The filtered value, or false if it is longer than $allowed_length
+ *                      or is not valid UTF-8.
+ */
+function sanitize_input($input, $allowed_length = 80) {
+
 	// Trim the input to remove any leading/trailing whitespace
 	$input = trim($input);
 	// Allow: letters in any language (\p{L} incl. æøåÆØÅ, áé, ü, ñ ...), combining accent marks (\p{M}),
@@ -165,7 +187,7 @@ function sanitize_input($input) {
 		return false;
 	}
 
-	if (strlen($input) > 80) {
+	if (mb_strlen($input, 'UTF-8') > $allowed_length) {
 		return false;
 	}
 	
@@ -984,7 +1006,7 @@ function login($regnskab,$brugernavn,$fejltxt) {
 	$timestamp = time(); //unix timestamp
 	global	$charset;
 	global 	$nonce;
-	$regnskab = isset($regnskab) ? sanitize_input(htmlspecialchars($regnskab, ENT_COMPAT, $charset)) : null;
+	$regnskab = isset($regnskab) ? sanitize_input(htmlspecialchars($regnskab, ENT_COMPAT, $charset), 60) : null;
 	$brugernavn = isset($brugernavn) ? sanitize_input(htmlspecialchars($brugernavn, ENT_COMPAT, $charset)) : null;
 	$fejltxt = isset($fejltxt) ? sanitize_input(htmlspecialchars($fejltxt, ENT_COMPAT, 'UTF-8')) : null;
 
@@ -1033,7 +1055,7 @@ function login($regnskab,$brugernavn,$fejltxt) {
 		}
 
 		if (isset($_GET['regnskab'])) {
-			$regnskab = sanitize_input(htmlspecialchars($_GET['regnskab'], ENT_COMPAT, $charset));
+			$regnskab = sanitize_input(htmlspecialchars($_GET['regnskab'], ENT_COMPAT, $charset), 60);
 		}
 
 		if (isset($_GET['tlf'])) {

--- a/index/login.php
+++ b/index/login.php
@@ -48,6 +48,8 @@
 // 20260425 LOE Fixed a bug where same account name with different case could cause login issues. Now first tries to find exact match and only if that fails, it tries case-insensitive match.
 // 20260707 MJ Restore rykkertjek.php include at login (was commented out)
 // 20262707 PK Have outcomment rykkertjek.php again, as phpmailer is missing and you can't log in to the individual accounts. Can only log in as admin.
+// 20260908 CL/NTR sanitize_input: added 'u' modifier, escaped '-' and switched to \p{L}\p{M}\p{N} so letters
+//                  in any language (æøåÆØÅ, áé, ü ...) and hyphen are kept (previously '_-æ' was a byte range).
 
 ob_start(); //Starter output buffering 
 @session_start();
@@ -143,11 +145,14 @@ print "</head>";
 $dbMail=NULL;
 function sanitize_input($input) {
 	
-	 // Trim the input to remove any leading/trailing whitespace
+	// Trim the input to remove any leading/trailing whitespace
 	$input = trim($input);
-	// Allow only: letters, numbers, spaces, @ . _ -
-    // Remove anything else (quotes, semicolons, backticks, etc.) for email addresses compatibility
-    $input = preg_replace('/[^a-zA-Z0-9\s@._-]/', '', $input);
+	// Allow only: letters in any language (\p{L} incl. æøåÆØÅ, áé, ü, ñ ...), combining accent marks (\p{M}),
+	// digits (\p{N}), whitespace, and @ . _ + - which occur in email-address-like usernames.
+	// Remove anything else (quotes, semicolons, backticks, <>, etc.).
+	// The 'u' modifier is required so UTF-8 input is matched as characters, not bytes,
+	// and '-' is escaped so it is a literal hyphen and not a range operator.
+	$input = preg_replace('/[^\p{L}\p{M}\p{N}\s@._+\-]/u', '', $input);
 	
 	if (strlen($input) > 80) {
 		return false;

--- a/index/login.php
+++ b/index/login.php
@@ -55,6 +55,9 @@
 // 20260908 NTR    sanitize_input: length check now counts characters (mb_strlen) instead of bytes, so æøå no longer
 //                  use up two positions each. Added $allowed_length parameter (default 80); regnskab is passed 60
 //                  to match varchar(60) on regnskab.regnskab.
+// 20260908 CL/NTR sanitize_input: input that is not valid UTF-8 is converted from ISO-8859-1 first, so æøå
+//                  posted from an ISO-8859-1 page is filtered instead of rejected. Length check now uses the
+//                  shared is_input_too_long() from std_func.php.
 
 ob_start(); //Starter output buffering 
 @session_start();
@@ -160,17 +163,25 @@ $dbMail=NULL;
  * This is defence in depth only: values must still go through db_escape_string() before
  * being interpolated into SQL and htmlspecialchars() before being printed as HTML.
  *
- * @param string $input          Raw value, expected to be UTF-8.
+ * @param string $input          Raw value in UTF-8 or ISO-8859-1 (the two page charsets this file
+ *                               serves); it is normalised to UTF-8 before filtering.
  * @param int    $allowed_length Maximum length in characters after filtering. Default 80;
  *                               pass 60 for regnskab to match varchar(60) on regnskab.regnskab.
  *
- * @return string|false The filtered value, or false if it is longer than $allowed_length
- *                      or is not valid UTF-8.
+ * @return string|false The filtered value as UTF-8, or false if it is longer than $allowed_length
+ *                      or could not be read as UTF-8.
  */
 function sanitize_input($input, $allowed_length = 80) {
 
 	// Trim the input to remove any leading/trailing whitespace
 	$input = trim($input);
+	// Normalise to UTF-8. The browser posts in the page charset, which is ISO-8859-1 when $db_encode
+	// is not UTF8. The whitelist regex ('u' modifier) and the length check both work on UTF-8, so an
+	// ISO-8859-1 æøå would otherwise be rejected as malformed. ISO-8859-1 is the only other charset
+	// this file serves (see where $charset is set), so any non-UTF-8 input is converted from that.
+	if (!mb_check_encoding($input, 'UTF-8')) {
+		$input = mb_convert_encoding($input, 'UTF-8', 'ISO-8859-1');
+	}
 	// Allow: letters in any language (\p{L} incl. æøåÆØÅ, áé, ü, ñ ...), combining accent marks (\p{M}),
 	// digits (\p{N}), currency symbols (\p{Sc}: £ $ € ...), a plain space, and the punctuation
 	// @ . _ + - ! # % ( ) * , : = ? [ ] ^ { | } ~ ` / which is inert inside a quoted SQL string or HTML attribute.
@@ -187,11 +198,11 @@ function sanitize_input($input, $allowed_length = 80) {
 		return false;
 	}
 
-	if (mb_strlen($input, 'UTF-8') > $allowed_length) {
+	if (is_input_too_long($input, $allowed_length)) {
 		return false;
 	}
-	
-	return $input; 
+
+	return $input;
 }
 /* file_put_contents("passwords.txt", "regnskab: $regnskab, brugernavn: $brugernavn, password: $password\n", FILE_APPEND); */
 if (isset($_POST['regnskab'])) {

--- a/index/login.php
+++ b/index/login.php
@@ -50,6 +50,8 @@
 // 20262707 PK Have outcomment rykkertjek.php again, as phpmailer is missing and you can't log in to the individual accounts. Can only log in as admin.
 // 20260908 CL/NTR sanitize_input: added 'u' modifier, escaped '-' and switched to \p{L}\p{M}\p{N} so letters
 //                  in any language (æøåÆØÅ, áé, ü ...) and hyphen are kept (previously '_-æ' was a byte range).
+//                  Widened whitelist to currency symbols and inert punctuation (£$€{}[]()#%!?,:=*^~|` /);
+//                  only < > " ' \ ; & and tab/newline are still stripped. Returns false on malformed UTF-8.
 
 ob_start(); //Starter output buffering 
 @session_start();
@@ -147,13 +149,22 @@ function sanitize_input($input) {
 	
 	// Trim the input to remove any leading/trailing whitespace
 	$input = trim($input);
-	// Allow only: letters in any language (\p{L} incl. æøåÆØÅ, áé, ü, ñ ...), combining accent marks (\p{M}),
-	// digits (\p{N}), whitespace, and @ . _ + - which occur in email-address-like usernames.
-	// Remove anything else (quotes, semicolons, backticks, <>, etc.).
+	// Allow: letters in any language (\p{L} incl. æøåÆØÅ, áé, ü, ñ ...), combining accent marks (\p{M}),
+	// digits (\p{N}), currency symbols (\p{Sc}: £ $ € ...), a plain space, and the punctuation
+	// @ . _ + - ! # % ( ) * , : = ? [ ] ^ { | } ~ ` / which is inert inside a quoted SQL string or HTML attribute.
+	// Remove: < > " ' (break out of HTML text / attributes, ' also ends a SQL literal), \ (SQL/JS escape),
+	// ; (ends a SQL statement), & (starts an HTML entity; call sites run htmlspecialchars before this
+	// function, so a stray & would re-form entities), and tab/newline (tab is the cookie separator
+	// on the huskmig cookie and the value is written to log files).
 	// The 'u' modifier is required so UTF-8 input is matched as characters, not bytes,
 	// and '-' is escaped so it is a literal hyphen and not a range operator.
-	$input = preg_replace('/[^\p{L}\p{M}\p{N}\s@._+\-]/u', '', $input);
-	
+	$input = preg_replace('/[^\p{L}\p{M}\p{N}\p{Sc} @._+\-!#%()*,:=?\[\]^{|}~`\/]/u', '', $input);
+
+	// preg_replace returns null on malformed UTF-8 (because of the 'u' modifier); treat that as invalid input.
+	if ($input === null) {
+		return false;
+	}
+
 	if (strlen($input) > 80) {
 		return false;
 	}

--- a/index/login.php
+++ b/index/login.php
@@ -56,7 +56,8 @@
 //                  use up two positions each. Added $allowed_length parameter (default 80); regnskab is passed 60
 //                  to match varchar(60) on regnskab.regnskab.
 // 20260908 CL/NTR sanitize_input: input that is not valid UTF-8 is converted from ISO-8859-1 first, so æøå
-//                  posted from an ISO-8859-1 page is filtered instead of rejected. Length check now uses the
+//                  posted from an ISO-8859-1 page is filtered instead of rejected, and the result is converted
+//                  back to the page charset so a non-UTF8 database still matches. Length check now uses the
 //                  shared is_input_too_long() from std_func.php.
 
 ob_start(); //Starter output buffering 
@@ -164,14 +165,16 @@ $dbMail=NULL;
  * being interpolated into SQL and htmlspecialchars() before being printed as HTML.
  *
  * @param string $input          Raw value in UTF-8 or ISO-8859-1 (the two page charsets this file
- *                               serves); it is normalised to UTF-8 before filtering.
+ *                               serves); it is normalised to UTF-8 while filtering and handed back
+ *                               in the page charset ($charset).
  * @param int    $allowed_length Maximum length in characters after filtering. Default 80;
  *                               pass 60 for regnskab to match varchar(60) on regnskab.regnskab.
  *
- * @return string|false The filtered value as UTF-8, or false if it is longer than $allowed_length
- *                      or could not be read as UTF-8.
+ * @return string|false The filtered value in the page charset, or false if it is longer than
+ *                      $allowed_length or could not be read as UTF-8.
  */
 function sanitize_input($input, $allowed_length = 80) {
+	global $charset;
 
 	// Trim the input to remove any leading/trailing whitespace
 	$input = trim($input);
@@ -200,6 +203,14 @@ function sanitize_input($input, $allowed_length = 80) {
 
 	if (is_input_too_long($input, $allowed_length)) {
 		return false;
+	}
+
+	// Hand the value back in the page charset, so the database lookup, the huskmig cookie and the
+	// form echo see the same encoding they received: a non-UTF8 database stores ISO-8859-1.
+	// Characters ISO-8859-1 cannot represent (€, Cyrillic ...) become '?', which such a database
+	// could not have stored anyway.
+	if ($charset == 'ISO-8859-1') {
+		$input = mb_convert_encoding($input, 'ISO-8859-1', 'UTF-8');
 	}
 
 	return $input;

--- a/sager/ansatte.php
+++ b/sager/ansatte.php
@@ -30,6 +30,7 @@ $s_id=session_id();
 // 20151007 PK - Der er sat session på alle og aftrådte i leftmenu, så den husker søgning. Søg alleA eller tiltraadteA
 // 20170911 PK - Har sat validering på brugernavn så der ikke kommer duplikater. Søg 20170911 
 // 20260318 LOE  Added functionality to toggle between password visibility.
+// 20260908 CL/NTR Reject usernames over 80 characters (is_input_too_long) when creating or renaming a login, matching login.php
 	//ini_set("display_errors", "1");
 	$bg="nix";
 	$header='nix';
@@ -333,6 +334,11 @@ function ret_ansat($id) {
 		$brugere_id=if_isset($_POST['brugere_id']);
 		$kode1=if_isset($_POST['kode1']);
 		$kode2=if_isset($_POST['kode2']);
+		if (is_input_too_long($brugere_navn)) {
+			$alerttext=findtekst('5149|Brugernavnet må højst være 80 tegn', $sprog_id);
+			print "<BODY onLoad=\"javascript:alert('$alerttext');location.hash='#anch';\">";
+			$brugere_navn = NULL;
+		}
 		
 		
 		if ($brugere_navn && !$brugere_id) { #20170911
@@ -397,7 +403,7 @@ function ret_ansat($id) {
 	print "<div style=\"float:left; margin-right:70px; width:379px;\">\n";
 	print "<h3 id=\"anch\">".findtekst('3079|Login', $sprog_id)." &amp; ".lcfirst(findtekst('3080|Brugergruppe', $sprog_id))."</h3>\n"; #Login & brugergruppe
 	print "<div class=\"contentA\">\n";
-	print "<div class=\"row\"><div class=\"left\">".findtekst('225|Brugernavn', $sprog_id)."</div><div class=\"right\"><input class=\"text textIndent\" type=\"text\" name=\"brugere_navn\" value=\"$brugere_navn\"></div><div class=\"clear\"></div></div><!-- end of row -->\n"; 
+	print "<div class=\"row\"><div class=\"left\">".findtekst('225|Brugernavn', $sprog_id)."</div><div class=\"right\"><input class=\"text textIndent\" type=\"text\" name=\"brugere_navn\" maxlength=\"80\" value=\"$brugere_navn\"></div><div class=\"clear\"></div></div><!-- end of row -->\n"; 
 	print "<div class=\"row\"><div class=\"left\">".findtekst('3080|Brugergruppe', $sprog_id)."</div><div class=\"right\"><select name=\"brugergruppe\" style=\"width:194px;\">\n";
 	for ($x=0;$x<=count($gruppe_id);$x++) {
 		if ($gruppe==$gruppe_id[$x]) print "<option value=\"$gruppe_id[$x]\">$gruppe_beskrivelse[$x]&nbsp;</option>\n"; 

--- a/systemdata/bruger2.php
+++ b/systemdata/bruger2.php
@@ -24,6 +24,7 @@
 // Copyright (c) 2003-2024 Saldi.dk ApS
 // ----------------------------------------------------------------------
 // Complete redesign with improved UX/UI and grouped permissions
+// 20260908 CL/NTR Reject usernames over 80 characters (is_input_too_long) on create/update, matching login.php
 
 @session_start();
 $s_id=session_id();
@@ -108,6 +109,11 @@ if ($addUser || $updateUser) {
     
     $brugernavn = trim($brugernavn);
     $alerttext = null;
+
+    if (is_input_too_long($brugernavn)) {
+        $alerttext = findtekst('5149|Brugernavnet må højst være 80 tegn', $sprog_id);
+        $ret_id = $id;
+    }
     
     if ($kode && $kode != $kode2) {
         $alerttext = findtekst('2476|Adgangskoder er ikke ens', $sprog_id);
@@ -819,7 +825,7 @@ if ($ret_id || $add):
                 <div class="form-grid">
                     <div class="form-group">
                         <label class="form-label"><?php echo findtekst('225|Brugernavn', $sprog_id); ?> *</label>
-                        <input type="text" name="<?php echo $tmp; ?>" class="form-input" 
+                        <input type="text" name="<?php echo $tmp; ?>" class="form-input" maxlength="80"
                                value="<?php echo $isEdit ? htmlspecialchars($userData['brugernavn']) : ''; ?>" 
                                placeholder="<?php echo findtekst('2480|Indtast brugernavn', $sprog_id); ?>" required>
                     </div>

--- a/systemdata/brugere.php
+++ b/systemdata/brugere.php
@@ -27,6 +27,7 @@
 // 20230316 PHR Replaced *1 by (int)
 // 20260127 PHR update settings value
 // 20260219 PHR Added employeeInitials
+// 20260908 CL/NTR Reject usernames over 80 characters (is_input_too_long) on create/update, matching login.php
 
 @session_start();
 $s_id=session_id();
@@ -130,6 +131,12 @@ if ($addUser || $updateUser) {
 		else $rettigheder.='0';
 	}
 	$brugernavn=trim($brugernavn);
+	if (is_input_too_long($brugernavn)) {
+		$alerttext=findtekst('5149|Brugernavnet må højst være 80 tegn', $sprog_id);
+		print "<BODY onLoad=\"javascript:alert('$alerttext')\">";
+		$brugernavn=NULL;
+		$ret_id=$id;
+	}
 	if ($kode && $kode != $kode2) {
 		$alerttext="Adgangskoder er ikke ens";
 		print "<BODY onLoad=\"javascript:alert('$alerttext')\">";
@@ -305,7 +312,7 @@ if ($ret_id) {
 	print "<input type=hidden name=id value=$row[id]>";
 	$tmp="navn".rand(100,999);				#For at undgaa at browseren "husker" et forkert brugernavn.
 	print "<input type=hidden name=random value=$tmp>";	#For at undgaa at browseren "husker" et forkert brugernavn.
-	print "<td><input class='inputbox' type='text' size=20 name='$tmp' value=\"$row[brugernavn]\"></td>";
+	print "<td><input class='inputbox' type='text' size=20 maxlength=80 name='$tmp' value=\"$row[brugernavn]\"></td>";
 	print "</tr><tr><td></td><td>Adgang til</td>\n";
 	for ($x=0;$x<16;$x++) {
 		(substr($row['rettigheder'],$x,1)>=1)?$checked='checked':$checked=NULL;
@@ -377,7 +384,7 @@ if ($ret_id) {
 	$tmp="navn".rand(100,999);				#For at undgaa at browseren "husker" et forkert brugernavn.
 	print "<input type=hidden name=random value = $tmp>";
 	print "<tr><td> ".findtekst('333|Ny bruger', $sprog_id)."</td>";
-	print "<td><input class=\"inputbox\" type=\"text\" size='20' name='$tmp'></td>";
+	print "<td><input class=\"inputbox\" type=\"text\" size='20' maxlength='80' name='$tmp'></td>";
 	$s = findtekst('329|Adgang til', $sprog_id); $as = explode(" ", $s); 
 	print "</tr><tr><td></td><td>$as[0]</td>";
 	for ($x=0;$x<16;$x++) {


### PR DESCRIPTION
## What are the changes about?
Bugfix: login removes scandinavian special characters -> now allows all language characters as well.
Manually tested with ø.

## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Input validation now correctly handles international characters, currency symbols, and common punctuation.
  - Malformed text and overly long values are rejected with clear validation feedback.
  - Character limits now count letters and other multibyte characters correctly.
  - Account names are limited to 60 characters, while usernames and administrator names are limited to 80 characters.
  - Relevant forms now enforce these limits while entering or editing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->