### PR TITLE
Dokumenter: Tilføj manglende XML-upload og lokalt UBL-udtræk

### DIFF
--- a/includes/docsIncludes/docPool.php
+++ b/includes/docsIncludes/docPool.php
@@ -43,6 +43,7 @@
 //                 which the very next INSERT/UPDATE in each of those code paths already
 //                 references - a brand-new tenant's first pool file would fail with
 //                 "column norm_amount does not exist". Added the column to both.
+// 20260910 CDX/PHR Enable local UBL XML invoice upload and extraction.
 include_once(__DIR__ . "/poolAmountNormalizer.php");
 /**
  * Log message to a file in temp/$db/docPool.log
@@ -3836,7 +3837,7 @@ JS;
 	print "<div style='padding: 12px;'>";
 	
 	// Unified upload zone (click to select or drag and drop)
-	print "<input id='fileUploadInput' type='file' name='uploadedFile[]' accept='.pdf,.jpg,.jpeg,.png' multiple style='display:none'>";
+	print "<input id='fileUploadInput' type='file' name='uploadedFile[]' accept='.pdf,.jpg,.jpeg,.png,.xml' multiple style='display:none'>";
 	print "<div id='dropZone' ondrop='handleDrop(event)' ondragover='handleDragOver(event)' onclick='document.getElementById(\"fileUploadInput\").click()' style='width: 100%; border: 2px dashed #bbb; border-radius: 10px; padding: 90px 16px; background-color: #f8f8f8; cursor: pointer; transition: all 0.3s ease; box-sizing: border-box; display: flex; align-items: center; justify-content: center; margin-bottom: 12px;'>";
 	print "<div id='dropText' style='display: flex; flex-direction: column; align-items: center; gap: 8px; pointer-events: none; text-align: center;'>";
 	print "<svg viewBox='0 0 24 24' fill='none' stroke='#7ab3d4' stroke-width='1.5' width='44' height='44'><path d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/><polyline points='14 2 14 8 20 8'/><line x1='16' y1='13' x2='8' y2='13'/><line x1='16' y1='17' x2='8' y2='17'/></svg>";
@@ -3874,7 +3875,7 @@ JS;
 	}
 
 	function uploadFiles(files) {
-		var allowedExtensions = ['.pdf', '.jpg', '.jpeg', '.png'];
+		var allowedExtensions = ['.pdf', '.jpg', '.jpeg', '.png', '.xml'];
 		var validFiles = [];
 		for (var i = 0; i < files.length; i++) {
 			var fileName = files[i].name.toLowerCase();

--- a/includes/docsIncludes/invoiceExtractionApi.php
+++ b/includes/docsIncludes/invoiceExtractionApi.php
@@ -2,6 +2,7 @@
 // --- includes/docsIncludes/invoiceExtractionApi.php -----
 // Helper functions for invoice extraction API integration
 
+// 20260910 CDX/PHR Enable local UBL XML invoice upload and extraction.
 function invoiceExtractionApiResolveApiKey() {
 	if (!function_exists('db_select') || !function_exists('db_fetch_array')) {
 		error_log("Invoice extraction API key lookup is unavailable");
@@ -53,13 +54,113 @@ function invoiceExtractionApiDependencies() {
 }
 
 /**
- * Extract invoice data from a PDF or image file using the external API.
+ * Extract standard invoice fields from an OIOUBL or Peppol UBL XML document.
  *
- * @param string $filePath Full path to the PDF or image file (jpg, jpeg, png)
+ * @param string $filePath Full path to the XML document.
+ * @return array{
+ *   amount: string|null,
+ *   date: string|null,
+ *   vendor: string|null,
+ *   invoiceNumber: string|null,
+ *   description: string|null,
+ *   currency: string|null
+ * }|null SALDI invoice fields, or null when the XML is not a supported UBL invoice.
+ */
+function extractUblInvoiceData($filePath) {
+	$xmlContent = file_get_contents($filePath);
+	if ($xmlContent === false || trim($xmlContent) === '') {
+		error_log("UBL invoice XML is empty or unreadable: $filePath");
+		return null;
+	}
+	if (stripos($xmlContent, '<!DOCTYPE') !== false || stripos($xmlContent, '<!ENTITY') !== false) {
+		error_log("UBL invoice XML contains a prohibited document type or entity declaration: $filePath");
+		return null;
+	}
+
+	$previousUseInternalErrors = libxml_use_internal_errors(true);
+	$document = new DOMDocument();
+	$loaded = $document->loadXML($xmlContent, LIBXML_NONET | LIBXML_NOBLANKS | LIBXML_COMPACT);
+	libxml_clear_errors();
+	libxml_use_internal_errors($previousUseInternalErrors);
+	if (!$loaded || !$document->documentElement) {
+		error_log("Failed to parse UBL invoice XML: $filePath");
+		return null;
+	}
+
+	$documentType = $document->documentElement->localName;
+	if (!in_array($documentType, array('Invoice', 'CreditNote'), true)) {
+		error_log("Unsupported UBL XML document type: $documentType (file: $filePath)");
+		return null;
+	}
+
+	$xpath = new DOMXPath($document);
+	$getValue = function ($expression) use ($xpath) {
+		$nodes = $xpath->query($expression);
+		if (!$nodes || $nodes->length === 0) return null;
+		$value = trim($nodes->item(0)->textContent);
+		return $value !== '' ? $value : null;
+	};
+
+	$invoiceNumber = $getValue('/*[local-name()="Invoice" or local-name()="CreditNote"]/*[local-name()="ID"][1]');
+	$date = $getValue('/*[local-name()="Invoice" or local-name()="CreditNote"]/*[local-name()="IssueDate"][1]');
+	$vendor = $getValue('/*/*[local-name()="AccountingSupplierParty"]//*[local-name()="PartyName"]/*[local-name()="Name"][1]');
+	if ($vendor === null) {
+		$vendor = $getValue('/*/*[local-name()="AccountingSupplierParty"]//*[local-name()="PartyLegalEntity"]/*[local-name()="RegistrationName"][1]');
+	}
+
+	$amountNodes = $xpath->query('/*/*[local-name()="LegalMonetaryTotal"]/*[local-name()="PayableAmount"][1]');
+	$amount = null;
+	$currency = null;
+	if ($amountNodes && $amountNodes->length > 0) {
+		$amountNode = $amountNodes->item(0);
+		$amount = trim($amountNode->textContent);
+		if ($amount === '') $amount = null;
+		$currency = trim($amountNode->getAttribute('currencyID'));
+		if ($currency === '') $currency = null;
+	}
+	if ($currency === null) {
+		$currency = $getValue('/*/*[local-name()="DocumentCurrencyCode"][1]');
+	}
+
+	$descriptionValues = array();
+	$descriptionNodes = $xpath->query('/*/*[local-name()="InvoiceLine" or local-name()="CreditNoteLine"]/*[local-name()="Item"]/*[local-name()="Name" or local-name()="Description"]');
+	if ($descriptionNodes) {
+		foreach ($descriptionNodes as $descriptionNode) {
+			$value = trim($descriptionNode->textContent);
+			if ($value !== '' && !in_array($value, $descriptionValues, true)) $descriptionValues[] = $value;
+		}
+	}
+	if (empty($descriptionValues)) {
+		$note = $getValue('/*/*[local-name()="Note"][1]');
+		if ($note !== null) $descriptionValues[] = $note;
+	}
+	$description = !empty($descriptionValues) ? implode('; ', $descriptionValues) : null;
+
+	if ($amount === null && $date === null && $vendor === null && $invoiceNumber === null && $description === null && $currency === null) {
+		return null;
+	}
+
+	return array(
+		'amount' => $amount,
+		'date' => $date,
+		'vendor' => $vendor,
+		'invoiceNumber' => $invoiceNumber,
+		'description' => $description,
+		'currency' => $currency
+	);
+}
+
+/**
+ * Extract invoice data locally from UBL XML or through the external API for PDF/images.
+ *
+ * @param string $filePath Full path to an XML, PDF, or image file (jpg, jpeg, png).
  * @param string $invoiceId Unique ID for the invoice (e.g., "invoice-001")
  * @return array|null Returns SALDI invoice fields on success, null on failure
  */
 function extractInvoiceData($filePath, $invoiceId = null) {
+	$fileExt = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+	if ($fileExt === 'xml') return extractUblInvoiceData($filePath);
+
 	$dependencies = invoiceExtractionApiDependencies();
 	$keyResolver = isset($dependencies['key_resolver']) && is_callable($dependencies['key_resolver'])
 		? $dependencies['key_resolver']
@@ -73,7 +174,6 @@ function extractInvoiceData($filePath, $invoiceId = null) {
 		return null;
 	}
 
-	$fileExt = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
 	$allowedTypes = array('pdf', 'jpg', 'jpeg', 'png');
 	if (!in_array($fileExt, $allowedTypes)) {
 		error_log("Unsupported file type for invoice extraction: $fileExt (file: $filePath)");

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -33,7 +33,7 @@
 // 20260910 CL/NTR Pool upload and vendor+date rename now reserve their target name atomically
 //                  via FileReservation instead of file_exists() polling, closing the window in
 //                  which two concurrent uploads could pick the same name (SST-776 follow-up).
-
+// 20260910 CDX/PHR Enable local UBL XML invoice upload and extraction.
 @session_start();
 $s_id=session_id();
 $css="../css/std.css";
@@ -137,7 +137,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 	}
 	
 	if ($isAjax || $openPool) {
-		$allowedTypes = array('jpg','jpeg','pdf','png');
+		$allowedTypes = array('jpg','jpeg','pdf','png','xml');
 		$fileName = basename($_FILES['uploadedFile']['name']);
 		
 		// Get file type from MIME type
@@ -166,6 +166,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 			// Sanitize filename
 			$baseName = pathinfo($fileName, PATHINFO_FILENAME);
 			$ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+			$storedExt = $ext === 'xml' ? 'xml' : 'pdf';
 			// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 			$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 			$baseName = sanitize_filename($baseName);
@@ -175,7 +176,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 			// concurrent uploads with the same name can't both settle on it (SST-776). Sibling
 			// extensions count as taken too, so a leftover "scan.jpg" or "scan.info" also bumps
 			// us to "scan_1". $targetFile is an empty placeholder until the upload lands on it.
-			$reservation = FileReservation::reserve($poolDir, $baseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+			$reservation = FileReservation::reserve($poolDir, $baseName, $storedExt, ['pdf', 'jpg', 'jpeg', 'png', 'xml', 'info']);
 			if ($reservation === null) {
 				error_log("documents.php (AJAX): could not reserve a pool filename for '$baseName' in $poolDir");
 				header('Content-Type: application/json');
@@ -221,13 +222,13 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 					}
 				}
 			} else {
-				// For PDF files, move directly onto the placeholder (rename = atomic replace)
+				// Move PDF and XML files unchanged onto the reserved placeholder.
 				if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile)) {
 					$reservation->discard();
 				}
