### PR TITLE
Sst 775 - Part 1

### DIFF
--- a/includes/docsIncludes/extractInvoiceHandler.php
+++ b/includes/docsIncludes/extractInvoiceHandler.php
@@ -2,6 +2,9 @@
 // --- includes/docsIncludes/extractInvoiceHandler.php ---
 // AJAX handler for invoice extraction from pool files
 // ----------------------------------------------------------------------
+// 20260909 CDX/MJ SST-775 Moved normalizeDateFormat() to poolDateNormalizer.php so the date
+//             handling is testable - this file connects to a database and exits when included.
+//             Behaviour is unchanged here; the fixes live in that file.
 
 // Set JSON response header FIRST
 header('Content-Type: application/json');
@@ -12,6 +15,7 @@ ob_start();
 // Include database connection
 include_once("../connect.php");
 include_once(__DIR__ . "/poolAmountNormalizer.php");
+include_once(__DIR__ . "/poolDateNormalizer.php");
 
 // Get database name from POST
 $db = isset($_POST['db']) ? $_POST['db'] : '';
@@ -48,82 +52,6 @@ include_once("invoiceExtractionApi.php");
 // Discard any buffered output from includes
 ob_end_clean();
 
-/**
- * Normalize date format from various formats to Y-m-d
- * Handles Danish month names like "januar", "februar", etc.
- * Also handles formats like "17.oktober.2025", "17-10-2025", "2025-10-17", etc.
- */
-function normalizeDateFormat($dateStr) {
-	if (empty($dateStr)) {
-		return '';
-	}
-	
-	// Danish month names to numbers
-	$danishMonths = [
-		'januar' => '01', 'jan' => '01',
-		'februar' => '02', 'feb' => '02',
-		'marts' => '03', 'mar' => '03',
-		'april' => '04', 'apr' => '04',
-		'maj' => '05',
-		'juni' => '06', 'jun' => '06',
-		'juli' => '07', 'jul' => '07',
-		'august' => '08', 'aug' => '08',
-		'september' => '09', 'sep' => '09', 'sept' => '09',
-		'oktober' => '10', 'okt' => '10', 'oct' => '10',
-		'november' => '11', 'nov' => '11',
-		'december' => '12', 'dec' => '12'
-	];
-	
-	// Clean up the date string
-	$dateStr = trim($dateStr);
-	$originalDate = $dateStr;
-	
-	// Convert to lowercase for matching
-	$lowerDate = strtolower($dateStr);
-	
-	// Replace Danish month names with numbers
-	foreach ($danishMonths as $monthName => $monthNum) {
-		if (stripos($lowerDate, $monthName) !== false) {
-			// Found a Danish month name, try to parse
-			// Pattern: day.monthname.year or day monthname year
-			if (preg_match('/(\d{1,2})[.\s\-]+' . preg_quote($monthName, '/') . '[.\s\-]+(\d{4}|\d{2})/i', $dateStr, $matches)) {
-				$day = str_pad($matches[1], 2, '0', STR_PAD_LEFT);
-				$year = $matches[2];
-				// Handle 2-digit year
-				if (strlen($year) == 2) {
-					$year = ($year > 50 ? '19' : '20') . $year;
-				}
-				return $year . '-' . $monthNum . '-' . $day;
-			}
-		}
-	}
-	
-	// Try standard formats
-	// Format: dd.mm.yyyy or dd-mm-yyyy or dd/mm/yyyy
-	if (preg_match('/^(\d{1,2})[.\-\/](\d{1,2})[.\-\/](\d{4})$/', $dateStr, $matches)) {
-		$day = str_pad($matches[1], 2, '0', STR_PAD_LEFT);
-		$month = str_pad($matches[2], 2, '0', STR_PAD_LEFT);
-		$year = $matches[3];
-		return $year . '-' . $month . '-' . $day;
-	}
-	
-	// Format: yyyy-mm-dd (already correct)
-	if (preg_match('/^(\d{4})[.\-\/](\d{1,2})[.\-\/](\d{1,2})$/', $dateStr, $matches)) {
-		$year = $matches[1];
-		$month = str_pad($matches[2], 2, '0', STR_PAD_LEFT);
-		$day = str_pad($matches[3], 2, '0', STR_PAD_LEFT);
-		return $year . '-' . $month . '-' . $day;
-	}
-	
-	// Try PHP's strtotime as fallback
-	$timestamp = strtotime($dateStr);
-	if ($timestamp !== false && $timestamp > 0) {
-		return date('Y-m-d', $timestamp);
-	}
-	
-	// Return original if nothing worked
-	return $originalDate;
-}
 
 // Get action and poolFile from POST
 $action = isset($_POST['action']) ? $_POST['action'] : '';

