### PR TITLE
SST-759: Explain rejected recipient characters and offer explicit ASC…

### DIFF
--- a/debitor/formularprint.php
+++ b/debitor/formularprint.php
@@ -31,6 +31,7 @@
 // 20260102 LOE Added department support for background files
 // 20260309 PHR Fixed error in $returside after printing
 // 20260309 PHR Fixed another error in $returside after printing
+// 20260909 Sawaneh SST-759: POST email_fix_from applies the recipient suggestion from send_mails() after explicit acceptance
 
 
 session_start();
@@ -88,6 +89,26 @@ function find_background_file($background, $file_type, $department) {
     }
 
     return null;
+}
+// 20260909 Sawaneh SST-759: the user accepted the suggested recipient correction shown by
+// send_mails(); the suggestion is re-derived server-side from the rejected address.
+if (isset($_POST['email_fix_from']) && isset($_POST['id'])) {
+    $id = (int)$_POST['id'];
+    $formular = (int)if_isset($_POST['formular']);
+    if ($rettigheder && substr($rettigheder, 5, 1) < '1') {
+        print tekstboks(findtekst('5221|Du har ikke rettigheder til at ændre ordrens e-mailadresse', $sprog_id));
+        exit;
+    }
+    include_once(__DIR__ . "/../includes/formFuncIncludes/emailLookalike.php");
+    $newEmail = emailLookalikeApply($id, $_POST['email_fix_from']);
+    if ($newEmail === '') {
+        print "<script type='text/javascript'>alert(" . json_encode(findtekst('5216|Ordrens e-mailadresse er ændret siden - kontrollér og send igen', $sprog_id), JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG) . ");</script>";
+        print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?id=$id\">";
+        exit;
+    }
+    print findtekst('5220|E-mailadressen på ordren er rettet til', $sprog_id) . " " . htmlspecialchars($newEmail, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "<br>";
+    print "<meta http-equiv=\"refresh\" content=\"1;URL=formularprint.php?id=$id&formular=$formular&udskriv_til=email\">";
+    exit;
 }
 //check Post for returside
 $returside = if_isset($_POST['returside']);

--- a/importfiler/tekster.csv
+++ b/importfiler/tekster.csv
@@ -5096,3 +5096,15 @@
 5149	Brugernavnet må højst være 80 tegn	The username may be at most 80 characters	Brukernavnet kan høyst være 80 tegn
 5150	Regnskabsnavnet må højst være 60 tegn	The account name may be at most 60 characters	Regnskapsnavnet kan høyst være 60 tegn
 
+5210	Ugyldig e-mailadresse	Invalid e-mail address	Ugyldig e-postadresse
+5211	Ugyldigt tegn	Invalid character	Ugyldig tegn
+5212	position	position	posisjon
+5213	Foreslået rettelse	Suggested correction	Foreslått rettelse
+5214	Brug den foreslåede adresse og send igen	Use the suggested address and send again	Bruk den foreslåtte adressen og send på nytt
+5215	Ret adressen manuelt på ordren eller debitorkortet	Correct the address manually on the order or the debtor card	Rett adressen manuelt på ordren eller debitorkortet
+5216	Ordrens e-mailadresse er ændret siden - kontrollér og send igen	The order's e-mail address has changed since - check and send again	Ordrens e-postadresse er endret siden - kontroller og send på nytt
+5217	Ukendt tegn	Unknown character	Ukjent tegn
+5218	erstattes med	is replaced by	erstattes med
+5219	fjernes	is removed	fjernes
+5220	E-mailadressen på ordren er rettet til	The e-mail address on the order was changed to	E-postadressen på ordren er rettet til
+5221	Du har ikke rettigheder til at ændre ordrens e-mailadresse	You do not have permission to change the order's e-mail address	Du har ikke rettigheter til å endre ordrens e-postadresse

--- a/includes/formFuncIncludes/emailLookalike.php
+++ b/includes/formFuncIncludes/emailLookalike.php
@@ -25,6 +25,8 @@
 // 20260909 Sawaneh SST-759: Explain why a recipient address is rejected (character,
 //                  code point, position), suggest the ASCII equivalent for known
 //                  lookalikes and let the user apply it explicitly on the order.
+// 20260910 Sawaneh SST-759: Apply only when the stored recipient is unchanged since it was
+//                  shown (conditional update + re-read), per CodeRabbit review on PR #583.
 
 if (!function_exists('emailLookalikeTable')) {
 	/**
@@ -244,6 +246,42 @@ if (!function_exists('emailLookalikeIssueText')) {
 	}
 }
 
+if (!function_exists('emailLookalikeOrderEmail')) {
+	/**
+	 * The raw recipient value stored on an order.
+	 *
+	 * @param int $ordre_id
+	 * @return string '' when the order does not exist or has no recipient
+	 */
+	function emailLookalikeOrderEmail($ordre_id) {
+		$ordre_id = (int)$ordre_id;
+		if ($ordre_id <= 0) {
+			return '';
+		}
+		$r = db_fetch_array(db_select("select email from ordrer where id = '$ordre_id'", __FILE__ . " linje " . __LINE__));
+		if (!$r || $r['email'] === null) {
+			return '';
+		}
+		return $r['email'];
+	}
+}
+
+if (!function_exists('emailLookalikeSplit')) {
+	/**
+	 * Splits a stored recipient list the same way send_mails() does.
+	 *
+	 * @param string $email
+	 * @return string[]
+	 */
+	function emailLookalikeSplit($email) {
+		if ($email === '') {
+			return [];
+		}
+		$parts = explode(';', str_replace([' ', ','], ['', ';'], emailLookalikeUtf8($email)));
+		return array_values(array_filter($parts, 'strlen'));
+	}
+}
+
 if (!function_exists('emailLookalikeOrderParts')) {
 	/**
 	 * The recipient list stored on an order, split the same way send_mails() splits it.
@@ -252,16 +290,7 @@ if (!function_exists('emailLookalikeOrderParts')) {
 	 * @return string[]
 	 */
 	function emailLookalikeOrderParts($ordre_id) {
-		$ordre_id = (int)$ordre_id;
-		if ($ordre_id <= 0) {
-			return [];
-		}
-		$r = db_fetch_array(db_select("select email from ordrer where id = '$ordre_id'", __FILE__ . " linje " . __LINE__));
-		if (!$r || $r['email'] === null || $r['email'] === '') {
-			return [];
-		}
-		$parts = explode(';', str_replace([' ', ','], ['', ';'], emailLookalikeUtf8($r['email'])));
-		return array_values(array_filter($parts, 'strlen'));
+		return emailLookalikeSplit(emailLookalikeOrderEmail($ordre_id));
 	}
 }
 
@@ -272,12 +301,14 @@ if (!function_exists('emailLookalikeApply')) {
 	 *
 	 * @param int $ordre_id
 	 * @param string $from The rejected address exactly as it was shown to the user
-	 * @return string The new recipient list, or '' when the order no longer holds $from or it is not fixable
+	 * @return string The new recipient list, or '' when the order no longer holds $from, it is not fixable,
+	 *                or the order was saved by someone else between the read and the write
 	 */
 	function emailLookalikeApply($ordre_id, $from) {
 		$ordre_id = (int)$ordre_id;
 		$from = emailLookalikeUtf8($from);
-		$parts = emailLookalikeOrderParts($ordre_id);
+		$stored = emailLookalikeOrderEmail($ordre_id);
+		$parts = emailLookalikeSplit($stored);
 		$index = array_search($from, $parts, true);
 		if ($index === false) {
 			return '';
@@ -288,7 +319,12 @@ if (!function_exists('emailLookalikeApply')) {
 		}
 		$parts[$index] = $analysis['suggested'];
 		$newEmail = implode(';', $parts);
-		db_modify("update ordrer set email = '" . db_escape_string($newEmail) . "' where id = '$ordre_id'", __FILE__ . " linje " . __LINE__);
+		$qtxt = "update ordrer set email = '" . db_escape_string($newEmail) . "' where id = '$ordre_id'"
+			. " and email = '" . db_escape_string($stored) . "'";
+		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+		if (emailLookalikeOrderEmail($ordre_id) !== $newEmail) {
+			return '';
+		}
 		return $newEmail;
 	}
 }

--- a/includes/formFuncIncludes/emailLookalike.php
+++ b/includes/formFuncIncludes/emailLookalike.php
@@ -1,0 +1,355 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- includes/formFuncIncludes/emailLookalike.php --- patch 5.0.0 --- 2026-09-09 ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+//
+// Copyright (c) 2003-2026 Saldi.dk ApS
+// ----------------------------------------------------------------------
+// 20260909 Sawaneh SST-759: Explain why a recipient address is rejected (character,
+//                  code point, position), suggest the ASCII equivalent for known
+//                  lookalikes and let the user apply it explicitly on the order.
+
+if (!function_exists('emailLookalikeTable')) {
+	/**
+	 * Known non-ASCII characters that are pasted into addresses by mistake.
+	 *
+	 * @return array<int, array{0: string, 1: string}> codepoint => [ASCII replacement ('' = remove), Unicode name]
+	 */
+	function emailLookalikeTable() {
+		static $table = null;
+		if ($table !== null) {
+			return $table;
+		}
+		$table = [
+			0x0009 => ['', 'CHARACTER TABULATION'],
+			0x000A => ['', 'LINE FEED'],
+			0x000D => ['', 'CARRIAGE RETURN'],
+			0x00A0 => ['', 'NO-BREAK SPACE'],
+			0x00AD => ['', 'SOFT HYPHEN'],
+			0x061C => ['', 'ARABIC LETTER MARK'],
+			0x1680 => ['', 'OGHAM SPACE MARK'],
+			0x180E => ['', 'MONGOLIAN VOWEL SEPARATOR'],
+			0x2000 => ['', 'EN QUAD'],
+			0x2001 => ['', 'EM QUAD'],
+			0x2002 => ['', 'EN SPACE'],
+			0x2003 => ['', 'EM SPACE'],
+			0x2004 => ['', 'THREE-PER-EM SPACE'],
+			0x2005 => ['', 'FOUR-PER-EM SPACE'],
+			0x2006 => ['', 'SIX-PER-EM SPACE'],
+			0x2007 => ['', 'FIGURE SPACE'],
+			0x2008 => ['', 'PUNCTUATION SPACE'],
+			0x2009 => ['', 'THIN SPACE'],
+			0x200A => ['', 'HAIR SPACE'],
+			0x200B => ['', 'ZERO WIDTH SPACE'],
+			0x200C => ['', 'ZERO WIDTH NON-JOINER'],
+			0x200D => ['', 'ZERO WIDTH JOINER'],
+			0x200E => ['', 'LEFT-TO-RIGHT MARK'],
+			0x200F => ['', 'RIGHT-TO-LEFT MARK'],
+			0x2010 => ['-', 'HYPHEN'],
+			0x2011 => ['-', 'NON-BREAKING HYPHEN'],
+			0x2012 => ['-', 'FIGURE DASH'],
+			0x2013 => ['-', 'EN DASH'],
+			0x2014 => ['-', 'EM DASH'],
+			0x2015 => ['-', 'HORIZONTAL BAR'],
+			0x2024 => ['.', 'ONE DOT LEADER'],
+			0x2028 => ['', 'LINE SEPARATOR'],
+			0x2029 => ['', 'PARAGRAPH SEPARATOR'],
+			0x202A => ['', 'LEFT-TO-RIGHT EMBEDDING'],
+			0x202B => ['', 'RIGHT-TO-LEFT EMBEDDING'],
+			0x202C => ['', 'POP DIRECTIONAL FORMATTING'],
+			0x202D => ['', 'LEFT-TO-RIGHT OVERRIDE'],
+			0x202E => ['', 'RIGHT-TO-LEFT OVERRIDE'],
+			0x202F => ['', 'NARROW NO-BREAK SPACE'],
+			0x2043 => ['-', 'HYPHEN BULLET'],
+			0x205F => ['', 'MEDIUM MATHEMATICAL SPACE'],
+			0x2060 => ['', 'WORD JOINER'],
+			0x2212 => ['-', 'MINUS SIGN'],
+			0x3000 => ['', 'IDEOGRAPHIC SPACE'],
+			0x3002 => ['.', 'IDEOGRAPHIC FULL STOP'],
+			0xFE63 => ['-', 'SMALL HYPHEN-MINUS'],
+			0xFE6B => ['@', 'SMALL COMMERCIAL AT'],
+			0xFEFF => ['', 'ZERO WIDTH NO-BREAK SPACE'],
+			0xFF0D => ['-', 'FULLWIDTH HYPHEN-MINUS'],
+			0xFF0E => ['.', 'FULLWIDTH FULL STOP'],
+			0xFF20 => ['@', 'FULLWIDTH COMMERCIAL AT'],
+			0xFF3F => ['_', 'FULLWIDTH LOW LINE'],
+			0xFF61 => ['.', 'HALFWIDTH IDEOGRAPHIC FULL STOP'],
+			0x0391 => ['A', 'GREEK CAPITAL LETTER ALPHA'],
+			0x0392 => ['B', 'GREEK CAPITAL LETTER BETA'],
+			0x0395 => ['E', 'GREEK CAPITAL LETTER EPSILON'],
+			0x0396 => ['Z', 'GREEK CAPITAL LETTER ZETA'],
+			0x0397 => ['H', 'GREEK CAPITAL LETTER ETA'],
+			0x0399 => ['I', 'GREEK CAPITAL LETTER IOTA'],
+			0x039A => ['K', 'GREEK CAPITAL LETTER KAPPA'],
+			0x039C => ['M', 'GREEK CAPITAL LETTER MU'],
+			0x039D => ['N', 'GREEK CAPITAL LETTER NU'],
+			0x039F => ['O', 'GREEK CAPITAL LETTER OMICRON'],
+			0x03A1 => ['P', 'GREEK CAPITAL LETTER RHO'],
+			0x03A4 => ['T', 'GREEK CAPITAL LETTER TAU'],
+			0x03A5 => ['Y', 'GREEK CAPITAL LETTER UPSILON'],
+			0x03A7 => ['X', 'GREEK CAPITAL LETTER CHI'],
+			0x03BF => ['o', 'GREEK SMALL LETTER OMICRON'],
+			0x0410 => ['A', 'CYRILLIC CAPITAL LETTER A'],
+			0x0412 => ['B', 'CYRILLIC CAPITAL LETTER VE'],
+			0x0415 => ['E', 'CYRILLIC CAPITAL LETTER IE'],
+			0x041A => ['K', 'CYRILLIC CAPITAL LETTER KA'],
+			0x041C => ['M', 'CYRILLIC CAPITAL LETTER EM'],
+			0x041D => ['H', 'CYRILLIC CAPITAL LETTER EN'],
+			0x041E => ['O', 'CYRILLIC CAPITAL LETTER O'],
+			0x0420 => ['P', 'CYRILLIC CAPITAL LETTER ER'],
+			0x0421 => ['C', 'CYRILLIC CAPITAL LETTER ES'],
+			0x0422 => ['T', 'CYRILLIC CAPITAL LETTER TE'],
+			0x0425 => ['X', 'CYRILLIC CAPITAL LETTER HA'],
+			0x0430 => ['a', 'CYRILLIC SMALL LETTER A'],
+			0x0435 => ['e', 'CYRILLIC SMALL LETTER IE'],
+			0x043E => ['o', 'CYRILLIC SMALL LETTER O'],
+			0x0440 => ['p', 'CYRILLIC SMALL LETTER ER'],
+			0x0441 => ['c', 'CYRILLIC SMALL LETTER ES'],
+			0x0443 => ['y', 'CYRILLIC SMALL LETTER U'],
+			0x0445 => ['x', 'CYRILLIC SMALL LETTER HA'],
+			0x0455 => ['s', 'CYRILLIC SMALL LETTER DZE'],
+			0x0456 => ['i', 'CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I'],
+			0x0458 => ['j', 'CYRILLIC SMALL LETTER JE'],
+			0x04BB => ['h', 'CYRILLIC SMALL LETTER SHHA'],
+			0x0501 => ['d', 'CYRILLIC SMALL LETTER KOMI DE'],
+		];
+		return $table;
+	}
+}
+
+if (!function_exists('emailLookalikeUtf8')) {
+	/**
+	 * Returns the address as valid UTF-8 so it can be walked character by character.
+	 *
+	 * @param string $email
+	 * @return string
+	 */
+	function emailLookalikeUtf8($email) {
+		if (mb_check_encoding($email, 'UTF-8')) {
+			return $email;
+		}
+		return mb_convert_encoding($email, 'UTF-8', 'Windows-1252');
+	}
+}
+
+if (!function_exists('emailLookalikeAnalyse')) {
+	/**
+	 * Finds every non-ASCII character in an address and the ASCII address it would become.
+	 *
+	 * @param string $email
+	 * @return array{
+	 *   input: string,
+	 *   suggested: string,
+	 *   fixable: bool,
+	 *   issues: array<int, array{
+	 *     position: int,
+	 *     char: string,
+	 *     codepoint: string,
+	 *     name: string,
+	 *     replacement: string,
+	 *     known: bool
+	 *   }>
+	 * }
+	 */
+	function emailLookalikeAnalyse($email) {
+		$email = emailLookalikeUtf8($email);
+		$table = emailLookalikeTable();
+		$issues = [];
+		$suggested = '';
+		$allKnown = true;
+		$chars = preg_split('//u', $email, -1, PREG_SPLIT_NO_EMPTY);
+		foreach ($chars as $position => $char) {
+			$cp = mb_ord($char, 'UTF-8');
+			if ($cp >= 0x20 && $cp < 0x7F) {
+				$suggested .= $char;
+				continue;
+			}
+			if (isset($table[$cp])) {
+				$replacement = $table[$cp][0];
+				$name = $table[$cp][1];
+				$known = true;
+			} elseif ($cp >= 0xFF01 && $cp <= 0xFF5E) {
+				$replacement = chr($cp - 0xFEE0);
+				$name = 'FULLWIDTH ' . strtoupper($replacement);
+				$known = true;
+			} else {
+				$replacement = $char;
+				$name = '';
+				$known = false;
+				$allKnown = false;
+			}
+			$suggested .= $replacement;
+			$issues[] = [
+				'position' => $position + 1,
+				'char' => $char,
+				'codepoint' => sprintf('U+%04X', $cp),
+				'name' => $name,
+				'replacement' => $replacement,
+				'known' => $known,
+			];
+		}
+		$fixable = count($issues) > 0 && $allKnown && $suggested !== $email
+			&& filter_var($suggested, FILTER_VALIDATE_EMAIL) !== false;
+		return [
+			'input' => $email,
+			'suggested' => $suggested,
+			'fixable' => $fixable,
+			'issues' => $issues,
+		];
+	}
+}
+
+if (!function_exists('emailLookalikeIssueText')) {
+	/**
+	 * One plain-text line per offending character, e.g.
+	 * "Ugyldigt tegn '−' (U+2212 MINUS SIGN) position 7 erstattes med '-'".
+	 *
+	 * @param array $analysis Result of emailLookalikeAnalyse()
+	 * @param int $sprog_id
+	 * @return string[]
+	 */
+	function emailLookalikeIssueText($analysis, $sprog_id) {
+		$lines = [];
+		foreach ($analysis['issues'] as $issue) {
+			$name = $issue['name'] !== '' ? $issue['name'] : findtekst('5217|Ukendt tegn', $sprog_id);
+			$line = findtekst('5211|Ugyldigt tegn', $sprog_id) . " '" . $issue['char'] . "' (" . $issue['codepoint'] . " " . $name . ") "
+				. findtekst('5212|position', $sprog_id) . " " . $issue['position'];
+			if ($issue['known']) {
+				if ($issue['replacement'] === '') {
+					$line .= " " . findtekst('5219|fjernes', $sprog_id);
+				} else {
+					$line .= " " . findtekst('5218|erstattes med', $sprog_id) . " '" . $issue['replacement'] . "'";
+				}
+			}
+			$lines[] = $line;
+		}
+		return $lines;
+	}
+}
+
+if (!function_exists('emailLookalikeOrderParts')) {
+	/**
+	 * The recipient list stored on an order, split the same way send_mails() splits it.
+	 *
+	 * @param int $ordre_id
+	 * @return string[]
+	 */
+	function emailLookalikeOrderParts($ordre_id) {
+		$ordre_id = (int)$ordre_id;
+		if ($ordre_id <= 0) {
+			return [];
+		}
+		$r = db_fetch_array(db_select("select email from ordrer where id = '$ordre_id'", __FILE__ . " linje " . __LINE__));
+		if (!$r || $r['email'] === null || $r['email'] === '') {
+			return [];
+		}
+		$parts = explode(';', str_replace([' ', ','], ['', ';'], emailLookalikeUtf8($r['email'])));
+		return array_values(array_filter($parts, 'strlen'));
+	}
+}
+
+if (!function_exists('emailLookalikeApply')) {
+	/**
+	 * Replaces one recipient on an order with its server-derived ASCII suggestion.
+	 * Only the address the user was shown is replaced; anything else on the order is untouched.
+	 *
+	 * @param int $ordre_id
+	 * @param string $from The rejected address exactly as it was shown to the user
+	 * @return string The new recipient list, or '' when the order no longer holds $from or it is not fixable
+	 */
+	function emailLookalikeApply($ordre_id, $from) {
+		$ordre_id = (int)$ordre_id;
+		$from = emailLookalikeUtf8($from);
+		$parts = emailLookalikeOrderParts($ordre_id);
+		$index = array_search($from, $parts, true);
+		if ($index === false) {
+			return '';
+		}
+		$analysis = emailLookalikeAnalyse($from);
+		if (!$analysis['fixable']) {
+			return '';
+		}
+		$parts[$index] = $analysis['suggested'];
+		$newEmail = implode(';', $parts);
+		db_modify("update ordrer set email = '" . db_escape_string($newEmail) . "' where id = '$ordre_id'", __FILE__ . " linje " . __LINE__);
+		return $newEmail;
+	}
+}
+
+if (!function_exists('emailRecipientRejected')) {
+	/**
+	 * Feedback for a recipient that failed FILTER_VALIDATE_EMAIL. Shows which character is
+	 * wrong and, when the address sits on the order and can be fixed, an explicit
+	 * "use suggested address" form. The form case keeps the page open (exit) so the
+	 * user can decide; every other case returns the message like before.
+	 *
+	 * @param string $address The rejected address
+	 * @param int $ordre_id
+	 * @param int $sprog_id
+	 * @param int $mailantal Number of mails in the current batch
+	 * @return string Plain-text error message for the caller
+	 */
+	function emailRecipientRejected($address, $ordre_id, $sprog_id, $mailantal) {
+		global $formular;
+		$ordre_id = (int)$ordre_id;
+		$analysis = emailLookalikeAnalyse($address);
+		$lines = emailLookalikeIssueText($analysis, $sprog_id);
+		$message = findtekst('5210|Ugyldig e-mailadresse', $sprog_id) . ": " . $analysis['input'];
+		if ($lines) {
+			$message .= "\n" . implode("\n", $lines);
+		}
+		if ($analysis['fixable']) {
+			$message .= "\n" . findtekst('5213|Foreslået rettelse', $sprog_id) . ": " . $analysis['suggested'];
+		}
+		echo "<script type='text/javascript'>alert(" . json_encode($message, JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG) . ");</script>\n";
+
+		$debitorPopup = strpos(isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : '', '/debitor/formularprint.php') !== false;
+		$onOrder = $debitorPopup && $analysis['fixable'] && $ordre_id > 0 && (int)$mailantal <= 1
+			&& in_array($analysis['input'], emailLookalikeOrderParts($ordre_id), true);
+		if (!$onOrder) {
+			return $message;
+		}
+
+		$h = function ($s) {
+			return htmlspecialchars($s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		};
+		$marked = '';
+		$chars = preg_split('//u', $analysis['input'], -1, PREG_SPLIT_NO_EMPTY);
+		foreach ($chars as $char) {
+			$marked .= (ord($char) < 0x80) ? $h($char) : "<mark>" . $h($char) . "</mark>";
+		}
+		echo "<div style=\"padding:10px;font-family:sans-serif\">\n";
+		echo "<b>" . $h(findtekst('5210|Ugyldig e-mailadresse', $sprog_id)) . ":</b> <code>$marked</code><br>\n";
+		foreach ($lines as $line) {
+			echo $h($line) . "<br>\n";
+		}
+		echo "<br><b>" . $h(findtekst('5213|Foreslået rettelse', $sprog_id)) . ":</b> <code>" . $h($analysis['suggested']) . "</code><br><br>\n";
+		echo "<form method=\"post\" action=\"formularprint.php\" accept-charset=\"UTF-8\">\n";
+		echo "<input type=\"hidden\" name=\"id\" value=\"$ordre_id\">\n";
+		echo "<input type=\"hidden\" name=\"formular\" value=\"" . (int)$formular . "\">\n";
+		echo "<input type=\"hidden\" name=\"email_fix_from\" value=\"" . $h($analysis['input']) . "\">\n";
+		echo "<input type=\"submit\" value=\"" . $h(findtekst('5214|Brug den foreslåede adresse og send igen', $sprog_id)) . "\">\n";
+		echo " <input type=\"button\" value=\"" . $h(findtekst('2172|Luk', $sprog_id)) . "\" onclick=\"document.location.href='ordre.php?id=$ordre_id'\">\n";
+		echo "</form>\n";
+		echo "<small>" . $h(findtekst('5215|Ret adressen manuelt på ordren eller debitorkortet', $sprog_id)) . "</small>\n";
+		echo "</div>\n";
+		exit;
+	}
+}

--- a/includes/formFuncIncludes/oldSendMail.php
+++ b/includes/formFuncIncludes/oldSendMail.php
@@ -30,6 +30,8 @@
 // 20260818 CL/LH Disabled shared-key payment-link minting in mail templates.
 // 20260819 Sawaneh Echo 'Mail sent to' confirmation like sendMail.php does, so
 //                  callers show it regardless of which mailer is loaded.
+// 20260909 Sawaneh SST-759: Rejected recipient feedback names the offending character
+//                  and offers the ASCII suggestion via emailLookalike.php.
 	
 /*if(!class_exists('phpmailer')) {
 	ini_set("include_path", ".:../phpmailer");
@@ -56,8 +58,8 @@ print "<!--function send_mails start-->";
 	else $emails[0]=$email;
 	for ($x=0;$x<count($emails);$x++) {
 		if (!filter_var($emails[$x], FILTER_VALIDATE_EMAIL)) { #20200122
-			alert("Invalid email format in $emails[$x]");
-			return ("Invalid email format in $emails[$x]");
+			include_once(__DIR__ . "/emailLookalike.php");
+			return emailRecipientRejected($emails[$x], $ordre_id, $sprog_id, $mailantal);
 		}
 	}
 	$bilag=$brugermail=$mail_bilag=NULL;

--- a/includes/formFuncIncludes/sendMail.php
+++ b/includes/formFuncIncludes/sendMail.php
@@ -32,6 +32,8 @@
 // 20260818 CL/LH Preserved plain-text mail bodies when anchor flattening fails.
 // 20260819 Sawaneh 'Mail sent to' confirmation translated via findtekst and
 //                  recipient escaped before output.
+// 20260909 Sawaneh SST-759: Rejected recipient feedback names the offending character
+//                  and offers the ASCII suggestion via emailLookalike.php.
 
 function send_mails($ordre_id,$filnavn,$email,$mailsprog,$form_nr,$subjekt,$mailtext,$mailbilag,$mailnr) {
 print "<!--function send_mails start-->";
@@ -53,8 +55,8 @@ print "<!--function send_mails start-->";
 	else $emails[0]=$email;
 	for ($x=0;$x<count($emails);$x++) {
 		if (!filter_var($emails[$x], FILTER_VALIDATE_EMAIL)) { #20200122
-			alert("Invalid email format in $emails[$x]");
-			return ("Invalid email format in $emails[$x]");
+			include_once(__DIR__ . "/emailLookalike.php");
+			return emailRecipientRejected($emails[$x], $ordre_id, $sprog_id, $mailantal);
 		}
 	}
 	$bilag=$brugermail=$mail_bilag=NULL;

--- a/tests/test_email_lookalike.php
+++ b/tests/test_email_lookalike.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Email lookalike analyser - unit test (no database needed)
+ *
+ * CLI: php tests/test_email_lookalike.php
+ */
+
+include(__DIR__ . "/../includes/formFuncIncludes/emailLookalike.php");
+
+$passed = 0;
+$failed = 0;
+
+function check($condition, $msg) {
+    global $passed, $failed;
+    if ($condition) {
+        $passed++;
+        echo "  PASS  $msg\n";
+    } else {
+        $failed++;
+        echo "  FAIL  $msg\n";
+    }
+}
+
+echo "SST-759 customer case: U+2212 in domain\n";
+$a = emailLookalikeAnalyse("oh@agf\u{2212}as.dk");
+check(count($a['issues']) === 1, 'exactly one issue found');
+check($a['issues'][0]['codepoint'] === 'U+2212', 'code point is U+2212');
+check($a['issues'][0]['name'] === 'MINUS SIGN', 'name is MINUS SIGN');
+check($a['issues'][0]['position'] === 7, 'position is 7 (1-based, character count)');
+check($a['issues'][0]['replacement'] === '-', 'replacement is ASCII hyphen');
+check($a['suggested'] === 'oh@agf-as.dk', 'suggested address is oh@agf-as.dk');
+check($a['fixable'] === true, 'marked fixable');
+
+echo "Invisible characters\n";
+$a = emailLookalikeAnalyse("info\u{200B}@saldi.dk\u{00A0}");
+check(count($a['issues']) === 2, 'zero-width space and NBSP both reported');
+check($a['issues'][0]['name'] === 'ZERO WIDTH SPACE' && $a['issues'][0]['replacement'] === '', 'ZWSP is removed');
+check($a['issues'][1]['name'] === 'NO-BREAK SPACE' && $a['issues'][1]['position'] === 15, 'NBSP reported at its position');
+check($a['suggested'] === 'info@saldi.dk' && $a['fixable'], 'suggestion strips both');
+
+echo "Dashes, fullwidth and homoglyphs\n";
+$a = emailLookalikeAnalyse("a\u{2013}b@x\u{FF0E}dk");
+check($a['suggested'] === 'a-b@x.dk' && $a['fixable'], 'en dash and fullwidth full stop mapped');
+$a = emailLookalikeAnalyse("\u{FF41}bc@x.dk");
+check($a['issues'][0]['name'] === 'FULLWIDTH A' && $a['suggested'] === 'abc@x.dk', 'fullwidth letters mapped generically');
+$a = emailLookalikeAnalyse("\u{0441}ontact@x.dk");
+check($a['issues'][0]['name'] === 'CYRILLIC SMALL LETTER ES' && $a['suggested'] === 'contact@x.dk', 'Cyrillic es -> c');
+
+echo "Unknown non-ASCII stays unfixable\n";
+$a = emailLookalikeAnalyse("bl\u{00E5}b\u{00E6}r@x.dk");
+check(count($a['issues']) === 2 && $a['issues'][0]['known'] === false, 'æ/å reported as unknown');
+check($a['issues'][0]['name'] === '' && $a['issues'][0]['codepoint'] === 'U+00E5', 'unknown char still has code point');
+check($a['fixable'] === false, 'not fixable');
+
+echo "Valid and plainly invalid addresses\n";
+$a = emailLookalikeAnalyse('normal.user+tag@example.co.uk');
+check($a['issues'] === [] && $a['fixable'] === false, 'valid ASCII address has no issues and no suggestion');
+$a = emailLookalikeAnalyse('foo@bar');
+check($a['issues'] === [] && $a['fixable'] === false, 'ASCII-only invalid address gets no suggestion');
+$a = emailLookalikeAnalyse("@\u{2212}x.dk");
+check($a['fixable'] === false, 'suggestion that is still invalid is not offered');
+
+echo "Latin-1 input is analysed as text, not as garbage bytes\n";
+$a = emailLookalikeAnalyse("o\xF8@x.dk");
+check($a['issues'][0]['codepoint'] === 'U+00F8', 'ISO-8859-1 ø converted before analysis');
+
+echo "\nPassed: $passed  Failed: $failed\n";
+exit($failed ? 1 : 0);


### PR DESCRIPTION
…II correction

## What are the changes about?
Provide a brief explanation of the changes you have made
SST-759: Explain rejected recipient characters and offer explicit ASCII correction

Background: MEDSHOP (saldi_390) could not mail invoice 240666 because the order's
e-mail held U+2212 MINUS SIGN instead of an ASCII hyphen. The old rejection only
said "Invalid email format in ...", and the address looked correct on screen.

Changes
- New includes/formFuncIncludes/emailLookalike.php: analyses a rejected address
  character by character and reports code point, Unicode name, 1-based position
  and the ASCII replacement for known lookalikes (dashes, invisible whitespace,
  fullwidth forms, Greek/Cyrillic homoglyphs). Unknown non-ASCII characters are
  still identified by code point but no suggestion is made.
- sendMail.php and oldSendMail.php: rejection goes through the shared feedback.
  The alert is JSON-encoded and page output is HTML-escaped, which also closes
  the unescaped alert("... $emails[$x]") in the old code.
- Explicit acceptance only: in the debitor print popup, single-mail flow, when
  the rejected address is literally on ordrer.email, the page stays open with the
  offending character marked, the suggestion, and an accept button. Batch flows
  (reminders, statements) and kreditor keep the old alert-and-return behaviour.
- debitor/formularprint.php: POST email_fix_from handler checks debitor rights,
  re-derives the suggestion server-side from the rejected address (client cannot
  supply an arbitrary address), verifies the order still holds that exact
  address, updates only that recipient, then redirects to the e-mail print URL.
- Texts 5210-5221 in tekster.csv. No migration needed.
- tests/test_email_lookalike.php: 21 CLI assertions, no DB required.

Manual tests on ssl12 (saldi_34, order 3342)
- dintest@agf−as.dk (U+2212): alert names MINUS SIGN, U+2212, position 12,
  suggests dintest@agf-as.dk; popup stays open with character highlighted.
- Accept button: "changed to dintest@agf-as.dk", order e-mail field now shows
  ASCII hyphen. ssl12 has no outbound mail, so delivery itself was not observed.
- php tests/test_email_lookalike.php passes locally and on the server.

Incident status
- Manual UPDATE on saldi_390 order 162742 applied 2026-09-09 (1 row affected).
- Customer confirmation of a successful resend still pending.

Not covered / out of scope
- Silent bulk cleanup, IDN/international addresses, unsolicited customer mail.


## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invalid email addresses now identify problematic characters and provide suggested ASCII replacements.
  * Users can review and apply suggested corrections when printing emails.
  * Corrections are validated for permissions and stale-address conflicts before being applied.

* **Bug Fixes**
  * Improved handling of email addresses containing lookalike, invisible, or non-ASCII characters.
  * Added support for recognizing legacy character encodings during validation.

* **Tests**
  * Added coverage for character detection, address suggestions, encoding conversion, and invalid addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->