-				// Extract data from PDF
+				// Extract PDF data through the API or UBL XML data locally.
 				if ($autoExtract && file_exists($targetFile)) {
-					error_log("documents.php (AJAX): Calling extractInvoiceData for PDF: $targetFile");
+					error_log("documents.php (AJAX): Calling extractInvoiceData for document: $targetFile");
 					$invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
 					$extractedData = extractInvoiceData($targetFile, $invoiceId);
 					if ($extractedData) {
@@ -274,19 +275,19 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				// Rename file if we have a new name - reserve the new name atomically first,
 				// then rename onto the placeholder (same race as the upload dedup above)
 				if ($newBaseName !== $baseName) {
-					$renameReservation = FileReservation::reserve($poolDir, $newBaseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+					$renameReservation = FileReservation::reserve($poolDir, $newBaseName, $storedExt, ['pdf', 'jpg', 'jpeg', 'png', 'xml', 'info']);
 					if ($renameReservation === null) {
-						error_log("documents.php (AJAX): could not reserve a pool filename for '$newBaseName' in $poolDir, keeping $baseName.pdf");
+						error_log("documents.php (AJAX): could not reserve a pool filename for '$newBaseName' in $poolDir, keeping $baseName.$storedExt");
 					} else {
 						$newBaseName = $renameReservation->baseName();
 						$newTargetFile = $renameReservation->path();
 						if (rename($targetFile, $newTargetFile)) {
 							$targetFile = $newTargetFile;
 							$baseName = $newBaseName;
-							error_log("documents.php (AJAX): Renamed file to: $newBaseName.pdf");
+							error_log("documents.php (AJAX): Renamed file to: $newBaseName.$storedExt");
 						} else {
 							$renameReservation->discard();
-							error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.pdf");
+							error_log("documents.php (AJAX): Failed to rename file to: $newBaseName.$storedExt");
 						}
 					}
 				}
@@ -364,7 +365,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				
 				// Save extracted currency directly to pool_files (currency not stored in .info files)
 				if ($extractedData !== null && !empty($extractedData['currency'])) {
-					$uploadFilename = $baseName . '.pdf';
+					$uploadFilename = $baseName . '.' . $storedExt;
 					$uploadCurrency = $extractedData['currency'];
 					$qtxt = "SELECT id FROM pool_files WHERE filename = '" . db_escape_string($uploadFilename) . "'";
 					$existingRow = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
@@ -379,7 +380,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && !empty($_FILES['
 				echo json_encode([
 					'success' => true,
 					'message' => 'File uploaded successfully',
-					'filename' => $baseName . '.pdf',
+					'filename' => $baseName . '.' . $storedExt,
 					'extracted' => $extractedData
 				]);
 				exit;
@@ -570,10 +571,11 @@ if (!$isModernLayout) {
 // Handle file uploads for pool view
 // Allow uploads when sourceId is set OR when openPool is set (for new pool uploads)
 if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $openPool)) {
-	$fileTypes = array('jpg','jpeg','pdf','png');
+	$fileTypes = array('jpg','jpeg','pdf','png','xml');
 	$fileName = basename($_FILES['uploadedFile']['name']);
 	list($tmp,$fileType) = explode("/",$_FILES['uploadedFile']['type']);
-	if (in_array(strtolower($fileType),$fileTypes)) {
+	$fileExt = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+	if (in_array(strtolower($fileType),$fileTypes) || in_array($fileExt, $fileTypes)) {
 		$poolDir = "$docFolder/$db/pulje";
 		if (!is_dir($poolDir)) {
 			mkdir($poolDir, 0755, true);
@@ -581,6 +583,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 		// Sanitize filename
 		$baseName = pathinfo($fileName, PATHINFO_FILENAME);
 		$ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+		$storedExt = $ext === 'xml' ? 'xml' : 'pdf';
 		// Remove .pdf suffix from baseName if present (handles files like "document.pdf.jpg")
 		$baseName = preg_replace('/\.pdf$/i', '', $baseName);
 		$baseName = sanitize_filename($baseName);
@@ -590,7 +593,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 		// concurrent uploads with the same name can't both settle on it (SST-776). Sibling
 		// extensions count as taken too, so a leftover "scan.jpg" or "scan.info" also bumps
 		// us to "scan_1". $targetFile is an empty placeholder until the upload lands on it.
-		$reservation = FileReservation::reserve($poolDir, $baseName, 'pdf', ['pdf', 'jpg', 'jpeg', 'png', 'info']);
+		$reservation = FileReservation::reserve($poolDir, $baseName, $storedExt, ['pdf', 'jpg', 'jpeg', 'png', 'xml', 'info']);
 		if ($reservation === null) {
 			error_log("documents.php (block2): could not reserve a pool filename for '$baseName' in $poolDir");
 			$targetFile = '';
@@ -637,13 +640,13 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 				}
 			}
 		} else {
-			// For PDF files, move directly onto the placeholder (rename = atomic replace)
+			// Move PDF and XML files unchanged onto the reserved placeholder.
 			if (!move_uploaded_file($_FILES['uploadedFile']['tmp_name'], $targetFile)) {
 				$reservation->discard();
 			}
-			// Extract data from PDF
+			// Extract PDF data through the API or UBL XML data locally.
 			if ($autoExtract && file_exists($targetFile)) {
-				error_log("documents.php (block2): Calling extractInvoiceData for PDF: $targetFile");
+				error_log("documents.php (block2): Calling extractInvoiceData for document: $targetFile");
 				$invoiceId = 'invoice-' . time() . '-' . rand(1000, 9999);
 				$extractedData = extractInvoiceData($targetFile, $invoiceId);
 				if ($extractedData) {
@@ -732,7 +735,7 @@ if (isset($_FILES) && isset($_FILES['uploadedFile']['name']) && ($sourceId || $o
 				"kladde_id=$kladde_id"."&".
 				"bilag=$bilag"."&".
 				"fokus=$fokus"."&".
-				"poolFile=$baseName.pdf"."&".
+				"poolFile=$baseName.$storedExt"."&".
 				"docFolder=$docFolder"."&".
 				"sourceId=$sourceId"."&".
 				"source=$source";

--- a/tests/test_invoice_extraction_api.php
+++ b/tests/test_invoice_extraction_api.php
@@ -1,4 +1,5 @@
 <?php
+// 20260910 CDX/PHR Cover local UBL extraction without an API key and reject unsafe XML.
 /**
  * Focused tests for includes/docsIncludes/invoiceExtractionApi.php.
  * Run: php tests/test_invoice_extraction_api.php
@@ -35,6 +36,18 @@ mkdir($tempDir);
 $pdfPath = $tempDir . '/invoice.pdf';
 $pdfBytes = "%PDF-1.7\npage-one\fpage-two\n%%EOF";
 file_put_contents($pdfPath, $pdfBytes);
+$xmlPath = $tempDir . '/invoice.xml';
+$xmlBytes = '<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017</cbc:CustomizationID>
+  <cbc:ID>INV-42</cbc:ID>
+  <cbc:IssueDate>2026-07-23</cbc:IssueDate>
+  <cbc:DocumentCurrencyCode>DKK</cbc:DocumentCurrencyCode>
+  <cac:AccountingSupplierParty><cac:Party><cac:PartyName><cbc:Name>Leverandør ApS</cbc:Name></cac:PartyName></cac:Party></cac:AccountingSupplierParty>
+  <cac:LegalMonetaryTotal><cbc:PayableAmount currencyID="DKK">1250.00</cbc:PayableAmount></cac:LegalMonetaryTotal>
+  <cac:InvoiceLine><cac:Item><cbc:Name>Konsulentydelse</cbc:Name></cac:Item></cac:InvoiceLine>
+</Invoice>';
+file_put_contents($xmlPath, $xmlBytes);
 
 $dbSelectCalls = array();
 $dbSelectResult = array('var_value' => 'global-key');
@@ -66,6 +79,30 @@ $invoiceExtractionApiDependencies = array(
 	'key_resolver' => function () { return null; },
 	'transport' => function () use (&$transportCalls) { $transportCalls++; return array(); }
 );
+$xmlResult = extractInvoiceData($xmlPath, 'xml-test');
+check($xmlResult === array('amount' => '1250.00', 'date' => '2026-07-23', 'vendor' => 'Leverandør ApS', 'invoiceNumber' => 'INV-42', 'description' => 'Konsulentydelse', 'currency' => 'DKK'), 'extracts standard OIOUBL/Peppol fields locally');
+check($transportCalls === 0, 'does not call the AI transport for XML invoices');
+
+$unsafeXmlPath = $tempDir . '/unsafe.xml';
+file_put_contents($unsafeXmlPath, '<!DOCTYPE Invoice [<!ENTITY secret SYSTEM "file:///etc/passwd">]><Invoice>&secret;</Invoice>');
+check(extractInvoiceData($unsafeXmlPath, 'unsafe-xml') === null, 'rejects XML document type and entity declarations');
+
+$creditXml = str_replace(array('<Invoice ', '</Invoice>', 'InvoiceLine', '<cac:PartyName><cbc:Name>Leverandør ApS</cbc:Name></cac:PartyName>'), array('<CreditNote ', '</CreditNote>', 'CreditNoteLine', '<cac:PartyLegalEntity><cbc:RegistrationName>Leverandør ApS</cbc:RegistrationName></cac:PartyLegalEntity>'), $xmlBytes);
+$creditXml = str_replace(array('currencyID="DKK"', 'xsd:Invoice-2'), array('', 'xsd:CreditNote-2'), $creditXml);
+file_put_contents($xmlPath, $creditXml);
+check(extractInvoiceData($xmlPath) === $xmlResult, 'extracts credit note fields with legal-name and currency fallbacks');
+file_put_contents($xmlPath, '<Invoice>');
+check(extractInvoiceData($xmlPath) === null, 'rejects malformed XML');
+file_put_contents($xmlPath, '<Order><ID>42</ID></Order>');
+check(extractInvoiceData($xmlPath) === null, 'rejects unsupported XML document types');
+file_put_contents($xmlPath, '');
+check(extractInvoiceData($xmlPath) === null, 'rejects empty XML');
+
+$transportCalls = 0;
+$invoiceExtractionApiDependencies = array(
+	'key_resolver' => function () { return null; },
+	'transport' => function () use (&$transportCalls) { $transportCalls++; return array(); }
+);
 check(extractInvoiceData($pdfPath, 'missing-key') === null && $transportCalls === 0, 'does not call transport without an API key');
 
 foreach (array(
@@ -80,8 +117,15 @@ foreach (array(
 	check(extractInvoiceData($pdfPath, 'failure-test') === null, "returns null for $label");
 }
 
+require_once(__DIR__ . '/../includes/docsIncludes/FileReservation.php');
+$xmlReservation = FileReservation::reserve($tempDir, 'invoice', 'xml', array('pdf', 'jpg', 'jpeg', 'png', 'xml', 'info'));
+check($xmlReservation !== null && $xmlReservation->baseName() === 'invoice_1' && $xmlReservation->ext() === 'xml', 'preserves XML extension when an upload filename is already taken');
+if ($xmlReservation !== null) $xmlReservation->discard();
+
 unset($invoiceExtractionApiDependencies);
 unlink($pdfPath);
+unlink($xmlPath);
+unlink($unsafeXmlPath);
 rmdir($tempDir);
 
 echo "\nResults: $passed passed, $failed failed\n";


### PR DESCRIPTION
## What are the changes about?
XML-fakturaer kunne udtrækkes i den lokale installation, men understøttelsen manglede på master: uploadvælgeren accepterede ikke XML, uploadforløbet gemte altid som PDF, og extractInvoiceData havde ingen lokal UBL-parser.

Tilføjer den lokale OIOUBL/Peppol UBL-udtrækning af beløb, dato, leverandør, fakturanummer, beskrivelse og valuta. XML behandles før opslag af API-nøgle og sendes ikke til AI-tjenesten. Invoice og CreditNote understøttes; fejlformet XML samt DOCTYPE/entity-deklarationer afvises. Dette er feltudtrækning, ikke fuld UBL-skemavalidering.

XML tillades i filvælger og drag/drop samt begge uploadforløb. Filtypen bevares i lagring, omdøbning, metadata og uploadsvaret. Integreret med masters nyere FileReservation, så beskyttelsen mod overskrivning ved navnesammenfald bevares, også mellem XML og PDF.

## Validering
- `php tests/test_invoice_extraction_api.php`: 21 bestået. Omfatter XML uden API-nøgle, faktura/kreditnota, fallback for leverandørnavn og valuta, ugyldig XML, navnekollision samt eksisterende PDF/API-forløb.
- `php tests/test_doc_pool_upload_exactly_once.php`: 11 bestået.
- PHP-syntakskontrol for alle fire ændrede filer og `git diff --check` bestået.
- Ingen ekstern AI-tjeneste eller databaseændringer brugt i testene. Browserforløbene nedenfor er ikke gennemført.

## Manuel kontrol ved review
- `includes/docsIncludes/docPool.php`: Upload samme UBL-fil via filvælger og drag/drop. Kontrollér, at XML accepteres, og at metadata kun gemmes én gang.
- `includes/documents.php`: Kontrollér, at filen fortsat hedder `.xml`, og at beløb, dato, fakturanummer, beskrivelse og valuta følger med. Genåbn dokumentet fra puljen. Gentag med to filer med samme navn og med samme leverandør/dato; begge dokumenter skal bevares med forskellige navne.
- `includes/docsIncludes/invoiceExtractionApi.php`: Upload en UBL-faktura uden API-nøgle med automatisk udtræk slået til. Kontrollér felterne, og gentag med automatisk udtræk slået fra. Kontrollér også PDF/JPG-upload med normal API-konfiguration.
- Kontrollér både den moderne pulje/AJAX-upload og det ældre uploadforløb fra en bilagstilknytning.

## Have you checked the following?
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