--- a/includes/docsIncludes/poolAmountNormalizer.php
+++ b/includes/docsIncludes/poolAmountNormalizer.php
@@ -20,6 +20,11 @@
 // 20260721 CL/SZ Added normalizePoolAmount() for the Bilagsmatch scoring engine, shared
 //                  between extractInvoiceHandler.php's save path and the pool_files.norm_amount
 //                  backfill in opdat_4.3.php.
+// 20260909 CDX/MJ SST-775 normalizePoolAmount(): read an accounting credit "(1.234,56)" as
+//                  negative. Only a literal '-' set the sign, so a parenthesised credit was
+//                  normalized to a positive norm_amount and could only ever match a debit.
+//                  NB: rows written before this change keep their positive norm_amount until
+//                  the pool file is saved again.
 
 if (!function_exists('normalizePoolAmount')) {
 	/**
@@ -43,6 +48,15 @@ if (!function_exists('normalizePoolAmount')) {
 		if ($raw === '') return null;
 
 		$negative = (strpos($raw, '-') !== false);
+
+		// Accounting notation wraps a credit in parentheses instead of signing it:
+		// "(1.234,56)" is -1234.56. The strip below removes the parentheses, so the sign has
+		// to be read while they are still there. Anchored to the whole value so that a
+		// parenthetical elsewhere in the string - "1.234,56 (faktura 123)" - is not read as
+		// a sign.
+		if (!$negative && preg_match('/^\(.*\d.*\)$/', $raw)) {
+			$negative = true;
+		}
 
 		// Drop currency symbols/letters/parentheses etc, keep only digits and separators.
 		$clean = preg_replace('/[^0-9,.\s]/', '', $raw);

--- a/includes/docsIncludes/poolDateNormalizer.php
+++ b/includes/docsIncludes/poolDateNormalizer.php
@@ -1,0 +1,176 @@
+<?php
+// --- includes/docsIncludes/poolDateNormalizer.php ---
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+//
+// Copyright (c) 2003-2026 Saldi.dk ApS
+// ----------------------------------------------------------------------
+// 20260909 CDX/MJ SST-775 Moved normalizeDateFormat() here out of extractInvoiceHandler.php,
+//                  which cannot be included without connecting to a database and exiting, so the
+//                  date handling had no test coverage. Same shape as poolAmountNormalizer.php.
+//                  Three extraction defects fixed at the same time - see normalizeDateFormat().
+
+if (!function_exists('poolDateFromParts')) {
+	/**
+	 * Assemble a Y-m-d date from its parts, but only when the parts describe a real day.
+	 *
+	 * Returns '' rather than the raw string when the parts are not a real date. Keeping
+	 * the raw string looks harmless because pool_files.file_date is a varchar, but
+	 * docPool.php then formats it for the cash journal with
+	 * date("d-m-Y", strtotime($newDate)) - and strtotime() rolls an impossible date over
+	 * instead of rejecting it, so "31.02.2025" posts a journal line dated 03-03-2025 just
+	 * as the old "2025-02-31" did. An empty value sets no date from the pool at all, which
+	 * leaves the field to be filled in rather than silently posting the wrong day.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Month, zero-padded.
+	 * @param string $day   Day, zero-padded.
+	 * @return string Y-m-d, or '' when the parts are not a real date.
+	 */
+	function poolDateFromParts($year, $month, $day)
+	{
+		if (!checkdate((int) $month, (int) $day, (int) $year)) {
+			return '';
+		}
+		return $year . '-' . $month . '-' . $day;
+	}
+}
+
+if (!function_exists('poolDateExpandYear')) {
+	/**
+	 * Expand a two-digit year to four digits, leaving four-digit years untouched.
+	 *
+	 * @param string $year
+	 * @return string
+	 */
+	function poolDateExpandYear($year)
+	{
+		if (strlen($year) != 2) {
+			return $year;
+		}
+		return ($year > 50 ? '19' : '20') . $year;
+	}
+}
+
+if (!function_exists('normalizeDateFormat')) {
+	/**
+	 * Normalize date format from various formats to Y-m-d.
+	 *
+	 * Handles Danish month names like "januar", "februar", etc., and formats like
+	 * "17.oktober.2025", "17-10-2025", "2025-10-17".
+	 *
+	 * Day-first is assumed throughout, which is the Danish convention. Two-digit years
+	 * are therefore read as dd-mm-yy; "25-10-17" is genuinely ambiguous and resolves to
+	 * 2017-10-25 rather than 2025-10-17.
+	 *
+	 * SST-775 fixed three defects here, all of which produced a wrong or impossible
+	 * bilagsdato that was then stored silently:
+	 *   - "17-10-25" returned 2017-10-25. The dd.mm.yyyy branch demanded a four-digit
+	 *     year, so two-digit years fell through to strtotime(), which reads a
+	 *     dash-separated triple as yy-mm-dd and swapped day with year.
+	 *   - "10/17/2025" returned "2025-17-10", i.e. month 17. A month-first document
+	 *     (US-style, as issued by some foreign suppliers) was read day-first.
+	 *   - "31.02.2025" returned "2025-02-31". Nothing validated the result, and returning the
+	 *     raw string instead was not enough either: docPool.php feeds file_date through
+	 *     strtotime(), which rolls "31.02.2025" over to 3 March exactly as "2025-02-31" did.
+	 *     An impossible date therefore yields '' - no date rather than the wrong one.
+	 *
+	 * @param string|null $dateStr Raw date as extracted from the document, or typed by a user.
+	 * @return string Y-m-d when the input describes a real date; '' when the input is empty
+	 *   or describes an impossible date; otherwise the trimmed input unchanged, for input
+	 *   that was never date-shaped to begin with (strtotime() rejects it downstream too).
+	 */
+	function normalizeDateFormat($dateStr)
+	{
+		if (empty($dateStr)) {
+			return '';
+		}
+
+		// Danish month names to numbers
+		$danishMonths = [
+			'januar' => '01', 'jan' => '01',
+			'februar' => '02', 'feb' => '02',
+			'marts' => '03', 'mar' => '03',
+			'april' => '04', 'apr' => '04',
+			'maj' => '05',
+			'juni' => '06', 'jun' => '06',
+			'juli' => '07', 'jul' => '07',
+			'august' => '08', 'aug' => '08',
+			'september' => '09', 'sep' => '09', 'sept' => '09',
+			'oktober' => '10', 'okt' => '10', 'oct' => '10',
+			'november' => '11', 'nov' => '11',
+			'december' => '12', 'dec' => '12'
+		];
+
+		// Clean up the date string
+		$dateStr = trim($dateStr);
+		$originalDate = $dateStr;
+
+		// Convert to lowercase for matching
+		$lowerDate = strtolower($dateStr);
+
+		// Replace Danish month names with numbers
+		foreach ($danishMonths as $monthName => $monthNum) {
+			if (stripos($lowerDate, $monthName) !== false) {
+				// Found a Danish month name, try to parse
+				// Pattern: day.monthname.year or day monthname year
+				if (preg_match('/(\d{1,2})[.\s\-]+' . preg_quote($monthName, '/') . '[.\s\-]+(\d{4}|\d{2})/i', $dateStr, $matches)) {
+					$day = str_pad($matches[1], 2, '0', STR_PAD_LEFT);
+					$year = poolDateExpandYear($matches[2]);
+					return poolDateFromParts($year, $monthNum, $day);
+				}
+			}
+		}
+
+		// Format: dd.mm.yyyy or dd-mm-yyyy or dd/mm/yyyy, and the same with a two-digit year.
+		// A leading four-digit group cannot match here, so yyyy-mm-dd still falls to the
+		// branch below.
+		if (preg_match('/^(\d{1,2})[.\-\/](\d{1,2})[.\-\/](\d{4}|\d{2})$/', $dateStr, $matches)) {
+			$day = (int) $matches[1];
+			$month = (int) $matches[2];
+			$year = poolDateExpandYear($matches[3]);
+			// When the second group cannot be a month but the first can, the document is
+			// month-first. Swapping is the only reading that yields a real date, so this is a
+			// correction rather than a guess; anything else stays as it was and gets validated.
+			if ($month > 12 && $day <= 12) {
+				$tmp = $day;
+				$day = $month;
+				$month = $tmp;
+			}
+			return poolDateFromParts(
+				$year,
+				str_pad((string) $month, 2, '0', STR_PAD_LEFT),
+				str_pad((string) $day, 2, '0', STR_PAD_LEFT)
+			);
+		}
+
+		// Format: yyyy-mm-dd (already correct)
+		if (preg_match('/^(\d{4})[.\-\/](\d{1,2})[.\-\/](\d{1,2})$/', $dateStr, $matches)) {
+			$year = $matches[1];
+			$month = str_pad($matches[2], 2, '0', STR_PAD_LEFT);
+			$day = str_pad($matches[3], 2, '0', STR_PAD_LEFT);
+			return poolDateFromParts($year, $month, $day);
+		}
+
+		// Try PHP's strtotime as fallback
+		$timestamp = strtotime($dateStr);
+		if ($timestamp !== false && $timestamp > 0) {
+			return date('Y-m-d', $timestamp);
+		}
+
+		// Return original if nothing worked
+		return $originalDate;
+	}
+}

