### PR TITLE
SST-783: Return purchase-tab orders to Indkøb

### DIFF
--- a/lager/lister/indkøb.php
+++ b/lager/lister/indkøb.php
@@ -24,6 +24,7 @@
 // ----------------------------------------------------------------------
 // 17042024 MMK - Added suport for reloading page, and keeping current URI, DELETED old system that didnt work
 // 17-10-2024 PBLM - Added link to booking
+// 20260909 CDX/LH SST-783: Return orders opened from Indkøb to the purchase tab.
 
 @session_start();
 $s_id = session_id();
@@ -251,7 +252,7 @@ function renderColumn($value, $row, $column, $type, $idField, $orderField, $amou
             $id = $idList[$index];
             $antal = $antalList[$index];
             $date = $dateList[$index];
-            $url = "../../$type/ordre.php?id=$id&returside=../lager/lister/ordrestatus.php";
+            $url = "../../$type/ordre.php?id=$id&returside=../lager/lister/indkøb.php";
             $details .= "<tr><td><a href='$url'>$ordrenr</a></td><td>".dkdecimal($antal)."</td><td colspan=2>".dkdato($date)."</td></tr>";
         }
         $details .= '</tbody></table>';


### PR DESCRIPTION
## What are the changes about?
SST-783: Closing an order opened from Lager → Varer → Indkøb returns to Ordrevisning because the generated link carries that page as `returside`. Point the link back to Indkøb.

https://saldi-team.atlassian.net/browse/SST-783

## Local verification — passed for the reported supplier-order flow, 9 September 2026

Verified real browser clicks against an isolated MEDSHOP dataset clone with PHP 8.3/PostgreSQL 16.

- Before/after comparison: a supplier order opened from Indkøb returned to Ordrevisning on baseline and returns to Indkøb with this patch, in both S and T layouts.
- Supplier orders opened from Ordrevisning still return there.
- Debtor-order links also return to their originating tab in the S layout. Generated links retain their order IDs and order type.
- PHP lint, whitespace checks and isolated E_ALL execution of `renderColumn()` passed.

Existing limitation: T-layout debtor orders ignore `returside` because `includes/ordrefunc.php::sidehoved()` hard-codes their close link to the debtor order list. Browser comparison confirmed the same behavior before and after this patch. It is outside the reported supplier-order defect; this PR does not claim to fix it.

Regression surface: `lager/lister/indkøb.php::renderColumn()` → debtor/supplier order page → close navigation. No production deployment performed. Customer screenshots remain local.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that I am not linking to new external styles or scripts.
- [ ] I have read and understood the externally linked developer guidelines.

Repository `doc/ai/MEMORY.md` and linked conventions were followed. No wiki change is needed for this bug fix.
