### PR TITLE
Fix SST-773 account-scoped automatic settlement

### DIFF
--- a/finans/autoudlign.php
+++ b/finans/autoudlign.php
@@ -38,16 +38,19 @@
 // 20260901 Sawaneh Review fixes: stale search responses are ignored, server
 //                  invoice scoring mirrors the client, amount search is a
 //                  prefix match on the absolute amount.
+// 20260908 CDX/LH Require an account before matching and validate selected open posts on save.
 
+ob_start();
 @session_start();
 $s_id = session_id();
 
 #$css = "../css/standard.css";
-include("../includes/connect.php");
-include("../includes/online.php");
-include("../includes/std_func.php");
+include(__DIR__ . "/../includes/connect.php");
+include(__DIR__ . "/../includes/online.php");
+include(__DIR__ . "/../includes/std_func.php");
+include_once(__DIR__ . "/kassekladde_includes/autoSettlement.php");
 
-$kladde_id = if_isset($_GET['kladde_id']);
+$kladde_id = intval($_GET['kladde_id'] ?? 0);
 $id        = intval(if_isset($_GET, 0, ['id']));
 $skipped   = max(0, intval($_GET['skipped']  ?? 0));
 $settled   = max(0, intval($_GET['settled']  ?? 0));
@@ -58,29 +61,26 @@ $settled   = max(0, intval($_GET['settled']  ?? 0));
 $save_error   = '';
 $save_success = false;
 