--- a/tests/characterization/includes/docsIncludes/PoolAmountNormalizerCharacterizationTest.test.php
+++ b/tests/characterization/includes/docsIncludes/PoolAmountNormalizerCharacterizationTest.test.php
@@ -1,0 +1,90 @@
+<?php
+// tests/characterization/includes/docsIncludes/PoolAmountNormalizerCharacterizationTest.test.php
+//
+// SST-775: pins normalizePoolAmount() in includes/docsIncludes/poolAmountNormalizer.php.
+//
+// The function is shared by extractInvoiceHandler.php's save path, the Bilagsmatch scoring
+// engine and the pool_files.norm_amount backfill, but had no test coverage. It read an
+// accounting credit "(1.234,56)" as +1234.56 because only a literal '-' set the sign, so a
+// credit note in the pool could only ever match a debit.
+//
+// The Danish/US separator handling it already got right is pinned too, so the sign fix
+// cannot regress it.
+//
+// History:
+// 20260909 CDX/MJ SST-775: created.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 4) . '/includes/docsIncludes/poolAmountNormalizer.php';
+
+final class PoolAmountNormalizerCharacterizationTest extends TestCase
+{
+	/** Separator handling that already worked - guard against regression. */
+	public static function separatorProvider(): array
+	{
+		return [
+			'danish, dot thousands + comma decimal' => ['1.234,56', 1234.56],
+			'us, comma thousands + dot decimal'     => ['1,234.56', 1234.56],
+			'plain decimal'                         => ['1234.56', 1234.56],
+			'single dot, three trailing digits'     => ['1.234', 1234.0],
+			'space as thousands separator'          => ['1 234,56', 1234.56],
+			'repeated thousands grouping'           => ['1.234.567', 1234567.0],
+			'currency prefix is ignored'            => ['DKK 1.234,56', 1234.56],
+			'signed negative'                       => ['-1.234,56', -1234.56],
+			'trailing minus'                        => ['1.234,56-', -1234.56],
+		];
+	}
+
+	#[DataProvider('separatorProvider')]
+	public function testSeparatorHandlingIsUnchanged(string $input, float $expected): void
+	{
+		$this->assertSame($expected, normalizePoolAmount($input));
+	}
+
+	public function testParenthesisedAmountIsACredit(): void
+	{
+		// Was +1234.56 / +500.0: the docblock notes parentheses are stripped, but nothing
+		// treated them as a sign.
+		$this->assertSame(-1234.56, normalizePoolAmount('(1.234,56)'));
+		$this->assertSame(-500.0, normalizePoolAmount('(500)'));
+		$this->assertSame(-1234.56, normalizePoolAmount('(DKK 1.234,56)'));
+	}
+
+	public function testParenthesisElsewhereInTheStringIsNotASign(): void
+	{
+		// The sign test is anchored to the whole value, so a parenthetical note stays positive.
+		// The magnitude is wrong for a separate, pre-existing reason - see the next test.
+		$this->assertGreaterThan(0, normalizePoolAmount('1.234,56 (faktura 123)'));
+	}
+
+	public function testTrailingDigitsOutsideTheAmountBleedIntoIt(): void
+	{
+		// Pinned as-is, NOT as desired behaviour. Non-numeric characters are stripped but the
+		// digits they surrounded are kept and concatenated, so any trailing text containing a
+		// number corrupts the amount: "1.234,56 (faktura 123)" becomes 1234.56123, rounded to
+		// 1234.561 rather than 1234.56.
+		//
+		// This is an amount extraction defect in its own right and in SST-775's scope, but
+		// fixing it means changing how this shared function tokenizes - it also feeds the
+		// Bilagsmatch scoring engine and the pool_files.norm_amount backfill - so it is left
+		// for a separate change rather than stacked onto the sign fix.
+		// (round() to 3 decimals is what stops these being even further out.)
+		$this->assertSame(1234.561, normalizePoolAmount('1.234,56 (faktura 123)'));
+		$this->assertSame(1234.562, normalizePoolAmount('1.234,56 DKK 2025'));
+	}
+
+	public function testAlreadyNegativeParenthesisedAmountStaysNegativeOnce(): void
+	{
+		$this->assertSame(-1234.56, normalizePoolAmount('(-1.234,56)'));
+	}
+
+	public function testEmptyAndUnparseableInputReturnNull(): void
+	{
+		$this->assertNull(normalizePoolAmount(null));
+		$this->assertNull(normalizePoolAmount(''));
+		$this->assertNull(normalizePoolAmount('   '));
+		$this->assertNull(normalizePoolAmount('ingen beløb'));
+	}
+}

