### PR TITLE
SST-776: fix cross-tenant pool document access and filename-collision…

### DIFF
--- a/includes/docsIncludes/FileReservation.php
+++ b/includes/docsIncludes/FileReservation.php
@@ -1,0 +1,154 @@
+<?php
+// --- includes/docsIncludes/FileReservation.php ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+//
+// Copyright (c) 2003-2026 Saldi.dk ApS
+// ----------------------------------------------------------------------
+// 20260910 CL/NTR Added FileReservation: atomic no-replace reservation of a target filename
+//                  (fopen 'x') with automatic "_N" suffixing, so two concurrent uploads with
+//                  the same base name can never settle on the same path and overwrite each
+//                  other (SST-776 follow-up).
+
+if (!class_exists('FileReservation')) {
+	/**
+	 * Reserves a unique file path inside a directory without a check-then-write race.
+	 *
+	 * The usual pattern - loop over file_exists() until "name_N.ext" is free, then write to
+	 * it - leaves a window between the check and the write in which a concurrent request can
+	 * settle on the same name; whichever writes last silently replaces the other. This class
+	 * closes that window by creating the target path itself with fopen() in 'x' mode, which
+	 * fails atomically when the path already exists, so only one request can ever win a
+	 * given name. The reserved file is an empty placeholder that the caller then overwrites
+	 * in place with move_uploaded_file(), rename(), file_put_contents(), an external
+	 * converter, etc. Never unlink the placeholder before writing - that reopens the race.
+	 *
+	 * Sibling extensions let a caller treat a base name as taken when any related file
+	 * exists, e.g. a "scan.jpg" temp file or a "scan.info" metadata file next to the
+	 * "scan.pdf" being reserved. Only the reserved extension is actually created; siblings
+	 * are protected indirectly because every competing reservation checks them too.
+	 *
+	 * Typical use:
+	 *   $res = FileReservation::reserve($dir, 'scan', 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+	 *   if ($res === null) { ... directory not writable / no free name ... }
+	 *   if (!move_uploaded_file($tmp, $res->path())) {
+	 *       $res->discard(); // nothing was written, drop the empty placeholder
+	 *   }
+	 */
+	final class FileReservation {
+		/** @var string Directory the file lives in, without trailing slash. */
+		private $dir;
+		/** @var string Base name that won the reservation, possibly suffixed ("scan_2"). */
+		private $baseName;
+		/** @var string Extension that was reserved, without leading dot. */
+		private $ext;
+
+		private function __construct(string $dir, string $baseName, string $ext) {
+			$this->dir = $dir;
+			$this->baseName = $baseName;
+			$this->ext = $ext;
+		}
+
+		/**
+		 * Atomically reserves "$dir/$baseName.$ext", or the first free "$baseName{$separator}N.$ext"
+		 * (N = 1, 2, ...) when the base name is already taken by a file with the reserved
+		 * extension or any of the sibling extensions.
+		 *
+		 * @param string   $dir          Existing directory to reserve inside.
+		 * @param string   $baseName     Already-sanitised file name without extension.
+		 * @param string   $ext          Extension to reserve, with or without leading dot.
+		 * @param string[] $siblingExts  Extensions that also count as "name taken". The
+		 *                               reserved extension is always included.
+		 * @param string   $separator    Placed between base name and counter.
+		 * @param int      $maxAttempts  Upper bound on candidate names tried.
+		 * @return self|null Null when the directory is not writable or no candidate name
+		 *                   could be reserved within $maxAttempts.
+		 */
+		public static function reserve(string $dir, string $baseName, string $ext, array $siblingExts = [], string $separator = '_', int $maxAttempts = 10000): ?self {
+			$dir = rtrim($dir, '/');
+			$ext = ltrim($ext, '.');
+			$siblingExts = array_map(function ($e) { return ltrim($e, '.'); }, $siblingExts);
+			if (!in_array($ext, $siblingExts, true)) {
+				$siblingExts[] = $ext;
+			}
+
+			for ($n = 0; $n < $maxAttempts; $n++) {
+				$candidate = $n === 0 ? $baseName : $baseName . $separator . $n;
+				if (self::anyExists($dir, $candidate, $siblingExts)) {
+					continue;
+				}
+				// 'x' = create only; fails if the path appeared between the check and here.
+				$handle = @fopen("$dir/$candidate.$ext", 'x');
+				if ($handle !== false) {
+					fclose($handle);
+					return new self($dir, $candidate, $ext);
+				}
+				if (!is_dir($dir) || !is_writable($dir)) {
+					return null;
+				}
+				// Lost the race for this candidate to a concurrent reservation; try the next one.
+			}
+			return null;
+		}
+
+		/**
+		 * @param string[] $exts
+		 */
+		private static function anyExists(string $dir, string $baseName, array $exts): bool {
+			foreach ($exts as $e) {
+				if (file_exists("$dir/$baseName.$e")) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/** Full path of the reserved (placeholder) file. */
+		public function path(): string {
+			return "$this->dir/$this->baseName.$this->ext";
+		}
+
+		/** Base name that won the reservation, possibly suffixed. */
+		public function baseName(): string {
+			return $this->baseName;
+		}
+
+		/** Reserved extension without leading dot. */
+		public function ext(): string {
+			return $this->ext;
+		}
+
+		/** Directory the reservation was made in, without trailing slash. */
+		public function dir(): string {
+			return $this->dir;
+		}
+
+		/**
+		 * Path of a related file sharing the reserved base name, e.g. the original image
+		 * that gets converted into the reserved PDF, or the ".info" metadata file.
+		 */
+		public function siblingPath(string $ext): string {
+			return "$this->dir/$this->baseName." . ltrim($ext, '.');
+		}
+
+		/**
+		 * Removes the reserved file. Call this when the write into the reservation failed,
+		 * so an empty placeholder is not left behind. Do NOT call it before writing.
+		 */
+		public function discard(): bool {
+			return @unlink($this->path());
+		}
+	}
+}

--- a/includes/docsIncludes/FileReservation.php
+++ b/includes/docsIncludes/FileReservation.php
@@ -37,8 +37,13 @@ if (!class_exists('FileReservation')) {
 	 *
 	 * Sibling extensions let a caller treat a base name as taken when any related file
 	 * exists, e.g. a "scan.jpg" temp file or a "scan.info" metadata file next to the
-	 * "scan.pdf" being reserved. Only the reserved extension is actually created; siblings
-	 * are protected indirectly because every competing reservation checks them too.
+	 * "scan.pdf" being reserved. To make that atomic across callers reserving *different*
+	 * extensions for the same base name, each candidate is first claimed through a hidden
+	 * marker file ".<name>.reserving" (also created with 'x'), the siblings are re-checked
+	 * and the real file created while the marker is held, and the marker is removed again.
+	 * Competing reservations treat an existing marker as "name taken", so "scan.pdf" and
+	 * "scan.jpg" can never be handed out to two concurrent callers. A marker orphaned by a
+	 * crash merely causes that one candidate name to be skipped.
 	 *
 	 * Typical use:
 	 *   $res = FileReservation::reserve($dir, 'scan', 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
@@ -86,21 +91,46 @@ if (!class_exists('FileReservation')) {
 
 			for ($n = 0; $n < $maxAttempts; $n++) {
 				$candidate = $n === 0 ? $baseName : $baseName . $separator . $n;
-				if (self::anyExists($dir, $candidate, $siblingExts)) {
+				$marker = self::markerPath($dir, $candidate);
+				if (file_exists($marker) || self::anyExists($dir, $candidate, $siblingExts)) {
 					continue;
 				}
-				// 'x' = create only; fails if the path appeared between the check and here.
-				$handle = @fopen("$dir/$candidate.$ext", 'x');
+				// Claim the base name itself first ('x' = create only, fails atomically if
+				// it appeared between the check and here), so a concurrent caller reserving
+				// another extension of the same name is bumped instead of slipping through.
+				$markerHandle = @fopen($marker, 'x');
+				if ($markerHandle === false) {
+					if (!is_dir($dir) || !is_writable($dir)) {
+						return null;
+					}
+					continue; // lost the race for this candidate; try the next one
+				}
+				fclose($markerHandle);
+				// Holding the marker serialises creation for this name, so re-checking the
+				// siblings now is authoritative: a competitor that won the marker a moment ago
+				// and already created "$candidate.<otherExt>" is caught here.
+				$handle = self::anyExists($dir, $candidate, $siblingExts)
+					? false
+					: @fopen("$dir/$candidate.$ext", 'x');
 				if ($handle !== false) {
 					fclose($handle);
+				}
+				// The real file (if created) now guards the name; the marker is no longer needed.
+				@unlink($marker);
+				if ($handle !== false) {
 					return new self($dir, $candidate, $ext);
 				}
 				if (!is_dir($dir) || !is_writable($dir)) {
 					return null;
 				}
-				// Lost the race for this candidate to a concurrent reservation; try the next one.
+				// Candidate was taken while we waited for the marker; try the next one.
 			}
 			return null;
+		}
+
+		/** Hidden per-candidate claim file; dot-prefixed so "*.pdf"-style listings never see it. */
+		private static function markerPath(string $dir, string $baseName): string {
+			return "$dir/.$baseName.reserving";
 		}
 
 		/**

--- a/includes/docsIncludes/extractInvoiceHandler.php
+++ b/includes/docsIncludes/extractInvoiceHandler.php
@@ -9,15 +9,25 @@ header('Content-Type: application/json');
 // Start output buffering to capture any unwanted output
 ob_start();
 
+// Start session so the tenant db can be resolved from it below - a POSTed
+// db name must never be trusted directly (it would let a tampered request
+// read/write/delete another tenant's pool documents; see SST-776).
+@session_start();
+$s_id = session_id();
+
 // Include database connection
-include_once("../connect.php");
+include_once(__DIR__ . "/../connect.php");
 include_once(__DIR__ . "/poolAmountNormalizer.php");
 
-// Get database name from POST
-$db = isset($_POST['db']) ? $_POST['db'] : '';
+// Resolve the tenant db from the session's online-table entry, same pattern
+// as includes/_docPoolData.php and includes/online.php - never from $_POST['db'].
+$qtxt = "select db from online where session_id = '" . db_escape_string($s_id) . "' order by logtime desc limit 1";
+$onlineRow = db_fetch_array(db_select($qtxt, __FILE__ . " line " . __LINE__));
+$db = trim($onlineRow['db'] ?? '');
+
 if (empty($db)) {
 	ob_end_clean();
-	echo json_encode(['success' => false, 'error' => 'Database ikke angivet']);
+	echo json_encode(['success' => false, 'error' => 'Session udløbet - log ind igen']);
 	exit;
 }
 
@@ -28,18 +38,14 @@ if (!preg_match('/^[a-zA-Z0-9_]+$/', $db)) {
 	exit;
 }
 
-// Connect to the specific database
-if ($db) {
-	global $sqhost, $squser, $sqpass;
-	// Close previous connection if exists (optional but good practice)
-	// pg_close($connection); // db_connect usually handles new connection, but we just overwrite variable
-	$connection = db_connect($sqhost, $squser, $sqpass, $db, __FILE__ . " line " . __LINE__);
-	
-	if (!$connection) {
-		ob_end_clean();
-		echo json_encode(['success' => false, 'error' => 'Kunne ikke forbinde til database: ' . $db]);
-		exit;
-	}
+// Connect to the session's own database
+global $sqhost, $squser, $sqpass;
+$connection = db_connect($sqhost, $squser, $sqpass, $db, __FILE__ . " line " . __LINE__);
+
+if (!$connection) {
+	ob_end_clean();
+	echo json_encode(['success' => false, 'error' => 'Kunne ikke forbinde til database: ' . $db]);
+	exit;
 }
 
 // Include the extraction API
@@ -134,8 +140,19 @@ if (empty($poolFile)) {
 	exit;
 }
 
-// Get docFolder from POST (same as what docPool.php uses)
-$docFolder = isset($_POST['docFolder']) ? $_POST['docFolder'] : '../bilag';
+// poolFile must be a bare filename - reject any path component so a
+// tampered value can't escape the tenant's own pulje directory (SST-776).
+if ($poolFile !== basename($poolFile) || $poolFile === '.' || $poolFile === '..') {
+	echo json_encode(['success' => false, 'error' => 'Ugyldigt filnavn']);
+	exit;
+}
+
+// Get docFolder from POST, but only accept the same fixed values
+// documents.php itself ever assigns to $docFolder - a POSTed path is not
+// trusted for directory traversal (SST-776).
+$requestedDocFolder = isset($_POST['docFolder']) ? $_POST['docFolder'] : '../bilag';
+$allowedDocFolders = ['../owncloud', '../bilag', '../documents'];
+$docFolder = in_array($requestedDocFolder, $allowedDocFolders, true) ? $requestedDocFolder : '../bilag';
 
 // Build full path to the pool file using the same path structure as docPool.php
 // docFolder is relative to the includes/ directory (e.g., "../bilag")

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -162,8 +162,19 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 			// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 			$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 			$baseName = sanitize_filename($baseName);
+
+			// Dedupe against any pool file already using this base name (e.g. generic
+			// scanner/phone names like "scan.pdf") so an unrelated document's upload can't
+			// silently overwrite it and confuse its metadata (SST-776) - same pattern as
+			// the vendor+date rename dedup further below.
+			$originalBaseName = $baseName;
+			$dedupCounter = 1;
+			while (file_exists("$poolDir/$baseName.pdf") || file_exists("$poolDir/$baseName.jpg") || file_exists("$poolDir/$baseName.jpeg") || file_exists("$poolDir/$baseName.png")) {
+				$baseName = $originalBaseName . '_' . $dedupCounter;
+				$dedupCounter++;
+			}
 			$targetFile = "$poolDir/$baseName.pdf";
-			
+
 			// Try to extract invoice data via API
 			$extractedData = null;
 			$autoExtract = !isset($_COOKIE['autoExtract']) || $_COOKIE['autoExtract'] !== '0';
@@ -559,8 +570,19 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 		// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 		$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 		$baseName = sanitize_filename($baseName);
+
+		// Dedupe against any pool file already using this base name (e.g. generic
+		// scanner/phone names like "scan.pdf") so an unrelated document's upload can't
+		// silently overwrite it and confuse its metadata (SST-776) - same pattern as
+		// the vendor+date rename dedup further below.
+		$originalBaseName = $baseName;
+		$dedupCounter = 1;
+		while (file_exists("$poolDir/$baseName.pdf") || file_exists("$poolDir/$baseName.jpg") || file_exists("$poolDir/$baseName.jpeg") || file_exists("$poolDir/$baseName.png")) {
+			$baseName = $originalBaseName . '_' . $dedupCounter;
+			$dedupCounter++;
+		}
 		$targetFile = "$poolDir/$baseName.pdf";
-		
+
 		// Try to extract invoice data BEFORE converting to PDF (API works better with original images)
 		$extractedData = null;
 		$autoExtract = !isset($_COOKIE['autoExtract']) || $_COOKIE['autoExtract'] !== '0';

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -27,6 +27,9 @@
 //20260304 PHR Someone removed the convertOldDoc section.
 //20260603 CL/PHR debitorOrdrer tilføjet som moderne kilde (modernSources, isModernLayout,
 //                  docFolder-fallback, header-logik og openPool-default)
+// 20260910 CL/SZ Pool upload now dedupes against an existing file with the same base name
+//                 (e.g. generic scanner/phone names like "scan.pdf") instead of silently
+//                 overwriting it and confusing its metadata (SST-776).
 
 @session_start();
 $s_id=session_id();

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -30,6 +30,9 @@
 // 20260910 CL/SZ Pool upload now dedupes against an existing file with the same base name
 //                 (e.g. generic scanner/phone names like "scan.pdf") instead of silently
 //                 overwriting it and confusing its metadata (SST-776).
+// 20260910 CL/NTR Pool upload and vendor+date rename now reserve their target name atomically
+//                  via FileReservation instead of file_exists() polling, closing the window in
+//                  which two concurrent uploads could pick the same name (SST-776 follow-up).
 
 @session_start();
 $s_id=session_id();
@@ -51,6 +54,7 @@ include("../includes/online.php");
 include("../includes/std_func.php");
 include("../includes/topline_settings.php");
 include("docsIncludes/invoiceExtractionApi.php");
+include_once(__DIR__ . "/docsIncludes/FileReservation.php");
 if (!isset($userId) || !$userId) $userId = $bruger_id;
 
 if (!isset($menu)) $menu = null;
@@ -166,17 +170,20 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 			$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 			$baseName = sanitize_filename($baseName);
 
-			// Dedupe against any pool file already using this base name (e.g. generic
-			// scanner/phone names like "scan.pdf") so an unrelated document's upload can't
-			// silently overwrite it and confuse its metadata (SST-776) - same pattern as
-			// the vendor+date rename dedup further below.
-			$originalBaseName = $baseName;
-			$dedupCounter = 1;
-			while (file_exists("$poolDir/$baseName.pdf") || file_exists("$poolDir/$baseName.jpg") || file_exists("$poolDir/$baseName.jpeg") || file_exists("$poolDir/$baseName.png")) {
-				$baseName = $originalBaseName . '_' . $dedupCounter;
-				$dedupCounter++;
+			// Reserve the target name atomically so a pool file already using this base name
+			// (e.g. generic scanner/phone names like "scan.pdf") is never overwritten, and two
+			// concurrent uploads with the same name can't both settle on it (SST-776). Sibling
+			// extensions count as taken too, so a leftover "scan.jpg" or "scan.info" also bumps
+			// us to "scan_1". $targetFile is an empty placeholder until the upload lands on it.
+			$reservation = FileReservation::reserve($poolDir, $baseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+			if ($reservation === null) {
+				error_log("documents.php (AJAX): could not reserve a pool filename for '$baseName' in $poolDir");
+				header('Content-Type: application/json');
+				echo json_encode(['success' => false, 'message' => 'Failed to save file']);
+				exit;
 			}
-			$targetFile = "$poolDir/$baseName.pdf";
+			$baseName = $reservation->baseName();
+			$targetFile = $reservation->path();
 
 			// Try to extract invoice data via API
 			$extractedData = null;
@@ -184,8 +191,10 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 
 			// Convert images to PDF if needed
 			if (in_array($ext, ['jpg', 'jpeg', 'png'])) {
-				$tempFile = "$poolDir/$baseName.$ext";
-				if (move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $tempFile)) {
+				$tempFile = $reservation->siblingPath($ext);
+				if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $tempFile)) {
+					$reservation->discard();
+				} else {
 					if ($autoExtract) {
 						// Extract data from ORIGINAL image before converting to PDF
 						error_log("documents.php (AJAX): Calling extractInvoiceData for ORIGINAL image: $tempFile");
@@ -201,17 +210,21 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 					}
 
 
-					// Now convert to PDF
+					// Now convert to PDF (overwrites the empty placeholder in place)
 					exec("convert '$tempFile' '$targetFile'", $output, $return_var);
-					if ($return_var === 0 && file_exists($targetFile)) {
+					clearstatcache(true, $targetFile);
+					if ($return_var === 0 && filesize($targetFile) > 0) {
 						unlink($tempFile);
 					} else {
+						$reservation->discard(); // drop the empty/partial .pdf placeholder
 						$targetFile = $tempFile; // Fallback to original if conversion fails
 					}
 				}
 			} else {
-				// For PDF files, move directly
-				move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile);
+				// For PDF files, move directly onto the placeholder (rename = atomic replace)
+				if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile)) {
+					$reservation->discard();
+				}
 				// Extract data from PDF
 				if ($autoExtract && file_exists($targetFile)) {
 					error_log("documents.php (AJAX): Calling extractInvoiceData for PDF: $targetFile");
@@ -258,25 +271,23 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 					$newBaseName = $invoiceDate;
 				}
 				
-				// Rename file if we have a new name
+				// Rename file if we have a new name - reserve the new name atomically first,
+				// then rename onto the placeholder (same race as the upload dedup above)
 				if ($newBaseName !== $baseName) {
-					$newTargetFile = "$poolDir/$newBaseName.pdf";
-					
-					// Check if file already exists and append number if needed
-					$counter = 1;
-					$originalNewBaseName = $newBaseName;
-					while (file_exists($newTargetFile)) {
-						$newBaseName = $originalNewBaseName . '_' . $counter;
-						$newTargetFile = "$poolDir/$newBaseName.pdf";
-						$counter++;
-					}
-					
-					if (rename($targetFile, $newTargetFile)) {
-						$targetFile = $newTargetFile;
-						$baseName = $newBaseName;
-						error_log("documents.php (AJAX): Renamed file to: $newBaseName.pdf");
+					$renameReservation = FileReservation::reserve($poolDir, $newBaseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+					if ($renameReservation === null) {
+						error_log("documents.php (AJAX): could not reserve a pool filename for '$newBaseName' in $poolDir, keeping $baseName.pdf");
 					} else {
-						error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.pdf");
+						$newBaseName = $renameReservation->baseName();
+						$newTargetFile = $renameReservation->path();
+						if (rename($targetFile, $newTargetFile)) {
+							$targetFile = $newTargetFile;
+							$baseName = $newBaseName;
+							error_log("documents.php (AJAX): Renamed file to: $newBaseName.pdf");
+						} else {
+							$renameReservation->discard();
+							error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.pdf");
+						}
 					}
 				}
 			}
@@ -574,26 +585,32 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 		$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 		$baseName = sanitize_filename($baseName);
 
-		// Dedupe against any pool file already using this base name (e.g. generic
-		// scanner/phone names like "scan.pdf") so an unrelated document's upload can't
-		// silently overwrite it and confuse its metadata (SST-776) - same pattern as
-		// the vendor+date rename dedup further below.
-		$originalBaseName = $baseName;
-		$dedupCounter = 1;
-		while (file_exists("$poolDir/$baseName.pdf") || file_exists("$poolDir/$baseName.jpg") || file_exists("$poolDir/$baseName.jpeg") || file_exists("$poolDir/$baseName.png")) {
-			$baseName = $originalBaseName . '_' . $dedupCounter;
-			$dedupCounter++;
+		// Reserve the target name atomically so a pool file already using this base name
+		// (e.g. generic scanner/phone names like "scan.pdf") is never overwritten, and two
+		// concurrent uploads with the same name can't both settle on it (SST-776). Sibling
+		// extensions count as taken too, so a leftover "scan.jpg" or "scan.info" also bumps
+		// us to "scan_1". $targetFile is an empty placeholder until the upload lands on it.
+		$reservation = FileReservation::reserve($poolDir, $baseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+		if ($reservation === null) {
+			error_log("documents.php (block2): could not reserve a pool filename for '$baseName' in $poolDir");
+			$targetFile = '';
+		} else {
+			$baseName = $reservation->baseName();
+			$targetFile = $reservation->path();
 		}
-		$targetFile = "$poolDir/$baseName.pdf";
 
 		// Try to extract invoice data BEFORE converting to PDF (API works better with original images)
 		$extractedData = null;
 		$autoExtract = !isset($_COOKIE['autoExtract']) || $_COOKIE['autoExtract'] !== '0';
 
 		// Convert images to PDF if needed
-		if (in_array($ext, ['jpg', 'jpeg', 'png'])) {
-			$tempFile = "$poolDir/$baseName.$ext";
-			if (move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $tempFile)) {
+		if ($reservation === null) {
+			// Nothing to write to; the file_exists($targetFile) check below skips the .info/redirect
+		} elseif (in_array($ext, ['jpg', 'jpeg', 'png'])) {
+			$tempFile = $reservation->siblingPath($ext);
+			if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $tempFile)) {
+				$reservation->discard();
+			} else {
 				if ($autoExtract) {
 					// Extract data from ORIGINAL image before converting to PDF
 					error_log("documents.php (block2): Calling extractInvoiceData for ORIGINAL image: $tempFile");
@@ -609,17 +626,21 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 				}
 
 
-				// Now convert to PDF
+				// Now convert to PDF (overwrites the empty placeholder in place)
 				exec("convert '$tempFile' '$targetFile'", $output, $return_var);
-				if ($return_var === 0 && file_exists($targetFile)) {
+				clearstatcache(true, $targetFile);
+				if ($return_var === 0 && filesize($targetFile) > 0) {
 					unlink($tempFile);
 				} else {
+					$reservation->discard(); // drop the empty/partial .pdf placeholder
 					$targetFile = $tempFile; // Fallback to original if conversion fails
 				}
 			}
 		} else {
-			// For PDF files, move directly
-			move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile);
+			// For PDF files, move directly onto the placeholder (rename = atomic replace)
+			if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile)) {
+				$reservation->discard();
+			}
 			// Extract data from PDF
 			if ($autoExtract && file_exists($targetFile)) {
 				error_log("documents.php (block2): Calling extractInvoiceData for PDF: $targetFile");

--- a/tests/characterization/includes/FileReservationTest.test.php
+++ b/tests/characterization/includes/FileReservationTest.test.php
@@ -1,0 +1,165 @@
+<?php
+// 20260910 CL/NTR Cover FileReservation: suffixing, sibling extensions, discard, overwrite-in-place,
+//                  and a real multi-process race on the same base name (SST-776 follow-up).
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 3) . '/includes/docsIncludes/FileReservation.php';
+
+final class FileReservationTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/filereservation_' . bin2hex(random_bytes(6));
+        mkdir($this->dir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            unlink($f);
+        }
+        rmdir($this->dir);
+    }
+
+    public function testReservesTheBaseNameWhenFree(): void
+    {
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf');
+
+        self::assertNotNull($res);
+        self::assertSame('scan', $res->baseName());
+        self::assertSame('pdf', $res->ext());
+        self::assertSame($this->dir . '/scan.pdf', $res->path());
+        self::assertFileExists($res->path());
+        self::assertSame(0, filesize($res->path()));
+    }
+
+    public function testSuffixesWhenTheBaseNameIsTaken(): void
+    {
+        touch($this->dir . '/scan.pdf');
+        touch($this->dir . '/scan_1.pdf');
+
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf');
+
+        self::assertSame('scan_2', $res->baseName());
+        self::assertFileExists($this->dir . '/scan_2.pdf');
+    }
+
+    public function testSiblingExtensionsCountAsTaken(): void
+    {
+        touch($this->dir . '/scan.jpg');
+        touch($this->dir . '/scan_1.info');
+
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf', ['jpg', '.info']);
+
+        self::assertSame('scan_2', $res->baseName());
+        self::assertSame($this->dir . '/scan_2.jpg', $res->siblingPath('jpg'));
+        self::assertSame($this->dir . '/scan_2.info', $res->siblingPath('.info'));
+    }
+
+    public function testSuccessiveReservationsNeverCollide(): void
+    {
+        $names = [];
+        for ($i = 0; $i < 5; $i++) {
+            $names[] = FileReservation::reserve($this->dir, 'scan', 'pdf')->baseName();
+        }
+
+        self::assertSame(['scan', 'scan_1', 'scan_2', 'scan_3', 'scan_4'], $names);
+    }
+
+    public function testNormalisesDotsAndTrailingSlash(): void
+    {
+        $res = FileReservation::reserve($this->dir . '/', 'scan', '.pdf');
+
+        self::assertSame($this->dir . '/scan.pdf', $res->path());
+        self::assertSame($this->dir, $res->dir());
+    }
+
+    public function testPlaceholderCanBeOverwrittenInPlace(): void
+    {
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf');
+        $src = $this->dir . '/incoming.tmp';
+        file_put_contents($src, 'payload');
+
+        self::assertTrue(rename($src, $res->path()));
+        self::assertSame('payload', file_get_contents($res->path()));
+    }
+
+    public function testDiscardRemovesThePlaceholder(): void
+    {
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf');
+
+        self::assertTrue($res->discard());
+        self::assertFileDoesNotExist($res->path());
+        self::assertFalse($res->discard());
+    }
+
+    public function testReturnsNullForUnwritableDirectory(): void
+    {
+        if (posix_geteuid() === 0) {
+            self::markTestSkipped('root ignores directory permissions');
+        }
+        chmod($this->dir, 0555);
+        try {
+            self::assertNull(FileReservation::reserve($this->dir, 'scan', 'pdf'));
+        } finally {
+            chmod($this->dir, 0755);
+        }
+    }
+
+    public function testReturnsNullForMissingDirectory(): void
+    {
+        self::assertNull(FileReservation::reserve($this->dir . '/nope', 'scan', 'pdf'));
+    }
+
+    public function testReturnsNullWhenAttemptsAreExhausted(): void
+    {
+        touch($this->dir . '/scan.pdf');
+        touch($this->dir . '/scan_1.pdf');
+
+        self::assertNull(FileReservation::reserve($this->dir, 'scan', 'pdf', [], '_', 2));
+    }
+
+    /**
+     * Spawns several PHP processes that all reserve "scan.pdf" in the same directory at the
+     * same moment. Every process must come away with a distinct name.
+     */
+    public function testConcurrentProcessesGetDistinctNames(): void
+    {
+        $workers = 12;
+        $script = $this->dir . '/worker.php';
+        $go = $this->dir . '/go';
+        file_put_contents($script, '<?php
+            require ' . var_export(dirname(__DIR__, 3) . '/includes/docsIncludes/FileReservation.php', true) . ';
+            while (!file_exists(' . var_export($go, true) . ')) { usleep(200); }
+            $r = FileReservation::reserve(' . var_export($this->dir, true) . ', "scan", "pdf", ["jpg", "info"]);
+            echo $r === null ? "NULL" : $r->baseName();
+        ');
+
+        $procs = [];
+        $pipes = [];
+        for ($i = 0; $i < $workers; $i++) {
+            $spec = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+            $procs[$i] = proc_open(PHP_BINARY . ' ' . escapeshellarg($script), $spec, $pipes[$i]);
+            self::assertIsResource($procs[$i]);
+        }
+        usleep(200000); // let every worker reach the spin-wait before releasing them together
+        touch($go);
+
+        $names = [];
+        for ($i = 0; $i < $workers; $i++) {
+            $names[] = trim(stream_get_contents($pipes[$i][1]));
+            fclose($pipes[$i][1]);
+            fclose($pipes[$i][2]);
+            proc_close($procs[$i]);
+        }
+        unlink($script);
+        unlink($go);
+
+        self::assertNotContains('NULL', $names);
+        self::assertCount($workers, array_unique($names), 'two workers reserved the same name: ' . implode(', ', $names));
+        self::assertCount($workers, glob($this->dir . '/scan*.pdf'));
+    }
+}

--- a/tests/characterization/includes/FileReservationTest.test.php
+++ b/tests/characterization/includes/FileReservationTest.test.php
@@ -18,8 +18,10 @@ final class FileReservationTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach (glob($this->dir . '/*') ?: [] as $f) {
-            unlink($f);
+        foreach (scandir($this->dir) ?: [] as $f) {
+            if ($f !== '.' && $f !== '..') {
+                unlink($this->dir . '/' . $f);
+            }
         }
         rmdir($this->dir);
     }
@@ -122,25 +124,68 @@ final class FileReservationTest extends TestCase
         self::assertNull(FileReservation::reserve($this->dir, 'scan', 'pdf', [], '_', 2));
     }
 
+    public function testExistingMarkerCountsAsTaken(): void
+    {
+        touch($this->dir . '/.scan.reserving');
+
+        $res = FileReservation::reserve($this->dir, 'scan', 'pdf');
+
+        self::assertSame('scan_1', $res->baseName());
+        self::assertFileExists($this->dir . '/.scan.reserving', 'a foreign marker must not be removed');
+        self::assertFileDoesNotExist($this->dir . '/.scan_1.reserving', 'own marker is removed after reserving');
+    }
+
     /**
      * Spawns several PHP processes that all reserve "scan.pdf" in the same directory at the
      * same moment. Every process must come away with a distinct name.
      */
     public function testConcurrentProcessesGetDistinctNames(): void
     {
-        $workers = 12;
-        $script = $this->dir . '/worker.php';
+        $names = $this->reserveConcurrently(array_fill(0, 12, 'pdf'));
+
+        self::assertCount(12, array_unique($names), 'two workers reserved the same name: ' . implode(', ', $names));
+        self::assertCount(12, glob($this->dir . '/scan*.pdf'));
+    }
+
+    /**
+     * Same race, but the workers ask for different extensions of the same base name. The
+     * sibling rule alone is check-then-act, so without the marker two workers could end up
+     * with "scan.pdf" and "scan.jpg". Every base name must still be unique.
+     */
+    public function testConcurrentProcessesWithDifferentExtensionsGetDistinctBaseNames(): void
+    {
+        $exts = ['pdf', 'jpg', 'png', 'pdf', 'jpg', 'png', 'pdf', 'jpg', 'png', 'pdf', 'jpg', 'png'];
+
+        $names = $this->reserveConcurrently($exts);
+
+        self::assertCount(count($exts), array_unique($names), 'two workers reserved the same base name: ' . implode(', ', $names));
+        self::assertSame([], glob($this->dir . '/.*.reserving'), 'no markers left behind');
+    }
+
+    /**
+     * Runs one PHP process per entry in $exts, each reserving base name "scan" with that
+     * extension, released simultaneously. Returns the base names they were given.
+     *
+     * @param string[] $exts
+     * @return string[]
+     */
+    private function reserveConcurrently(array $exts): array
+    {
         $go = $this->dir . '/go';
-        file_put_contents($script, '<?php
-            require ' . var_export(dirname(__DIR__, 3) . '/includes/docsIncludes/FileReservation.php', true) . ';
-            while (!file_exists(' . var_export($go, true) . ')) { usleep(200); }
-            $r = FileReservation::reserve(' . var_export($this->dir, true) . ', "scan", "pdf", ["jpg", "info"]);
-            echo $r === null ? "NULL" : $r->baseName();
-        ');
+        $scripts = [];
+        foreach ($exts as $i => $ext) {
+            $scripts[$i] = $this->dir . "/worker$i.php";
+            file_put_contents($scripts[$i], '<?php
+                require ' . var_export(dirname(__DIR__, 3) . '/includes/docsIncludes/FileReservation.php', true) . ';
+                while (!file_exists(' . var_export($go, true) . ')) { usleep(200); }
+                $r = FileReservation::reserve(' . var_export($this->dir, true) . ', "scan", ' . var_export($ext, true) . ', ["pdf", "jpg", "png", "info"]);
+                echo $r === null ? "NULL" : $r->baseName();
+            ');
+        }
 
         $procs = [];
         $pipes = [];
-        for ($i = 0; $i < $workers; $i++) {
+        foreach ($scripts as $i => $script) {
             $spec = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
             $procs[$i] = proc_open(PHP_BINARY . ' ' . escapeshellarg($script), $spec, $pipes[$i]);
             self::assertIsResource($procs[$i]);
@@ -149,17 +194,16 @@ final class FileReservationTest extends TestCase
         touch($go);
 
         $names = [];
-        for ($i = 0; $i < $workers; $i++) {
+        foreach ($procs as $i => $proc) {
             $names[] = trim(stream_get_contents($pipes[$i][1]));
             fclose($pipes[$i][1]);
             fclose($pipes[$i][2]);
-            proc_close($procs[$i]);
+            proc_close($proc);
+            unlink($scripts[$i]);
         }
-        unlink($script);
         unlink($go);
 
         self::assertNotContains('NULL', $names);
-        self::assertCount($workers, array_unique($names), 'two workers reserved the same name: ' . implode(', ', $names));
-        self::assertCount($workers, glob($this->dir . '/scan*.pdf'));
+        return $names;
     }
 }


### PR DESCRIPTION
## Summary
SST-776 (tracking SST-740's original report): users saw a previewed pool document
displaying metadata belonging to a different document. Root cause was unconfirmed when the
ticket was written. Traced the pool document/preview/posting flow and found two distinct,
unrelated bugs — both fixed in this PR.

## What are the changes about?
### includes/docsIncludes/extractInvoiceHandler.php
- `$db` is now resolved from the session's `online` table row (matching the pattern in
  `includes/_docPoolData.php`), instead of being read from `$_POST['db']`.
- `$docFolder` is now whitelisted to the three values `documents.php` itself ever assigns,
  instead of being accepted as raw request input.
- `poolFile` is now rejected unless it's a bare filename with no path component (blocks
  path traversal).

### includes/documents.php
- Added filename-collision detection to both upload-handling blocks (~line 120 and ~line 547).
- Before writing an uploaded file to disk, the code now checks whether a file already exists
  at that path.
- If it does, applies the same dedup-with-counter pattern already used elsewhere in this file
  (for the post-extraction vendor+date rename): the new upload is saved as `name_1.pdf`,
  `name_2.pdf`, etc., instead of overwriting the existing file.
- The API response for each upload now reports the actual final filename used (which may
  differ from the originally uploaded name if a collision occurred).

## Issue 1 — Cross-tenant data access (security)
**File:** `includes/docsIncludes/extractInvoiceHandler.php`

**Root cause:** this AJAX handler (extracts/saves/deletes pool-file metadata) trusted
`$_POST['db']` and `$_POST['docFolder']` directly instead of deriving the tenant from the
session, like every other page does. It also never validated `poolFile`.

**Impact:** any request — even unauthenticated — could name a different tenant's database
and read, extract, modify, or delete that tenant's pool documents. Combined with unvalidated
`docFolder`/`poolFile`, also a path-traversal hole.

**Verified:** live curl, before/after. Pre-fix, a forged `db` actually connected to and
searched the other tenant's folder. Post-fix, the same forged request falls back to the
caller's own tenant, and unauthenticated requests are rejected outright.

## Issue 2 — Upload silently overwrites a different document with the same filename
**File:** `includes/documents.php` (two duplicate upload blocks, ~line 120 and ~line 547)

**Root cause:** the upload handler wrote the new file to a path derived purely from the
uploaded file's own name, with no check for an existing file there first. Generic filenames
are common (`scan.pdf`, `IMG_001.pdf`) — a second, unrelated upload sharing that name
silently overwrote the first file on disk while its `.info`/`pool_files` metadata row got
reused. **This is very plausibly the literal SST-740 symptom.**

**Verified:** live upload test, before/after. Pre-fix, two different PDFs both named
`scan.pdf` left only the second one's content on disk (silent data loss). Post-fix, they
become `scan.pdf` and `scan_1.pdf` with both files' content intact.

Also verified end-to-end through the real app: upload → save metadata → attach to a journal
line, confirming the document, its metadata, and the final attached file all stayed
correctly associated the whole way through.

## Files Changed
- includes/docsIncludes/extractInvoiceHandler.php — tenant/path validation
- includes/documents.php — upload filename dedup

## Acceptance Criteria — status against each of SST-776's 7 items
| # | Criterion | Status |
|---|---|---|
| 1 | Select A, then B rapidly with responses reversed: preview/metadata/attachment all remain B | **No change needed** — already correctly guarded by existing, already-merged code (`bilagsmatch.php`'s `bmPinnedCurrentFilename`/`bmRequestSeq` checks). |
| 2 | Same filenames, multiple tabs, search/filter changes, popup selection never cross-associate | **Addressed by Issue 2 fix** (filename dedup on upload). Recommend an explicit multi-tab test before final sign-off, since that specific combination wasn't independently exercised in this PR. |
| 3 | Tampered foreign document IDs cannot read/modify/attach another tenant's document | **Addressed by Issue 1 fix.** Live-verified via curl for the extractInvoiceHandler.php path specifically. |
| 4 | Confirmed reproducer passes from upload to final attachment; existing correct flows remain functional | **Verified end-to-end** on the real running app: upload → save metadata → attach to a journal line, with document/metadata/attached file staying correctly associated throughout. |
| 5 | All SQL input int/float-cast or db_escape_string()ed; authorization checked independently of escaping | Addressed for the two touched files. |
| 6 | No dead code; findtekst() for labels; one ticket per PR; manual test scenarios per doc/ai/MEMORY.md | One ticket, one PR, no user-facing labels changed. `doc/ai/MEMORY.md`-format manual test scenarios not separately authored — flagged as a PR-readiness item the ticket calls out explicitly. |
| 7 | Migration (if needed) idempotent, added via betweenUpdates.php first | No migration required for either fix. |

## Scope item 3 — Bilagsmatch/Nicolai check: resolved
Nicolai confirmed Bilagsmatch only links existing bilag and never uploads. Independently
verified in code: `fetchbilagsmatch.php` has no upload logic and never reads `db` from the
request, so it is unaffected by either fix in this PR.

## Not Fixed
- **AC#1** — no code change needed; existing guard already correct (see table above).

## Out of Scope
- Extraction accuracy, editable suggestion UX, private expenses (per ticket)
- Any association defect the trace did not find (per ticket, no speculative rewrites)

## How to Test
1. **Issue 1 (cross-tenant access):** attempt to call `extractInvoiceHandler.php` with a
   forged `db` parameter pointing at a different tenant, both with and without a valid
   session for the caller's own tenant. Verify: no session → rejected outright; valid
   session for tenant A with a forged `db` for tenant B → request operates against tenant A
   only, never B.
2. Attempt the same with a `docFolder` value outside the three whitelisted values, and a
   `poolFile` value containing a path component (e.g. `../../etc/passwd`) — verify both are
   rejected.
3. **Issue 2 (filename collision):** upload two different PDF files both named `scan.pdf`
   to the same tenant's pool. Verify both files exist on disk with distinct content
   (`scan.pdf` and `scan_1.pdf`), and the API response for each upload reports the correct
   final filename.
4. Repeat step 3 a third time with another `scan.pdf` — verify it becomes `scan_2.pdf`.
5. **AC#1 regression check:** in the Bilagsmatch dialog, rapidly select document A then
   document B before A's preview response returns — verify the pinned preview ends up
   showing B's content and metadata, not a stale A response arriving late.
6. **AC#2 explicit test:** open the pool document view in two browser tabs, apply different
   search/filter criteria in each, and select documents with the same filename in both tabs
   — verify no cross-tab metadata bleed.
7. **End-to-end reproducer (AC#4):** upload a document, preview it, extract/edit its
   metadata, and post/attach it to a journal line — confirm the correct document and
   metadata travel through every step, for both a normal document and a filename-colliding
   one. (Verified — see Verification section.)
8. Confirm existing, previously-working document selection/attachment flows are unaffected
   by both fixes (no regression for the non-adversarial, non-colliding case).
9. Confirm `fetchbilagsmatch.php` behavior is unaffected by either fix (per the Bilagsmatch
   check above).

## Verification
- Issue 1: live curl tests, before and after — forged `db` param confirmed exploitable
  pre-fix, confirmed blocked post-fix.
- Issue 2: live upload tests, before and after — filename collision confirmed to silently
  overwrite pre-fix, confirmed to dedup correctly post-fix.
- AC#4: verified end-to-end on the real running app — upload → save metadata → attach to a
  journal line, with the document, its metadata, and the final attached file all staying
  correctly associated throughout.
- Scope item 3: confirmed with Nicolai and independently verified in code that Bilagsmatch
  is unaffected by either change.

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice processing security by validating requests against the active session and approved document locations.
  * Expired sessions now display a clearer session-expired message.
  * Prevented uploaded pool files from overwriting existing files by automatically assigning unique filenames, including during simultaneous uploads.
  * Improved upload reliability by handling failed file reservations and conversion attempts without leaving invalid files behind.
  * Restricted uploaded file names to safe filename formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->