+if (empty($_SESSION['autoudlign_token'])) {
+    $_SESSION['autoudlign_token'] = bin2hex(random_bytes(32));
+}
 if (isset($_POST['action']) && $_POST['action'] === 'udlign') {
-    $post_kontonr = trim($_POST['kontonr']   ?? '');
-    $post_art     = trim($_POST['art']       ?? '');
-    $post_faktnr  = trim($_POST['faktnr']    ?? '');
-    $post_amount  = floatval($_POST['amount'] ?? 0);
-    $post_id      = intval($_POST['entry_id'] ?? 0);
-
-    if ($post_art && $post_kontonr && $post_id) {
-        $kontonr_esc = db_escape_string($post_kontonr);
-        $art_esc     = db_escape_string($post_art);
-        $faktnr_esc  = db_escape_string($post_faktnr);
-
-        if ($post_amount < 0) {
-            $qtxt = "UPDATE kassekladde SET d_type='$art_esc', debet='$kontonr_esc', faktura='$faktnr_esc' WHERE id = $post_id";
-        } else {
-            $qtxt = "UPDATE kassekladde SET k_type='$art_esc', kredit='$kontonr_esc', faktura='$faktnr_esc' WHERE id = $post_id";
+    $webservice = true;
+    ob_clean();
+    header('Content-Type: application/json; charset=utf-8');
+    try {
+        $token = $_POST['token'] ?? '';
+        if (!is_string($token) || !hash_equals($_SESSION['autoudlign_token'], $token)) {
+            throw new RuntimeException('The session has changed. Reload before settling.');
         }
-        db_modify($qtxt, __FILE__ . " line " . __LINE__);
-        $save_success = true;
-        $settled++;   // increment for URL carry-through
-    } else {
-        $save_error = 'Invalid data – please fill in all required fields.';
+        saveAutoSettlement($kladde_id, $_POST['entry_id'] ?? 0, $_POST['openpost_id'] ?? 0,
+            $_POST['account_id'] ?? 0, $_POST['snapshot'] ?? '');
+        echo json_encode(['success' => true]);
+    } catch (RuntimeException $error) {
+        http_response_code(409);
+        echo json_encode(['success' => false, 'error' => $error->getMessage()]);
     }
+    exit;
 }
 
 /* ---------------------------------------------------------------
@@ -88,9 +88,13 @@ if (isset($_POST['action']) && $_POST['action'] === 'udlign') {
 --------------------------------------------------------------- */
 $brugt = [];
 if ($kladde_id) {
-    $q = db_select("SELECT faktura FROM kassekladde WHERE kladde_id=$kladde_id AND faktura != ''", __FILE__ . " line " . __LINE__);
+    $q = db_select("SELECT faktura, debet, kredit, d_type, k_type FROM kassekladde WHERE kladde_id=$kladde_id AND faktura != ''", __FILE__ . " line " . __LINE__);
     while ($r = db_fetch_array($q)) {
-        $brugt[] = trim($r['faktura']);
+        foreach (['debet' => 'd_type', 'kredit' => 'k_type'] as $field => $typeField) {
+            if (in_array(trim((string)$r[$typeField]), ['D', 'K'], true)) {
+                $brugt[] = trim((string)$r[$typeField]) . ':' . trim((string)$r[$field]) . ':' . trim((string)$r['faktura']);
+            }
+        }
     }
 }
 
@@ -104,12 +108,11 @@ if ($kladde_id) {
         __FILE__ . " line " . __LINE__
     );
     while ($r = db_fetch_array($q)) {
-        $amount = 0;
-        if ($r['debet'] && !$r['kredit'])  $amount =  floatval($r['amount']);
-        elseif (!$r['debet'] && $r['kredit']) $amount = -floatval($r['amount']);
-        if ($amount != 0) {
+        $context = autoSettlementContext($r);
+        if ($context) {
             $entry = $r;
-            $entry['resolved_amount'] = $amount;
+            $entry['resolved_amount'] = $context['amount'];
+            $entryContext = $context;
             break;
         }
     }
@@ -127,6 +130,22 @@ if ($entry) {
     }
 }
 
+$accountOptions = [];
+$selectedAccountId = '';
+if ($entry) {
+    $accountWhere = "art IN ('D', 'K')";
+    if ($entryContext['account'] !== '') {
+        $number = db_escape_string($entryContext['account']);
+        $type = db_escape_string($entryContext['accountType']);
+        $accountWhere = "kontonr = '$number' AND art = '$type'";
+    }
+    $query = db_select("SELECT id, kontonr, art, firmanavn FROM adresser WHERE $accountWhere ORDER BY firmanavn, kontonr", __FILE__ . ' line ' . __LINE__);
+    while ($account = db_fetch_array($query)) {
+        $accountOptions[] = $account;
+        if ($entryContext['account'] !== '') $selectedAccountId = (string)$account['id'];
+    }
+}
+
 $amount_fmt = $entry
     ? number_format($entry['resolved_amount'], 2, ',', '.')
     : '';
@@ -141,11 +160,11 @@ $returside       = $kassekladde_url;
 $total_unsettled = 0;
 if ($kladde_id) {
     $q = db_select(
-        "SELECT debet, kredit FROM kassekladde WHERE kladde_id=$kladde_id",
+        "SELECT * FROM kassekladde WHERE kladde_id=$kladde_id",
         __FILE__ . " line " . __LINE__
     );
     while ($r = db_fetch_array($q)) {
-        if (($r['debet'] && !$r['kredit']) || (!$r['debet'] && $r['kredit'])) {
+        if (autoSettlementContext($r)) {
             $total_unsettled++;
         }
     }
@@ -729,6 +748,21 @@ print "</tbody></table></td></tr></tbody></table>";
         <?php endif; ?>
       </div>
 
+      <div class="search-row">
+        <label for="accountSelect"><?= 'Account' ?></label>
+        <select id="accountSelect" class="search-input" <?= $entryContext['account'] !== '' ? 'disabled' : '' ?>>
+          <option value=""><?= 'Choose customer or supplier…' ?></option>
+          <?php foreach ($accountOptions as $account): ?>
+          <option value="<?= (int)$account['id'] ?>"
+            data-account="<?= htmlspecialchars($account['kontonr'], ENT_QUOTES, 'UTF-8') ?>"
+            data-type="<?= htmlspecialchars($account['art'], ENT_QUOTES, 'UTF-8') ?>"
+            <?= (string)$account['id'] === $selectedAccountId ? 'selected' : '' ?>>
+            <?= htmlspecialchars($account['art'] . ' ' . $account['kontonr'] . ' — ' . $account['firmanavn'], ENT_QUOTES, 'UTF-8') ?>
+          </option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+
       <!-- Search bar -->
       <div class="search-row">
         <input
@@ -800,6 +834,8 @@ print "</tbody></table></td></tr></tbody></table>";
 
   /* ── PHP data passed to JS ──────────────────────────────── */
   const KLADDE_ID   = <?= json_encode($kladde_id) ?>;
+  const TOKEN       = <?= json_encode($_SESSION['autoudlign_token']) ?>;
+  const SNAPSHOT    = <?= json_encode(autoSettlementSnapshot($entry)) ?>;
   const ENTRY_ID    = <?= json_encode((int)$entry['id']) ?>;
   const AMOUNT      = <?= json_encode((float)$entry['resolved_amount']) ?>;
   const BESKRIVELSE = <?= json_encode($entry['beskrivelse'] ?? '') ?>;
@@ -816,9 +852,11 @@ print "</tbody></table></td></tr></tbody></table>";
   let selectedIndex    = -1;
   let debounceTimer    = null;
   let autoSelected     = false;    // did we auto-pick a candidate?
+  let saving           = false;
   let fetchSeq         = 0;        // guards against stale responses
 
   /* ── DOM ────────────────────────────────────────────────── */
+  const accountSelect = document.getElementById('accountSelect');
   const searchInput   = document.getElementById('searchInput');
   const candidateBody = document.getElementById('candidateBody');
   const udlignBtn     = document.getElementById('udlignBtn');
@@ -841,6 +879,8 @@ print "</tbody></table></td></tr></tbody></table>";
     const params = new URLSearchParams({
         search:        search,
         currentAmount: AMOUNT,
+        account:       accountSelect.selectedOptions[0].dataset.account || '',
+        accountType:   accountSelect.selectedOptions[0].dataset.type || '',
         page:          page,
         mode:          'open_post',                  
         hintTokens:    JSON.stringify(HINT_TOKENS),
@@ -933,14 +973,18 @@ print "</tbody></table></td></tr></tbody></table>";
     page   = page || 1;
     currentPage = page;
 
-    setLoading();
-
     const seq = ++fetchSeq;
+    setLoading();
+    if (!accountSelect.value) {
+      candidates = [];
+      candidateBody.innerHTML = '<tr><td colspan="6"><div class="state-msg">Choose a customer or supplier to see their open entries.</div></td></tr>';
+      return;
+    }
     fetch(getSearchUrl(search, page))
       .then(r => r.json())
       .then(data => {
         if (seq !== fetchSeq) return;   // a newer request superseded this one
-        const raw   = (data.results || []).filter(c => !BRUGT.includes(String(c.faktnr)));
+        const raw   = (data.results || []).filter(c => !BRUGT.includes(c.art + ':' + c.kontonr + ':' + c.faktnr));
         candidates  = sortAndScore(raw);
         totalCount  = data.pagination ? data.pagination.total : candidates.length;
         hasMore     = data.pagination ? data.pagination.hasMore : false;
@@ -1033,10 +1077,10 @@ print "</tbody></table></td></tr></tbody></table>";
 
   /* ── Auto-select best candidate ─────────────────────────── */
   function autoSelectBest() {
-    if (candidates.length === 0) return;
+    if (!accountSelect.value || candidates.length === 0) return;
 
     const best = candidates[0];
-    if (best._score > 0 || candidates.length === 1) {
+    if (best.amountMatch && (candidates.length === 1 || best._score > candidates[1]._score)) {
       setSelected(0);
       autoSelected = true;
     }
@@ -1074,16 +1118,17 @@ print "</tbody></table></td></tr></tbody></table>";
 
   /* ── Do udlign ───────────────────────────────────────────── */
   function doUdlign() {
-    if (selectedIndex < 0 || !candidates[selectedIndex]) return;
+    if (saving || !accountSelect.value || selectedIndex < 0 || !candidates[selectedIndex]) return;
     const c = candidates[selectedIndex];
 
     const formData = new FormData();
     formData.append('action',   'udlign');
     formData.append('entry_id', ENTRY_ID);
-    formData.append('kontonr',  c.kontonr);
-    formData.append('art',      c.art);
-    formData.append('faktnr',   c.faktnr);
-    formData.append('amount',   AMOUNT);
+    formData.append('openpost_id', c.id);
+    formData.append('account_id', accountSelect.value);
+    formData.append('snapshot', SNAPSHOT);
+    formData.append('token', TOKEN);
+    saving = true;
 
     udlignBtn.disabled = true;
     udlignBtn.textContent = 'Saving…';
@@ -1092,8 +1137,9 @@ print "</tbody></table></td></tr></tbody></table>";
       method: 'POST',
       body:   formData
     })
-    .then(r => {
-      if (!r.ok) throw new Error('HTTP ' + r.status);
+    .then(r => r.json())
+    .then(data => {
+      if (!data.success) throw new Error(data.error || 'The journal could not be saved.');
       // Advance to next entry, carrying counters (settled+1, skipped unchanged)
       window.location.href = window.location.pathname +
         '?kladde_id=' + encodeURIComponent(KLADDE_ID) +
@@ -1101,10 +1147,11 @@ print "</tbody></table></td></tr></tbody></table>";
         '&settled=' + (SETTLED + 1) +
         '&skipped=' + SKIPPED;
     })
-    .catch(() => {
+    .catch(error => {
+      saving = false;
       udlignBtn.disabled = false;
       udlignBtn.textContent = 'Settle';
-      alert('An error occurred. Please try again.');
+      alert(error.message);
     });
   }
 
@@ -1141,6 +1188,7 @@ print "</tbody></table></td></tr></tbody></table>";
 
   /* ── Keyboard navigation ─────────────────────────────────── */
   document.addEventListener('keydown', e => {
+    if (saving || e.target === accountSelect) return;
     const rows = candidateBody.querySelectorAll('.candidate-row'); 
     if (!rows.length) return;
 
@@ -1171,9 +1219,16 @@ print "</tbody></table></td></tr></tbody></table>";
   /* ── Search debounce ─────────────────────────────────────── */
   searchInput.addEventListener('input', () => {
     clearTimeout(debounceTimer);
+    ++fetchSeq;
+    setLoading();
     debounceTimer = setTimeout(() => {
       fetchCandidates(searchInput.value, 1);
     }, 220);
+  });
+
+  accountSelect.addEventListener('change', () => {
+    clearTimeout(debounceTimer);
+    fetchCandidates(searchInput.value, 1);
   });
 
   /* ── Pagination buttons ──────────────────────────────────── */
@@ -1210,7 +1265,7 @@ print "</tbody></table></td></tr></tbody></table>";
   }
 
   /* ── Boot ────────────────────────────────────────────────── */
-  // Load all open posts unfiltered; HINT_TOKENS/DESC_WORDS scoring ranks them.
+  // Only fetch open posts after an account has been selected.
   // Using the raw description as a literal filter hides the real matches.
   fetchCandidates('', 1);
 

--- a/finans/autoudlign.php
+++ b/finans/autoudlign.php
@@ -852,6 +852,7 @@ print "</tbody></table></td></tr></tbody></table>";
   let selectedIndex    = -1;
   let debounceTimer    = null;
   let autoSelected     = false;    // did we auto-pick a candidate?
+  let autoSelectId     = null;     // server checks uniqueness before pagination
   let saving           = false;
   let fetchSeq         = 0;        // guards against stale responses
 
@@ -986,6 +987,7 @@ print "</tbody></table></td></tr></tbody></table>";
         if (seq !== fetchSeq) return;   // a newer request superseded this one
         const raw   = (data.results || []).filter(c => !BRUGT.includes(c.art + ':' + c.kontonr + ':' + c.faktnr));
         candidates  = sortAndScore(raw);
+        autoSelectId = data.autoSelectId ?? null;
         totalCount  = data.pagination ? data.pagination.total : candidates.length;
         hasMore     = data.pagination ? data.pagination.hasMore : false;
         render(search);
@@ -1079,9 +1081,10 @@ print "</tbody></table></td></tr></tbody></table>";
   function autoSelectBest() {
     if (!accountSelect.value || candidates.length === 0) return;
 
-    const best = candidates[0];
-    if (best.amountMatch && (candidates.length === 1 || best._score > candidates[1]._score)) {
-      setSelected(0);
+    const bestIndex = candidates.findIndex(c => String(c.id) === String(autoSelectId));
+    const best = candidates[bestIndex];
+    if (best && best.amountMatch && Math.abs(Number(best.amount) - AMOUNT) < 0.001) {
+      setSelected(bestIndex);
       autoSelected = true;
     }
 

--- a/finans/kassekladde_includes/autoSettlement.php
+++ b/finans/kassekladde_includes/autoSettlement.php
@@ -1,0 +1,113 @@
+<?php
+// 20260908 CDX/LH Scope automatic settlement to the chosen account and validate live rows before saving.
+
+/**
+ * Identify the customer/supplier side, or the empty side of an imported bank line.
+ *
+ * @return array{account: string, accountType: string, field: string, amount: float}|null
+ */
+function autoSettlementContext(array $entry) {
+    $accounts = [];
+    foreach (['debet' => 'd_type', 'kredit' => 'k_type'] as $field => $typeField) {
+        $account = trim((string)($entry[$field] ?? ''));
+        $type = trim((string)($entry[$typeField] ?? ''));
+        if ($account && in_array($type, ['D', 'K'], true)) {
+            $accounts[] = ['account' => $account, 'accountType' => $type, 'field' => $field];
+        }
+    }
+    if (count($accounts) > 1 || (float)($entry['amount'] ?? 0) == 0) return null;
+    if ($accounts) {
+        if (trim((string)($entry['faktura'] ?? '')) !== '') return null;
+        $context = $accounts[0];
+    } else {
+        $debit = (bool)trim((string)($entry['debet'] ?? ''));
+        $credit = (bool)trim((string)($entry['kredit'] ?? ''));
+        if ($debit === $credit) return null;
+        $context = ['account' => '', 'accountType' => '', 'field' => $debit ? 'kredit' : 'debet'];
+    }
+    $context['amount'] = (float)$entry['amount'] * ($context['field'] === 'debet' ? -1 : 1);
+    return $context;
+}
+
+/** @return string Fingerprint of the journal values the user reviewed. */
+function autoSettlementSnapshot(array $entry) {
+    $values = [];
+    foreach (['id', 'kladde_id', 'debet', 'kredit', 'd_type', 'k_type', 'faktura', 'amount', 'transdate', 'valuta', 'valutakurs', 'beskrivelse'] as $field) {
+        $values[$field] = (string)($entry[$field] ?? '');
+    }
+    return hash('sha256', json_encode($values));
+}
+
+/** @return string SQL predicate that never broadens an incomplete account filter. */
+function autoSettlementAccountWhere($account, $type) {
+    if (!is_string($account) || !is_string($type)) return '1 = 0';
+    $account = trim($account);
+    $type = trim($type);
+    if ($account === '' || !in_array($type, ['D', 'K'], true)) return '1 = 0';
+    $account = db_escape_string($account);
+    return "openpost.konto_nr = '$account' AND adresser.kontonr = '$account' AND adresser.art = '$type'";
+}
+
+/** @return void */
+function autoSettlementWrite($sql) {
+    $result = db_modify($sql, __FILE__ . ' line ' . __LINE__);
+    if (!is_string($result) || strncmp($result, "0\t", 2) !== 0) {
+        throw new RuntimeException('The journal could not be saved. Reload and try again.');
+    }
+}
+
+/**
+ * Resolve invoice/account values from the selected open post, never from submitted labels.
+ * Partial payments remain valid: selecting an invoice does not change the journal amount.
+ *
+ * @return void
+ * @throws RuntimeException When the journal, line, account or open post is no longer eligible.
+ */
+function saveAutoSettlement($journalId, $entryId, $openpostId, $accountId, $snapshot) {
+    $journalId = is_scalar($journalId) ? filter_var($journalId, FILTER_VALIDATE_INT) : false;
+    $entryId = is_scalar($entryId) ? filter_var($entryId, FILTER_VALIDATE_INT) : false;
+    $openpostId = is_scalar($openpostId) ? filter_var($openpostId, FILTER_VALIDATE_INT) : false;
+    $accountId = is_scalar($accountId) ? filter_var($accountId, FILTER_VALIDATE_INT) : false;
+    if ($journalId <= 0 || $entryId <= 0 || $openpostId <= 0 || $accountId <= 0 || !is_string($snapshot)) {
+        throw new RuntimeException('Choose an account and an open entry before settling.');
+    }
+    autoSettlementWrite('BEGIN');
+    try {
+        $journal = db_fetch_array(db_select("SELECT bogfort FROM kladdeliste WHERE id = $journalId FOR UPDATE", __FILE__ . ' line ' . __LINE__));
+        if (!$journal || !in_array(trim((string)$journal['bogfort']), ['-', '!'], true)) {
+            throw new RuntimeException('This journal is no longer open. Reload the journal.');
+        }
+        $entry = db_fetch_array(db_select("SELECT * FROM kassekladde WHERE id = $entryId AND kladde_id = $journalId FOR UPDATE", __FILE__ . ' line ' . __LINE__));
+        if (!$entry || !hash_equals(autoSettlementSnapshot($entry), $snapshot)) {
+            throw new RuntimeException('This journal line has changed. Reload before settling.');
+        }
+        $context = autoSettlementContext($entry);
+        if (!$context) throw new RuntimeException('This journal line can no longer be settled here.');
+        $post = db_fetch_array(db_select("SELECT * FROM openpost WHERE id = $openpostId FOR UPDATE", __FILE__ . ' line ' . __LINE__));
+        $account = db_fetch_array(db_select("SELECT kontonr, art FROM adresser WHERE id = $accountId FOR UPDATE", __FILE__ . ' line ' . __LINE__));
+        if (!$post || !$account || (int)$post['konto_id'] !== $accountId
+            || (string)$post['udlignet'] === '1'
+            || trim((string)$post['konto_nr']) !== trim((string)$account['kontonr'])
+            || !in_array(trim((string)$account['art']), ['D', 'K'], true)) {
+            throw new RuntimeException('The selected open entry is no longer available for this account. Search again.');
+        }
+        if ($context['account'] !== '' && ($context['account'] !== trim((string)$account['kontonr'])
+            || $context['accountType'] !== trim((string)$account['art']))) {
+            throw new RuntimeException('The selected entry belongs to a different account than the journal line.');
+        }
+        $invoice = db_escape_string(trim((string)$post['faktnr']));
+        $assignments = "faktura = '$invoice'";
+        if ($context['account'] === '') {
+            $number = db_escape_string(trim((string)$account['kontonr']));
+            $type = db_escape_string(trim((string)$account['art']));
+            $field = $context['field'];
+            $typeField = $field === 'debet' ? 'd_type' : 'k_type';
+            $assignments .= ", $field = '$number', $typeField = '$type'";
+        }
+        autoSettlementWrite("UPDATE kassekladde SET $assignments WHERE id = $entryId AND kladde_id = $journalId");
+        autoSettlementWrite('COMMIT');
+    } catch (Throwable $error) {
+        autoSettlementWrite('ROLLBACK');
+        throw $error;
+    }
+}

--- a/finans/kassekladde_includes/autoSettlement.php
+++ b/finans/kassekladde_includes/autoSettlement.php
@@ -48,6 +48,23 @@ function autoSettlementAccountWhere($account, $type) {
     return "openpost.konto_nr = '$account' AND adresser.kontonr = '$account' AND adresser.art = '$type'";
 }
 
+/** @return bool Whether an automatic match has the same amount and payment direction. */
+function autoSettlementAmountMatches($amount, $currentAmount) {
+    return $currentAmount !== null && abs((float)$amount - (float)$currentAmount) < 0.001;
+}
+
+/**
+ * Decide before pagination or client-side removal of already-used invoices.
+ *
+ * @param array $sortedRows All matching open posts, sorted by score descending.
+ * @return int|null The unique highest-scored exact match, or null when selection must be manual.
+ */
+function autoSettlementBestCandidateId(array $sortedRows) {
+    if (!$sortedRows || !$sortedRows[0]['amountMatch']) return null;
+    if (isset($sortedRows[1]) && $sortedRows[0]['_score'] <= $sortedRows[1]['_score']) return null;
+    return (int)$sortedRows[0]['id'];
+}
+
 /** @return void */
 function autoSettlementWrite($sql) {
     $result = db_modify($sql, __FILE__ . ' line ' . __LINE__);
@@ -90,6 +107,9 @@ function saveAutoSettlement($journalId, $entryId, $openpostId, $accountId, $snap
             || trim((string)$post['konto_nr']) !== trim((string)$account['kontonr'])
             || !in_array(trim((string)$account['art']), ['D', 'K'], true)) {
             throw new RuntimeException('The selected open entry is no longer available for this account. Search again.');
+        }
+        if (trim((string)$post['faktnr']) === '') {
+            throw new RuntimeException('The selected open entry has no invoice reference to assign.');
         }
         if ($context['account'] !== '' && ($context['account'] !== trim((string)$account['kontonr'])
             || $context['accountType'] !== trim((string)$account['art']))) {

--- a/finans/kassekladde_includes/invoiceSearch.php
+++ b/finans/kassekladde_includes/invoiceSearch.php
@@ -46,7 +46,6 @@ $totalCount = 0;
 
 $search_escaped = db_escape_string($search);
 // Sanitize accountType - only allow 'D' or 'K'
-$hasAccountFilter = $accountNr !== '' || $accountType !== '';
 $accountType = strtoupper($accountType);
 if ($accountType !== 'D' && $accountType !== 'K') {
     $accountType = '';
@@ -54,8 +53,12 @@ if ($accountType !== 'D' && $accountType !== 'K') {
 
 $baseWhere = "(openpost.udlignet != '1' OR openpost.udlignet IS NULL)";
 
-if ($mode === 'open_post' || $hasAccountFilter) {
+if ($mode === 'open_post' || $accountNr !== '') {
     $baseWhere .= ' AND (' . autoSettlementAccountWhere($accountNr, $accountType) . ')';
+}
+
+if ($mode === 'open_post') {
+    $baseWhere .= " AND TRIM(COALESCE(openpost.faktnr, '')) != ''";
 }
 
 // Add search filter
@@ -129,7 +132,7 @@ if ($mode === 'open_post') {
         $score = 0;
         
         // 1. Amount match
-        $amountMatch = ($currentAmountFloat !== null) && (abs(abs($rowAmount) - abs($currentAmountFloat)) < 0.001);
+        $amountMatch = autoSettlementAmountMatches($rowAmount, $currentAmountFloat);
         if ($amountMatch) $score += 40;
         
         // 2. Company name words in description words
@@ -203,6 +206,7 @@ if ($mode === 'open_post') {
         return strcmp($a['faktnr'], $b['faktnr']);
     });
     
+    $autoSelectId = autoSettlementBestCandidateId($allRows);
     $totalCount = count($allRows);
     $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
     $limit = 50;
@@ -214,6 +218,7 @@ if ($mode === 'open_post') {
     
     $response = [
         'results' => $pageResults,
+        'autoSelectId' => $autoSelectId,
         'pagination' => [
             'page' => $page,
             'limit' => $limit,

--- a/finans/kassekladde_includes/invoiceSearch.php
+++ b/finans/kassekladde_includes/invoiceSearch.php
@@ -1,4 +1,5 @@
 <?php
+// 20260908 CDX/LH Require an exact customer/supplier filter for automatic settlement.
 
 ob_start();
 
@@ -12,17 +13,19 @@ $webservice = true;
 
 chdir(dirname(__FILE__) . '/..');
 
-include("../includes/connect.php");
-include("../includes/online.php");
-include("../includes/std_func.php"); 
+include(__DIR__ . "/../../includes/connect.php");
+include(__DIR__ . "/../../includes/online.php");
+include(__DIR__ . "/../../includes/std_func.php");
+
+include_once(__DIR__ . '/autoSettlement.php');
 
 ob_end_clean();
 
 header('Content-Type: application/json; charset=utf-8');
 
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
-$accountNr = isset($_GET['account']) ? trim($_GET['account']) : '';
-$accountType = isset($_GET['accountType']) ? trim($_GET['accountType']) : ''; // D or K
+$accountNr = is_string($_GET['account'] ?? null) ? trim($_GET['account']) : '';
+$accountType = is_string($_GET['accountType'] ?? null) ? trim($_GET['accountType']) : ''; // D or K
 $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
 $limit = 50; 
 $offset = ($page - 1) * $limit;
@@ -42,22 +45,17 @@ $results = array();
 $totalCount = 0;
 
 $search_escaped = db_escape_string($search);
-$accountNr_escaped = db_escape_string($accountNr);
 // Sanitize accountType - only allow 'D' or 'K'
-$accountType = strtoupper(substr($accountType, 0, 1));
+$hasAccountFilter = $accountNr !== '' || $accountType !== '';
+$accountType = strtoupper($accountType);
 if ($accountType !== 'D' && $accountType !== 'K') {
     $accountType = '';
 }
 
 $baseWhere = "(openpost.udlignet != '1' OR openpost.udlignet IS NULL)";
 
-if ($accountNr !== '' && $accountType !== '') {
-    $baseWhere .= " AND openpost.konto_nr = '$accountNr_escaped'";
-    $ktoQuery = db_select("SELECT id FROM adresser WHERE kontonr = '$accountNr_escaped' AND art = '$accountType'", __FILE__ . " line " . __LINE__);
-    if ($ktoRow = db_fetch_array($ktoQuery)) {
-        $konto_id = $ktoRow['id'];
-        $baseWhere .= " AND openpost.konto_id = '$konto_id'";
-    }
+if ($mode === 'open_post' || $hasAccountFilter) {
+    $baseWhere .= ' AND (' . autoSettlementAccountWhere($accountNr, $accountType) . ')';
 }
 
 // Add search filter

--- a/tests/test_auto_settlement.php
+++ b/tests/test_auto_settlement.php
@@ -1,0 +1,135 @@
+<?php
+// 20260908 CDX/LH Exercise account matching and journal assignment with isolated SQLite fixtures.
+// Run: php tests/test_auto_settlement.php (pdo_sqlite; no application bootstrap).
+// Optional isolated Postgres: SALDI_CHAR_DSN, SALDI_CHAR_PGUSER, SALDI_CHAR_PGPASS.
+// Fixtures use connection-local temporary tables only.
+
+error_reporting(E_ALL);
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+require_once __DIR__ . '/../finans/kassekladde_includes/autoSettlement.php';
+
+function db_select($sql, $trace) {
+    if ($GLOBALS['testDb']->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+        $sql = str_replace(' FOR UPDATE', '', $sql);
+    }
+    return $GLOBALS['testDb']->query($sql);
+}
+function db_fetch_array($query) {
+    return $query->fetch(PDO::FETCH_ASSOC);
+}
+function db_escape_string($value) {
+    return substr($GLOBALS['testDb']->quote($value), 1, -1);
+}
+function db_modify($sql, $trace) {
+    if ($GLOBALS['failUpdate'] && strpos($sql, 'UPDATE kassekladde') === 0) return "1\tInjected failure";
+    $GLOBALS['testDb']->exec($sql);
+    return "0\tquery accepted";
+}
+function fixture() {
+    $db = new PDO(getenv('SALDI_CHAR_DSN') ?: 'sqlite::memory:', getenv('SALDI_CHAR_PGUSER') ?: null, getenv('SALDI_CHAR_PGPASS') ?: null);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec("CREATE TEMP TABLE kladdeliste (id INTEGER PRIMARY KEY, bogfort TEXT);
+        CREATE TEMP TABLE adresser (id INTEGER PRIMARY KEY, kontonr TEXT, art TEXT);
+        CREATE TEMP TABLE openpost (id INTEGER PRIMARY KEY, konto_id INTEGER, konto_nr TEXT, faktnr TEXT, amount NUMERIC, udlignet TEXT);
+        CREATE TEMP TABLE kassekladde (id INTEGER PRIMARY KEY, kladde_id INTEGER, debet TEXT, kredit TEXT,
+            d_type TEXT, k_type TEXT, faktura TEXT, amount NUMERIC, transdate TEXT, valuta TEXT, valutakurs NUMERIC, beskrivelse TEXT);
+        INSERT INTO kladdeliste VALUES (99, '-'), (100, '-');
+        INSERT INTO adresser VALUES (29, '1009', 'K'), (30, '1009', 'D'), (31, '2000', 'K');
+        INSERT INTO openpost VALUES (101,29,'1009','INV-1',1991.50,'0'), (102,30,'1009','INV-1',1991.50,'0'),
+            (103,31,'2000','INV-1',1991.50,'0'), (104,29,'1009','PAID',1991.50,'1'), (105,29,'1009','NULL-OPEN',150,NULL);
+        INSERT INTO kassekladde VALUES (1,99,'','5800','F','F','',500,'2026-09-03','DKK',100,'alcar'),
+            (2,100,'','5800','F','F','',500,'2026-09-03','DKK',100,'other journal');");
+    $GLOBALS['testDb'] = $db;
+    $GLOBALS['failUpdate'] = false;
+    return $db;
+}
+function entry($id = 1) {
+    return $GLOBALS['testDb']->query('SELECT * FROM kassekladde WHERE id = ' . (int)$id)->fetch(PDO::FETCH_ASSOC);
+}
+function check($condition, $message) {
+    if (!$condition) throw new RuntimeException($message);
+}
+function reject($callback, $message) {
+    $before = $GLOBALS['testDb']->query('SELECT * FROM kassekladde ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+    try {
+        $callback();
+    } catch (RuntimeException $error) {
+        check($before === $GLOBALS['testDb']->query('SELECT * FROM kassekladde ORDER BY id')->fetchAll(PDO::FETCH_ASSOC), 'Rejected save changed a journal row');
+        check(strpos($error->getMessage(), $message) !== false, 'Unexpected rejection: ' . $error->getMessage());
+        return;
+    }
+    throw new RuntimeException('Expected rejection: ' . $message);
+}
+
+$passed = 0;
+foreach ([['1009','K',[101,105]], ['1009','D',[102]], ['2000','K',[103]], ['404','K',[]],
+    ['','',[]], ['1009','',[]], ['','K',[]], ['1009','F',[]], [[], 'K', []], ["1009' OR 1=1 --",'K',[]]] as [$number,$type,$expected]) {
+    $db = fixture();
+    $where = autoSettlementAccountWhere($number, $type);
+    $ids = $db->query("SELECT openpost.id FROM openpost JOIN adresser ON adresser.id = openpost.konto_id
+        WHERE (openpost.udlignet != '1' OR openpost.udlignet IS NULL) AND ($where) ORDER BY openpost.id")->fetchAll(PDO::FETCH_COLUMN);
+    check($ids === $expected, 'Account/type filter widened to unrelated rows');
+    ++$passed;
+}
+
+foreach ([['', '5800', 'F', 'F', 29, 101, '1009', '5800', 'K', 'F'],
+          ['0', '5800', 'F', 'F', 29, 101, '1009', '5800', 'K', 'F'],
+          [null, '5800', 'F', 'F', 29, 101, '1009', '5800', 'K', 'F'],
+          ['5800', '', 'F', 'F', 30, 102, '5800', '1009', 'F', 'D'],
+          ['1009', '5800', 'K', 'F', 29, 101, '1009', '5800', 'K', 'F'],
+          ['5800', '1009', 'F', 'D', 30, 102, '5800', '1009', 'F', 'D'],
+          ['1009', '', 'K', 'F', 29, 101, '1009', '', 'K', 'F']] as $case) {
+    [$debit,$credit,$dt,$kt,$accountId,$postId,$newDebit,$newCredit,$newDt,$newKt] = $case;
+    $db = fixture();
+    $db->prepare('UPDATE kassekladde SET debet=?, kredit=?, d_type=?, k_type=? WHERE id=1')->execute([$debit,$credit,$dt,$kt]);
+    $before = entry();
+    saveAutoSettlement(99, 1, $postId, $accountId, autoSettlementSnapshot($before));
+    $after = entry();
+    check([$after['debet'],$after['kredit'],$after['d_type'],$after['k_type'],$after['faktura']] === [$newDebit,$newCredit,$newDt,$newKt,'INV-1'], 'Wrong assignment side or account');
+    check($after['amount'] === $before['amount'], 'Partial-payment amount was changed');
+    check($db->query('SELECT udlignet FROM openpost WHERE id=101')->fetchColumn() === '0', 'Invoice itself was reconciled prematurely');
+    reject(fn() => saveAutoSettlement(99, 1, $postId, $accountId, autoSettlementSnapshot($before)), 'line has changed');
+    ++$passed;
+}
+foreach ([
+    [99,1,101,0,'Choose an account'], [99,1,101,31,'no longer available'], [99,1,104,29,'no longer available'],
+    [99,1,999,29,'no longer available'], [99,2,101,29,'line has changed'], [100,1,101,29,'line has changed'],
+    [99,999,101,29,'line has changed'], [99,[1],101,29,'Choose an account'], [99,1,'101 OR 1=1',29,'Choose an account'],
+] as [$journal,$id,$post,$account,$message]) {
+    fixture();
+    $snapshot = autoSettlementSnapshot(entry());
+    reject(fn() => saveAutoSettlement($journal,$id,$post,$account,$snapshot), $message);
+    ++$passed;
+}
+foreach (['debet'=>'1009', 'kredit'=>'5900', 'amount'=>'499', 'faktura'=>'other', 'transdate'=>'2026-09-04', 'valuta'=>'EUR', 'beskrivelse'=>'edited'] as $field=>$value) {
+    $db = fixture();
+    $snapshot = autoSettlementSnapshot(entry());
+    $db->prepare("UPDATE kassekladde SET $field=? WHERE id=1")->execute([$value]);
+    reject(fn() => saveAutoSettlement(99,1,101,29,$snapshot), 'line has changed');
+    ++$passed;
+}
+foreach (['V', 'S'] as $posted) {
+    $db = fixture();
+    $db->prepare('UPDATE kladdeliste SET bogfort=? WHERE id=99')->execute([$posted]);
+    reject(fn() => saveAutoSettlement(99,1,101,29,autoSettlementSnapshot(entry())), 'no longer open');
+    ++$passed;
+}
+$db = fixture();
+$db->exec("UPDATE kassekladde SET debet='1009', d_type='K' WHERE id=1");
+reject(fn() => saveAutoSettlement(99,1,102,30,autoSettlementSnapshot(entry())), 'different account');
+++$passed;
+$db = fixture();
+$db->exec("UPDATE adresser SET art='F' WHERE id=29");
+reject(fn() => saveAutoSettlement(99,1,101,29,autoSettlementSnapshot(entry())), 'no longer available');
+++$passed;
+fixture();
+$GLOBALS['failUpdate'] = true;
+reject(fn() => saveAutoSettlement(99,1,101,29,autoSettlementSnapshot(entry())), 'could not be saved');
+++$passed;
+fixture();
+saveAutoSettlement(99,1,105,29,autoSettlementSnapshot(entry()));
+check(entry()['faktura'] === 'NULL-OPEN', 'NULL udlignet should remain eligible');
+++$passed;
+echo "PASS: $passed account-filter and settlement cases (" . $GLOBALS['testDb']->getAttribute(PDO::ATTR_DRIVER_NAME) . ", E_ALL).\n";

--- a/tests/test_auto_settlement.php
+++ b/tests/test_auto_settlement.php
@@ -64,6 +64,18 @@ function reject($callback, $message) {
 }
 
 $passed = 0;
+foreach ([[500,500,true], [-500,500,false], [500,-500,false], [-500,-500,true], [500,499,false], [500,null,false]] as [$amount,$target,$expected]) {
+    check(autoSettlementAmountMatches($amount,$target) === $expected, 'Automatic matching ignored payment direction');
+    ++$passed;
+}
+$exact = ['id'=>101,'amountMatch'=>true,'_score'=>40];
+$partial = ['id'=>102,'amountMatch'=>false,'_score'=>0];
+$tied = array_fill(0, 51, $exact);
+foreach ([[$tied,null], [[$exact],101], [[$exact,$partial],101], [[$partial],null], [[],null]] as [$rows,$expected]) {
+    check(autoSettlementBestCandidateId($rows) === $expected, 'Automatic selection ignored global ambiguity');
+    ++$passed;
+}
+
 foreach ([['1009','K',[101,105]], ['1009','D',[102]], ['2000','K',[103]], ['404','K',[]],
     ['','',[]], ['1009','',[]], ['','K',[]], ['1009','F',[]], [[], 'K', []], ["1009' OR 1=1 --",'K',[]]] as [$number,$type,$expected]) {
     $db = fixture();
@@ -108,6 +120,12 @@ foreach (['debet'=>'1009', 'kredit'=>'5900', 'amount'=>'499', 'faktura'=>'other'
     $snapshot = autoSettlementSnapshot(entry());
     $db->prepare("UPDATE kassekladde SET $field=? WHERE id=1")->execute([$value]);
     reject(fn() => saveAutoSettlement(99,1,101,29,$snapshot), 'line has changed');
+    ++$passed;
+}
+foreach (['', ' ', null] as $invoice) {
+    $db = fixture();
+    $db->prepare('UPDATE openpost SET faktnr=? WHERE id=101')->execute([$invoice]);
+    reject(fn() => saveAutoSettlement(99,1,101,29,autoSettlementSnapshot(entry())), 'no invoice reference');
     ++$passed;
 }
 foreach (['V', 'S'] as $posted) {

--- a/tests/test_auto_settlement_ui.mjs
+++ b/tests/test_auto_settlement_ui.mjs
@@ -13,7 +13,7 @@ script = script.replace(/(const|let)\s+(\w+)\s*=\s*<\?= .*? \?>;/g, (_,kind,name
   return `${kind} ${name} = ${JSON.stringify(values[name])};`;
 });
 
-function boot(initialAccount = '') {
+function boot(initialAccount = '', used = []) {
   const nodes = new Map();
   const listeners = {};
   const requests = [];
@@ -51,13 +51,13 @@ function boot(initialAccount = '') {
     document:{getElementById:id=>nodes.get(id),addEventListener:(name,fn)=>{listeners[name]=fn;}},
     setTimeout:fn=>{timers.set(++timerId,fn);return timerId;},clearTimeout:id=>timers.delete(id),
     fetch:(url,options)=>new Promise((resolve,reject)=>requests.push({url,options,resolve,reject}))};
-  vm.runInNewContext(script, context, {filename:'autoudlign-page.js'});
+  vm.runInNewContext(script.replace('const BRUGT = [];', 'const BRUGT = ' + JSON.stringify(used) + ';'), context, {filename:'autoudlign-page.js'});
   const key = (key,target=nodes.get('searchInput')) => listeners.keydown({key,target,preventDefault(){}});
   return {nodes,requests,choose,key,location,alerts,timers};
 }
 const candidate = (id=101, amountMatch=true) => ({id,konto_id:29,kontonr:'1009',art:'K',faktnr:`REF-${id}`,firmanavn:'Alcar',amount:amountMatch?500:1991.50,amountMatch,transdate:'2026-09-01'});
-async function respond(request, results) {
-  request.resolve({json:async()=>({results,pagination:{total:results.length,hasMore:false}})});
+async function respond(request, results, metadata = {}) {
+  request.resolve({json:async()=>({results,autoSelectId:results.length === 1 ? results[0].id : null,pagination:{total:results.length,hasMore:false},...metadata})});
   await new Promise(resolve=>setImmediate(resolve));
 }
 async function saveResponse(request, data) {
@@ -138,4 +138,22 @@ ui.choose('');
 await respond(ui.requests[0],[candidate()]);
 assert.match(ui.nodes.get('candidateBody').innerHTML,/Choose a customer or supplier/);
 assert.equal(ui.nodes.get('udlignBtn').disabled,true);
+ui=boot('29');
+await respond(ui.requests[0],[{...candidate(),amount:-500}]);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Opposite-sign credit was automatically selected');
+ui.key('ArrowDown');
+ui.key('Enter');
+assert.equal(ui.requests[1].options.body.get('openpost_id'),'101','Credit could not be chosen manually');
+
+const pageOfTies = Array.from({length:50},(_,i)=>candidate(101+i));
+ui=boot('29',pageOfTies.slice(0,49).map(c=>c.art + ':' + c.kontonr + ':' + c.faktnr));
+await respond(ui.requests[0],pageOfTies,{autoSelectId:null,pagination:{total:51,hasMore:true}});
+assert.equal(ui.nodes.get('candidateBody').rows.length,1,'Fixture should leave one unused visible candidate');
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Filtering a page hid the server-reported global tie');
+ui.key('Enter');
+assert.equal(ui.requests.length,1,'Enter confirmed a tie on another page');
+ui.nodes.get('nextBtn').dispatch('click');
+await respond(ui.requests[1],[candidate(151)],{autoSelectId:null,pagination:{total:51,hasMore:false}});
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Last-page single row hid global ambiguity');
+
 console.log('PASS: account choice, typed search parameters, keyboard confirmation, ambiguous/partial/no matches, duplicate submit guard, save errors and stale responses.');

--- a/tests/test_auto_settlement_ui.mjs
+++ b/tests/test_auto_settlement_ui.mjs
@@ -1,0 +1,141 @@
+// 20260908 CDX/LH Exercise the actual settlement-page JavaScript with an isolated DOM and transport.
+// Run: node tests/test_auto_settlement_ui.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const page = fs.readFileSync(new URL('../finans/autoudlign.php', import.meta.url), 'utf8');
+let script = page.match(/<script>\s*(\(function \(\) \{[\s\S]*?\}\)\(\);)\s*<\/script>/)[1];
+const values = {KLADDE_ID:99, ENTRY_ID:1, TOKEN:'fixture-session', SNAPSHOT:'fixture-snapshot', AMOUNT:500,
+  BESKRIVELSE:'invoice payment', BRUGT:[], HINT_TOKENS:[], SKIPPED:0, SETTLED:0};
+script = script.replace(/(const|let)\s+(\w+)\s*=\s*<\?= .*? \?>;/g, (_,kind,name) => {
+  assert.ok(Object.hasOwn(values, name), `Missing PHP fixture for ${name}`);
+  return `${kind} ${name} = ${JSON.stringify(values[name])};`;
+});
+
+function boot(initialAccount = '') {
+  const nodes = new Map();
+  const listeners = {};
+  const requests = [];
+  const alerts = [];
+  const timers = new Map();
+  let timerId = 0;
+  function element(id) {
+    const handlers = {};
+    const node = {id, value:'', disabled:false, style:{}, dataset:{}, selectedOptions:[{dataset:{}}],
+      addEventListener: (event, fn) => { handlers[event] = fn; },
+      dispatch: (event) => handlers[event]?.(), focus(){}, scrollIntoView(){},
+      classList:{toggle(){}}, textContent:'', rows:[],
+      querySelectorAll: () => node.rows};
+    Object.defineProperty(node, 'innerHTML', {get:()=>node.html || '', set:html => {
+      node.html = html;
+      node.rows = [...html.matchAll(/data-index="(\d+)"/g)].map(([,index]) => {
+        const row = element(`row-${index}`); row.dataset.index=index; return row;
+      });
+    }});
+    nodes.set(id,node);
+    return node;
+  }
+  ['accountSelect','searchInput','candidateBody','udlignBtn','skipBtn','selectionInfo','matchHint','pageInfo','paginationBar','prevBtn','nextBtn'].forEach(element);
+  nodes.get('udlignBtn').disabled = true;
+  const account = nodes.get('accountSelect');
+  function choose(id, number = '1009', type = 'K') {
+    account.value = id;
+    account.selectedOptions = [{dataset:{account:number,type}}];
+    account.dispatch('change');
+  }
+  account.value = initialAccount;
+  if (initialAccount) account.selectedOptions = [{dataset:{account:'1009',type:'K'}}];
+  const location = {pathname:'/finans/autoudlign.php', href:''};
+  const context = {URLSearchParams,FormData,console,window:{location},alert:message=>alerts.push(message),
+    document:{getElementById:id=>nodes.get(id),addEventListener:(name,fn)=>{listeners[name]=fn;}},
+    setTimeout:fn=>{timers.set(++timerId,fn);return timerId;},clearTimeout:id=>timers.delete(id),
+    fetch:(url,options)=>new Promise((resolve,reject)=>requests.push({url,options,resolve,reject}))};
+  vm.runInNewContext(script, context, {filename:'autoudlign-page.js'});
+  const key = (key,target=nodes.get('searchInput')) => listeners.keydown({key,target,preventDefault(){}});
+  return {nodes,requests,choose,key,location,alerts,timers};
+}
+const candidate = (id=101, amountMatch=true) => ({id,konto_id:29,kontonr:'1009',art:'K',faktnr:`REF-${id}`,firmanavn:'Alcar',amount:amountMatch?500:1991.50,amountMatch,transdate:'2026-09-01'});
+async function respond(request, results) {
+  request.resolve({json:async()=>({results,pagination:{total:results.length,hasMore:false}})});
+  await new Promise(resolve=>setImmediate(resolve));
+}
+async function saveResponse(request, data) {
+  request.resolve({json:async()=>data});
+  await new Promise(resolve=>setImmediate(resolve));
+}
+
+let ui = boot();
+assert.equal(ui.requests.length,0,'Unassigned line fetched cross-account suggestions');
+ui.key('Enter');
+assert.equal(ui.requests.length,0,'Enter submitted without an account');
+ui.choose('29');
+let query = new URL(ui.requests[0].url,'https://fixture.invalid').searchParams;
+assert.equal(query.get('account'),'1009');
+assert.equal(query.get('accountType'),'K');
+await respond(ui.requests[0],[candidate()]);
+assert.equal(ui.nodes.get('udlignBtn').disabled,false,'Unique exact amount should be selectable');
+ui.key('Enter');
+ui.key('Enter');
+assert.equal(ui.requests.length,2,'Repeated Enter submitted twice while saving');
+assert.equal(ui.requests[1].options.body.get('openpost_id'),'101');
+assert.equal(ui.requests[1].options.body.get('account_id'),'29');
+assert.equal(ui.requests[1].options.body.has('amount'),false,'Client controls accounting amount');
+await saveResponse(ui.requests[1],{success:false,error:'This journal line has changed.'});
+assert.equal(ui.location.href,'','Failed save advanced to the next line');
+assert.equal(ui.alerts[0],'This journal line has changed.');
+ui.key('Enter');
+await saveResponse(ui.requests[2],{success:true});
+assert.match(ui.location.href,/settled=1/);
+
+ui=boot('29');
+await respond(ui.requests[0],[candidate(101),candidate(102)]);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Tied amount matches were automatically selected');
+ui.key('Enter');
+assert.equal(ui.requests.length,1);
+ui.key('ArrowDown',ui.nodes.get('accountSelect'));
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Account chooser arrow key selected an invoice');
+ui.key('ArrowDown');
+ui.key('Enter');
+assert.equal(ui.requests.length,2,'Explicit keyboard selection did not submit');
+
+ui=boot('29');
+await respond(ui.requests[0],[candidate(101,false)]);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true,'Partial payment was automatically selected');
+ui.key('ArrowDown');
+ui.key('Enter');
+assert.equal(ui.requests[1].options.body.get('openpost_id'),'101','Partial payment could not be selected explicitly');
+
+ui=boot('29');
+await respond(ui.requests[0],[]);
+ui.key('Enter');
+assert.equal(ui.requests.length,1);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true);
+assert.match(ui.nodes.get('candidateBody').innerHTML,/No open entries match/);
+
+ui=boot();
+ui.choose('29');
+ui.choose('31','2000','K');
+await respond(ui.requests[1],[]);
+await respond(ui.requests[0],[candidate()]);
+assert.match(ui.nodes.get('candidateBody').innerHTML,/No open entries match/,'Stale account response overwrote current results');
+ui.key('Enter');
+assert.equal(ui.requests.length,2);
+
+ui=boot('29');
+await respond(ui.requests[0],[candidate()]);
+ui.nodes.get('searchInput').value='new query';
+ui.nodes.get('searchInput').dispatch('input');
+ui.key('Enter');
+assert.equal(ui.requests.length,1,'Enter submitted a stale selection during search debounce');
+for (const callback of ui.timers.values()) callback();
+assert.equal(ui.requests.length,2);
+await respond(ui.requests[1],[]);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true);
+
+ui=boot('29');
+ui.choose('');
+await respond(ui.requests[0],[candidate()]);
+assert.match(ui.nodes.get('candidateBody').innerHTML,/Choose a customer or supplier/);
+assert.equal(ui.nodes.get('udlignBtn').disabled,true);
+console.log('PASS: account choice, typed search parameters, keyboard confirmation, ambiguous/partial/no matches, duplicate submit guard, save errors and stale responses.');


### PR DESCRIPTION
## What are the changes about?

[SST-773](https://saldi-team.atlassian.net/browse/SST-773): automatic settlement searched across customers and suppliers, allowing suggestions from unrelated accounts. An imported bank line now requires a customer/supplier choice before suggestions load; an already assigned D/K account stays fixed. Search matches the exact account number and type, including when a customer and supplier share a number.

Automatic selection requires a unique highest-scored match with the same signed amount, determined across all results before pagination. Partial payments and credit notes remain manually selectable. Invoice references already used on another account no longer suppress this account's candidates. Normal journal invoice autocomplete retains its existing blank-account lookup and absolute-amount matching.

Saving resolves invoice/account values from the selected open-post ID. It validates the current journal, line snapshot, selected account and unsettled open post inside a transaction. Stale, posted, missing, mismatched or blank-reference selections return a failure; the browser advances only after confirmed JSON success. Repeated Enter and stale search responses are guarded.

Files: `finans/autoudlign.php`, `finans/kassekladde_includes/invoiceSearch.php`, new `autoSettlement.php`, and two regression runners in `tests/`.

## Validation

- PHP lint and diff checks passed; independent review found no remaining blocking issues.
- `php tests/test_auto_settlement.php`: **53 cases** with E_ALL and isolated SQLite fixtures. The initial 39 transaction/account cases also passed independently on PostgreSQL 16, including actual row locking and rollback.
- `node tests/test_auto_settlement_ui.mjs`: actual embedded page script exercised for account choice, keyboard confirmation, partial/tied/no matches, direction, pagination, stale responses, duplicate submissions and failed saves.
- Full authenticated browser/PostgreSQL checks passed on a disposable local tenant: account required; same-number D/K isolation; preassigned account fixed; successful invoice assignment; partial amount unchanged; ties unselected; stale and mismatched submissions return 409 without advancing; posted journals rejected; blank references excluded and rejected.
- A 51-way tie with 49 already-used invoices left one visible row on each page; neither was auto-selected. Opposite-sign credit was not auto-selected. A deliberately narrowed exact match saved successfully. Normal invoice lookup with a type and blank account still returned results.

## Manual regression before deployment

1. Open automatic settlement for an imported bank line, choose the intended customer/supplier and compare results against another account sharing an invoice number. Repeat with a D/K account already assigned on either side.
2. Check exact, partial, opposite-sign, ambiguous, no-match and multi-page results. Confirm keyboard/manual selection preserves amount and existing bank/account values.
3. Change a line, post the journal or settle the selected open post in another session before saving; verify rejection without advancing. Repeat Enter during a save.
4. Use ordinary journal invoice autocomplete with and without an account number to check invoice-to-account fill still works.

Local verification is complete. Customer deployment and verification on the affected installation remain outstanding; this PR does not resolve the support ticket automatically.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that I am not linking to new external resources that could compromise stability
- [ ] I have read and understood the developer guidelines