--- a/tests/characterization/includes/docsIncludes/PoolDateNormalizerCharacterizationTest.test.php
+++ b/tests/characterization/includes/docsIncludes/PoolDateNormalizerCharacterizationTest.test.php
@@ -1,0 +1,113 @@
+<?php
+// tests/characterization/includes/docsIncludes/PoolDateNormalizerCharacterizationTest.test.php
+//
+// SST-775: pins normalizeDateFormat() in includes/docsIncludes/poolDateNormalizer.php.
+//
+// pool_files.file_date is a varchar, so whatever this function returns is stored verbatim
+// and read back by Bilagsmatch and the cash journal. Three defects each produced a wrong
+// or impossible bilagsdato that was then posted silently:
+//   - a two-digit year swapped day with year   ("17-10-25" -> 2017-10-25)
+//   - a month-first document was read day-first ("10/17/2025" -> "2025-17-10", month 17)
+//   - nothing validated the result             ("31.02.2025" -> "2025-02-31")
+//
+// The formats that already worked are pinned too, so the fix cannot regress them.
+//
+// History:
+// 20260909 CDX/MJ SST-775: created.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 4) . '/includes/docsIncludes/poolDateNormalizer.php';
+
+final class PoolDateNormalizerCharacterizationTest extends TestCase
+{
+	/** Formats that already worked before SST-775 - guard against regression. */
+	public static function alreadyWorkingProvider(): array
+	{
+		return [
+			'danish month name, dotted' => ['17.oktober.2025', '2025-10-17'],
+			'danish month name, spaced' => ['1. maj 2025', '2025-05-01'],
+			'danish month abbreviation' => ['17. okt 2025', '2025-10-17'],
+			'day first, dashes'         => ['17-10-2025', '2025-10-17'],
+			'day first, dots'           => ['17.10.2025', '2025-10-17'],
+			'day first, slashes'        => ['17/10/2025', '2025-10-17'],
+			'already iso'               => ['2025-10-17', '2025-10-17'],
+			'iso with slashes'          => ['2025/10/17', '2025-10-17'],
+		];
+	}
+
+	#[DataProvider('alreadyWorkingProvider')]
+	public function testFormatsThatAlreadyWorkedStillWork(string $input, string $expected): void
+	{
+		$this->assertSame($expected, normalizeDateFormat($input));
+	}
+
+	public function testTwoDigitYearIsReadDayFirstInsteadOfSwappingDayAndYear(): void
+	{
+		// Was 2017-10-25: the day-first branch demanded a four-digit year, so this fell
+		// through to strtotime(), which reads a dash-separated triple as yy-mm-dd.
+		$this->assertSame('2025-10-17', normalizeDateFormat('17-10-25'));
+		$this->assertSame('2025-10-17', normalizeDateFormat('17.10.25'));
+		$this->assertSame('2025-10-17', normalizeDateFormat('17/10/25'));
+	}
+
+	public function testMonthFirstDocumentIsRecognisedRatherThanProducingMonthSeventeen(): void
+	{
+		// Was "2025-17-10". A month of 17 is impossible, so month-first is the only
+		// reading that yields a real date.
+		$this->assertSame('2025-10-17', normalizeDateFormat('10/17/2025'));
+		$this->assertSame('2025-12-31', normalizeDateFormat('12/31/2025'));
+	}
+
+	public function testAmbiguousDayFirstDateIsStillReadDayFirst(): void
+	{
+		// Both groups are valid months, so nothing is swapped: day-first wins, as before.
+		$this->assertSame('2025-10-11', normalizeDateFormat('11/10/2025'));
+	}
+
+	public function testImpossibleDateYieldsNoDateRatherThanTheWrongOne(): void
+	{
+		// Was "2025-02-31" / "2025-02-30", stored silently into a varchar column and then
+		// rolled over to 3 March by docPool.php's strtotime(). Returning the raw string
+		// instead was no better - strtotime() rolls "31.02.2025" over just the same - so an
+		// impossible date has to yield nothing at all.
+		$this->assertSame('', normalizeDateFormat('31.02.2025'));
+		$this->assertSame('', normalizeDateFormat('30-02-2025'));
+		// Neither group can be a month, so there is nothing to swap and nothing to invent.
+		$this->assertSame('', normalizeDateFormat('31/17/2025'));
+	}
+
+	public function testImpossibleIsoDateIsNotAccepted(): void
+	{
+		$this->assertSame('', normalizeDateFormat('2025-02-31'));
+	}
+
+	public function testImpossibleDanishMonthDayIsNotAccepted(): void
+	{
+		$this->assertSame('', normalizeDateFormat('31. februar 2025'));
+	}
+
+	public function testInputThatWasNeverDateShapedIsLeftAlone(): void
+	{
+		// Nothing parsed it, so there is no impossible date to suppress - and strtotime()
+		// rejects it downstream as well, so it cannot become a wrong journal date.
+		$this->assertSame('ikke en dato', normalizeDateFormat('ikke en dato'));
+	}
+
+	public function testEmptyInputReturnsEmptyString(): void
+	{
+		$this->assertSame('', normalizeDateFormat(''));
+		$this->assertSame('', normalizeDateFormat(null));
+	}
+
+	public function testLeapDayIsAccepted(): void
+	{
+		$this->assertSame('2024-02-29', normalizeDateFormat('29-02-2024'));
+	}
+
+	public function testNonLeapDayIsRejected(): void
+	{
+		$this->assertSame('', normalizeDateFormat('29-02-2025'));
+	}
+}


### PR DESCRIPTION
## What are the changes about?
Four defects in the document pool's normalizers. All of them silently produced a wrong
value: three put a wrong or missing date on a cash journal line, the fourth turned a
credit note into a debit for Bilagsmatch.

**Please do not close SST-775 on this PR** — see *What this PR does not cover* at the
bottom. The ticket's central instruction is to use SST-740's document trace to fix the
defect at its actual source, and that trace does not exist yet. These are defects I found
by inspecting the two files the ticket names; nobody has confirmed they are the ones the
customer reported.

### 1. Dates — `normalizeDateFormat()`

`pool_files.file_date` is a `character varying`, so an invalid date is stored verbatim
rather than rejected. `docPool.php:381` then formats it for the journal with
`date("d-m-Y", strtotime($newDate))`:

| Date on the document | Stored before | Journal line before | After |
|---|---|---|---|
| `17-10-25` | `2017-10-25` | 25-10-2017 — wrong year | `2025-10-17` |
| `10/17/2025` | `2025-17-10` — month 17 | *no date at all* (`strtotime` fails) | `2025-10-17` |
| `31.02.2025` | `2025-02-31` | 03-03-2025 — three days late | *no date* |

Causes, in the same order:

- **Two-digit years fell through to `strtotime()`.** The day-first branch required
  `(\d{4})` for the year, so `17-10-25` never matched it, and `strtotime()` reads a
  dash-separated triple as `yy-mm-dd`. The branch now accepts `\d{2}` too and keeps the
  day-first reading.
- **A month-first document was read day-first.** Some foreign suppliers issue
  `mm/dd/yyyy`. When the second group cannot be a month but the first can, the two are
  swapped — the only reading that yields a real date, so a correction rather than a guess.
  When both are valid months nothing is swapped and day-first still wins, so `11/10/2025`
  is unchanged.
- **Nothing validated the result.** There was no `checkdate()` in the function at all.

An impossible date now returns `''`. Returning the raw string off the document was my
first attempt and it was not enough: `strtotime('31.02.2025')` rolls over to 3 March
exactly as `2025-02-31` did, so the wrong journal date survived. Empty means no date is
taken from the pool and the field has to be filled in — **missing rather than wrong**. The
trade-off is that the raw value no longer shows in the Dato column; the document itself is
still there to read it from. Input that was never date-shaped is still returned unchanged,
because `strtotime()` rejects that downstream as well.

### 2. Amounts — `normalizePoolAmount()`

The sign came from a literal `-` only, so an accounting credit in parentheses came back
positive:

| Raw amount | Before | After |
|---|---|---|
| `(1.234,56)` | `+1234.56` | `-1234.56` |
| `(500)` | `+500.0` | `-500.0` |
| `(DKK 1.234,56)` | `+1234.56` | `-1234.56` |

The docblock already noted that parentheses get stripped with the currency symbols, but
nothing read them as a sign — so a credit note in the pool normalized to a debit and could
only ever match the wrong side in Bilagsmatch. The test is anchored to the whole value, so
a parenthetical elsewhere (`1.234,56 (faktura 123)`) is not read as a sign.

**Rows written before this change keep their positive `norm_amount` until the pool file is
saved again.** There is no backfill here — the existing one lives in `opdat_4.3.php` and
re-running it is a release decision, not a bug fix. Flagged for SD-578 / Saul as the ticket
asks.

### Why `normalizeDateFormat()` moved

It now lives in `includes/docsIncludes/poolDateNormalizer.php`, mirroring its sibling
`poolAmountNormalizer.php`. It had to move to be testable at all: `extractInvoiceHandler.php`
sets response headers, connects to a tenant database and `exit`s while being included, so
nothing could require it. Both call sites in the handler are unchanged — it just includes
the new file. Only the fixes above change behaviour; the move is mechanical.

Two commits, 5 files, +397 / −76.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing

## How I verified this

### Reproduced on master, at function level

I drove the real `normalizeDateFormat()` from master's `extractInvoiceHandler.php` with a
table of inputs and checked each result with `checkdate()`:

```
'17.oktober.2025'  -> 2025-10-17    valid
'17-10-2025'       -> 2025-10-17    valid
'2025-10-17'       -> 2025-10-17    valid
'17/10/2025'       -> 2025-10-17    valid
'17-10-25'         -> 2017-10-25    valid but wrong  (day/year swapped)
'10/17/2025'       -> 2025-17-10    *** INVALID DATE ***
'31.02.2025'       -> 2025-02-31    *** INVALID DATE ***
```

and confirmed why the invalid ones survive: `pool_files.file_date` is
`character varying`, so Postgres stores them as text without complaint.

### UI walkthrough — Bilagspulje, local docker stack, test tenant `job106`

Four documents in the pool, each saved through the Bilagspulje's own save call
(`extractInvoiceHandler.php`, `action=save`) — the request the pool fires when you accept
the values from an AI scan — then `pool_files` read back. Only the checkout of the
normalizers differed between runs:

| Document | Sent | `file_date` on master | `file_date` after | `norm_amount` after |
|---|---|---|---|---|
| `SST775-A-usformat.pdf` | `10/17/2025` | `2025-17-10` | `2025-10-17` | 1234.560 |
| `SST775-B-umuligdato.pdf` | `31.02.2025` | `2025-02-31` | *empty* | 1234.560 |
| `SST775-C-tocifretaar.pdf` | `17-10-25` | `2017-10-25` | `2025-10-17` | 1234.560 |
| `SST775-D-dansk.pdf` | `17.oktober.2025` + `(1.234,56)` | `2025-10-17` | `2025-10-17` | **−1234.560** |

The pool list renders the corrected dates, and the credit is stored negative.

**Downstream, this was not cosmetic.** Running master's stored values through
`docPool.php`'s `date("d-m-Y", strtotime(...))`:

```
2025-02-31  ->  03-03-2025      journal line posted three days late
2025-17-10  ->  FALSE           journal line posted with no date at all
2017-10-25  ->  25-10-2017      wrong year posted
2025-10-17  ->  17-10-2025      correct - what this PR now stores in all three cases
```

That second date path in `docPool.php` needs no change; it behaves correctly once
`file_date` holds a real date.

### Automated tests — 32 new, both files had none

```
Pool Date Normalizer Characterization        OK (18 tests, 24 assertions)
Pool Amount Normalizer Characterization      OK (14 tests, 20 assertions)
```

They cover the four defects plus the eight date formats and nine amount formats that
already worked, so the fixes cannot regress them. `php -l` clean on all three changed PHP
files.

**Full suite:** `226 tests, 250 assertions, 1 error, 7 failures, 74 skipped`. The error is
`NewlabelCharacterizationTest` (`pg_query(): Argument #1 must be PgSql\Connection, false
given`) and all 7 failures are `UsdecimalCharacterizationTest`. Both are pre-existing on
master — I ran the identical suite against a pristine master checkout to confirm the same
identities, and neither file appears in this diff. (The raw counts differ between runs
because the DB-backed suites skip or error depending on tenant availability, so I compared
which tests fail, not how many.)

### Acceptance criteria — including one that is still failing

| Criterion | Status |
|---|---|
| Failing fixtures produce verified expected values, incl. localized dates and credit/negative amounts | Partly — verified for the defects I found; the *reported* fixtures live in SST-740 and I have not seen them |
| Correctly extracted existing fixtures remain unchanged | Done — 17 previously-working formats pinned |
| Uncertain output reviewable rather than silently posted | Done for dates — an impossible date posts nothing instead of the wrong day |
| **Re-extraction does not overwrite a saved user correction without explicit consent** | **Failing — not fixed here, see below** |
| SQL values cast/escaped, no raw `$_GET`/`$_POST` in SQL | This PR adds no SQL; the save path already routes every value through `db_escape_string()` |
| No dead code; labels via `findtekst()`; one ticket per PR | Done — no user-facing strings added |
| Migration idempotent across tenant DBs | N/A — no schema change |
| Regression report attached | Done — the tests and this description |
| Prodtest evidence tied to original document IDs | **Not done** — the document IDs live in SST-740 |



## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date handling for two-digit years, month-first formats, leap years, and impossible dates.
  * Parenthesized accounting amounts are now correctly recognized as negative credits.
  * Prevented invalid dates from being converted into incorrect journal dates.

* **Refactor**
  * Consolidated date normalization behavior while preserving existing functionality.

* **Tests**
  * Added coverage for date formats, invalid dates, separator handling, and credit amount notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->