### PR TITLE
Sz/fix/sst 755 lock release owner tidspkt matching

### DIFF
--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -109,9 +109,13 @@
 // 20260907 CDX/LH Keep counter-account types in suggestions and match posted duplicates in base currency
 //                  with customer/supplier evidence; isolate journal history queries for regression tests.
 
+// 20260908 SZ SST-755: every exit path (Tilbage/Luk/Ny) now releases the lock through
+//                  includes/luk.php instead of the dead/conditional exitDraft links, and an
+//                  unload/pagehide beacon was added (there was none before).
+
 require_once __DIR__ . '/kassekladde_includes/journalHistory.php';
 
-ob_start(); //Starter output buffering  
+ob_start(); //Starter output buffering
 
 register_shutdown_function(function() {
     $e = error_get_last();
@@ -1573,6 +1577,18 @@ if ($kladde_id) {
 	$kladdenote = htmlentities(stripslashes($row['kladdenote']), ENT_QUOTES, $charset);
 	$bogfort = $row['bogfort'];
 }
+
+// 20260908 SZ SST-755: every exit path (Tilbage/Luk/Ny) now releases the lock through
+// includes/luk.php with the row's *current* DB tidspkt, instead of the old exitDraft links
+// (dead for the "Ny" button, since kassekladde.php never read exitDraft; and skipped entirely
+// whenever the back target wasn't kladdeliste.php). $kladdeLukBase is reused below for every
+// exit link, with &returside=<target> appended per link.
+$lockTidspkt = NULL;
+if ($kladde_id) {
+	$lockRow = db_fetch_array(db_select("select tidspkt from kladdeliste where id=" . (int)$kladde_id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($lockRow && $lockRow['tidspkt'] !== '' && $lockRow['tidspkt'] !== null) $lockTidspkt = $lockRow['tidspkt'];
+}
+$kladdeLukBase = "../includes/luk.php?tabel=kladdeliste&id=" . (int)$kladde_id . ($lockTidspkt !== null ? "&tidspkt=" . urlencode($lockTidspkt) : "");
 $x = 0;
 ($visipop) ? $ny = NULL : $ny = findtekst('39|Ny', $sprog_id); #20210628
 
@@ -1603,10 +1619,10 @@ if (!$simuler) {
 
 			$tekst = findtekst('154|Dine ændringer er ikke blevet gemt! Tryk OK for at forlade siden uden at gemme.', $sprog_id);
 			print "<div id='header'>";
-			$backTarget = $backUrl != '../finans/kladdeliste.php' ? $backUrl : "../finans/kladdeliste.php?exitDraft=$kladde_id&line=". __line__ .";";
+			$backTarget = $kladdeLukBase . "&returside=" . urlencode($backUrl);
 			print "<div class='headerbtnLft headLink'><a href=\"javascript:confirmClose('" . htmlspecialchars($backTarget, ENT_QUOTES, $charset) . "','$tekst')\" accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i> &nbsp;" . findtekst('30|Tilbage', $sprog_id) . "</a></div>";
 			print "<div class='headerTxt'>$title &nbsp;•&nbsp; $kladde_id</div>";
-			print "<div class='headerbtnRght headLink'><a accesskey=N href=\"javascript:confirmClose('../finans/kassekladde.php?exitDraft=$kladde_id&line=". __line__ .";','$tekst')\" title='TEXTHERE'><i class='fa fa-plus-square fa-lg'></i></a></div>";
+			print "<div class='headerbtnRght headLink'><a accesskey=N href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase . "&returside=" . urlencode('../finans/kassekladde.php'), ENT_QUOTES, $charset) . "','$tekst')\" title='TEXTHERE'><i class='fa fa-plus-square fa-lg'></i></a></div>";
 			print "</div>";
 			print "<div class='content-noside'>";
 
@@ -1619,14 +1635,12 @@ if (!$simuler) {
 			else print "<td $top_bund>";
 			$tekst = findtekst('154|Dine ændringer er ikke blevet gemt! Tryk OK for at forlade siden uden at gemme.', $sprog_id);
 			if ($popup || $visipop) {
-				print "<a href=\"javascript:confirmClose('../includes/luk.php?tabel=kladdeliste&amp;id=$kladde_id&exitDraft=$kladde_id&line=". __line__ .";','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
-			} elseif ($backUrl != '../finans/kladdeliste.php') {
-				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($backUrl, ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
+				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase, ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
 			} else {
-				print "<a href=\"javascript:confirmClose('../finans/kladdeliste.php?exitDraft=$kladde_id&line=". __line__ .";','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
+				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase . "&returside=" . urlencode($backUrl), ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
 			}
 			print "<td width='80%' $top_bund> " . findtekst('1072|Kassekladde', $sprog_id) . "  $kladde_id</td>";
-			print "<td width='10%' $top_bund align='right'><a href=\"javascript:confirmClose('../finans/kassekladde.php?exitDraft=$kladde_id&line=". __line__ .";','$tekst')\" accesskey='N'>$ny</a></td></tr>";
+			print "<td width='10%' $top_bund align='right'><a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase . "&returside=" . urlencode('../finans/kassekladde.php'), ENT_QUOTES, $charset) . "','$tekst')\" accesskey='N'>$ny</a></td></tr>";
 			print "</tbody></table>"; # Tabel 1.1 <- Toplinje
 			print "</td></tr>\n";
 		}
@@ -5527,4 +5541,57 @@ document.addEventListener('DOMContentLoaded', function() {
 	});
 </script>
 
-<?php ?>
+<?php
+// 20260908 SZ SST-755: kassekladde had no unload/pagehide release at all. Re-read the lock
+// fresh here (not the earlier $lockTidspkt) since $kladde_id can change later in this script
+// (e.g. a newly created kladde) - the beacon must reference whatever is actually locked by the
+// time the page finishes rendering.
+$beaconKladdeId = (int)if_isset($kladde_id, 0);
+$beaconTidspkt = NULL;
+if ($beaconKladdeId) {
+	$beaconRow = db_fetch_array(db_select("select tidspkt from kladdeliste where id=" . $beaconKladdeId . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($beaconRow && $beaconRow['tidspkt'] !== '' && $beaconRow['tidspkt'] !== null) $beaconTidspkt = $beaconRow['tidspkt'];
+}
+if ($beaconTidspkt) {
+?>
+<script>
+let isSubmittingKassekladde = false;
+// 20260908 SZ SST-755: a plain addEventListener("submit", ...) misses any form.submit() called
+// directly from JS (kopierForm.submit(), document.getElementById('kassekladde').submit(), etc.
+// further up this file) - per DOM spec, calling .submit() does NOT fire the submit event, only a
+// real user-click/requestSubmit() does. That gap let normal in-page actions (delete line, copy to
+// new) look like the user leaving, so the beforeunload beacon released the lock mid-edit. Catch
+// both: a document-level listener for genuine submit events (also covers forms added after this
+// script ran), and a prototype patch for direct .submit() calls that bypass the event entirely.
+document.addEventListener("submit", function () { isSubmittingKassekladde = true; }, true);
+(function () {
+    var nativeFormSubmit = HTMLFormElement.prototype.submit;
+    HTMLFormElement.prototype.submit = function () {
+        isSubmittingKassekladde = true;
+        return nativeFormSubmit.apply(this, arguments);
+    };
+})();
+function unlockKassekladdeBeacon(evtName) {
+    if (!isSubmittingKassekladde && !window.kassekladdeUnlocked) {
+        window.kassekladdeUnlocked = true;
+        let data = new URLSearchParams();
+        data.append("table", "kladdeliste");
+        data.append("id", "<?php echo $beaconKladdeId; ?>");
+        data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
+        data.append("event", evtName);
+        if (navigator.sendBeacon) {
+            navigator.sendBeacon("../includes/unlock_order.php", data);
+        } else {
+            let xhr = new XMLHttpRequest();
+            xhr.open('POST', '../includes/unlock_order.php', false);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            xhr.send(data.toString());
+        }
+    }
+}
+window.addEventListener("beforeunload", function() { unlockKassekladdeBeacon('beforeunload'); });
+window.addEventListener("pagehide", function() { unlockKassekladdeBeacon('pagehide'); });
+</script>
+<?php
+}
+?>

--- a/finans/kassekladde.php
+++ b/finans/kassekladde.php
@@ -112,6 +112,9 @@
 // 20260908 SZ SST-755: every exit path (Tilbage/Luk/Ny) now releases the lock through
 //                  includes/luk.php instead of the dead/conditional exitDraft links, and an
 //                  unload/pagehide beacon was added (there was none before).
+// 20260910 SZ SST-755 (CodeRabbit): popup/visipop Luk link now carries a returside fallback
+//                  too, and the unload beacon checks sendBeacon()'s return value before
+//                  treating the lock as released, falling back to the sync XHR when it fails.
 
 require_once __DIR__ . '/kassekladde_includes/journalHistory.php';
 
@@ -1635,7 +1638,7 @@ if (!$simuler) {
 			else print "<td $top_bund>";
 			$tekst = findtekst('154|Dine ændringer er ikke blevet gemt! Tryk OK for at forlade siden uden at gemme.', $sprog_id);
 			if ($popup || $visipop) {
-				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase, ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
+				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase . "&returside=" . urlencode($backUrl), ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
 			} else {
 				print "<a href=\"javascript:confirmClose('" . htmlspecialchars($kladdeLukBase . "&returside=" . urlencode($backUrl), ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>" . findtekst('30|Tilbage', $sprog_id) . "</a></td>";
 			}
@@ -5573,20 +5576,22 @@ document.addEventListener("submit", function () { isSubmittingKassekladde = true
 })();
 function unlockKassekladdeBeacon(evtName) {
     if (!isSubmittingKassekladde && !window.kassekladdeUnlocked) {
-        window.kassekladdeUnlocked = true;
         let data = new URLSearchParams();
         data.append("table", "kladdeliste");
         data.append("id", "<?php echo $beaconKladdeId; ?>");
         data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
         data.append("event", evtName);
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon("../includes/unlock_order.php", data);
-        } else {
+        // sendBeacon() can return false (queue full/rejected) without sending anything - only
+        // treat the lock as released, and skip the sync XHR fallback, once one of the two has
+        // actually gone out (CodeRabbit).
+        let queued = navigator.sendBeacon && navigator.sendBeacon("../includes/unlock_order.php", data);
+        if (!queued) {
             let xhr = new XMLHttpRequest();
             xhr.open('POST', '../includes/unlock_order.php', false);
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
             xhr.send(data.toString());
         }
+        window.kassekladdeUnlocked = true;
     }
 }
 window.addEventListener("beforeunload", function() { unlockKassekladdeBeacon('beforeunload'); });

--- a/finans/kassekladde_includes/topLineKassekladde.php
+++ b/finans/kassekladde_includes/topLineKassekladde.php
@@ -25,6 +25,8 @@
 // 20260126 PHR fixed $exitDraft
 // 20260904 Sawaneh Gear button for the Customize view panel added next to 'Ny' (editable journals only);
 //                  the panel itself and its logic live in kassekladde.php.
+// 20260908 SZ SST-755: Back/Ny now release the lock through includes/luk.php unconditionally,
+//           instead of exitDraft (which only fired when the back target equaled kladdeliste.php).
 
 $border = 'border:1px';
 $TableBG = "bgcolor=$bgcolor";
@@ -42,7 +44,10 @@ print "<tr><td height='25' align='center' valign='top' class='top-header'>";
 print "<table class='topLine' width='100%' align='center' border='0' cellspacing='2' cellpadding='0'><tbody><tr class='header-row'>"; # Tabel 1.1 ->
 
 # Back button
-$backTargetS = ($backUrl == '../finans/kladdeliste.php') ? "$backUrl?exitDraft=$kladde_id&line=". __line__ : $backUrl;
+// 20260908 SZ SST-755: release the lock through includes/luk.php (with the row's current
+// tidspkt) regardless of the back target, instead of only when $backUrl happened to equal
+// kladdeliste.php - see finans/kassekladde.php for $kladdeLukBase.
+$backTargetS = isset($kladdeLukBase) ? $kladdeLukBase . "&returside=" . urlencode($backUrl) : $backUrl;
 print "<td width=5% style='$buttonStyle'>
 	<a href=\"javascript:confirmClose('" . htmlspecialchars($backTargetS, ENT_QUOTES, $charset) . "','$tekst')\" accesskey='L'>
 	<button class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">
@@ -86,8 +91,9 @@ print "<button class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\
 print $help_icon;
 print findtekst('2564|Hjælp', $sprog_id)."</button></td>";
 
+$createNewTarget = isset($kladdeLukBase) ? $kladdeLukBase . "&returside=" . urlencode('../finans/kassekladde.php') : '../finans/kassekladde.php';
 print "<td id='create-new' width='5%' style='$buttonStyle'>
-	<a href=\"javascript:confirmClose('../finans/kassekladde.php?exitDraft=$kladde_id','$tekst')\" accesskey='N'>
+	<a href=\"javascript:confirmClose('" . htmlspecialchars($createNewTarget, ENT_QUOTES, $charset) . "','$tekst')\" accesskey='N'>
 	<button class='center-btn' style='$buttonStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">
 		$add_icon ".
 		findtekst('39|Ny', $sprog_id)."

--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -38,6 +38,10 @@
 // 20260904 Sawaneh WP-1.4: pass GET returside (sanitised) to topLineFinans; exitDraft cast to int
 // 20260908 SZ SST-755: exitDraft's release now also requires hvem to still match the
 //                  current user, so it can't clear a lock a different user has since taken.
+// 20260910 SZ SST-755 (CodeRabbit): removed the exitDraft release entirely - it still let a
+//                  stale tab clobber a lock a newer tab had since acquired (no tidspkt check),
+//                  and every real caller now goes through includes/luk.php instead (confirmed
+//                  no remaining ?exitDraft= link generator anywhere in the codebase).
 
 @session_start();
 $s_id=session_id();
@@ -201,12 +205,6 @@ print "<script LANGUAGE=\"JavaScript\" SRC=\"../javascript/jquery-3.6.4.min.js\"
 print "<script LANGUAGE=\"JavaScript\" SRC=\"../javascript/moment.min.js\"></script>";
 print "<script LANGUAGE=\"JavaScript\" SRC=\"../javascript/daterangepicker.min.js\" defer></script>";
 print '<link rel="stylesheet" type="text/css" href="../css/daterangepicker.css" />';
-
-$exitDraft = isset($_GET['exitDraft']) ? (int)$_GET['exitDraft'] : null;
-if ($exitDraft) {
-	$qtxt = "update kladdeliste set hvem = '', tidspkt = NULL where id = '$exitDraft' and hvem = '$brugernavn'";
-	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-}
 
 if (strpos(findtekst('639|Kladdeliste', $sprog_id),'undtrykke')) {
 	$qtxt = "update tekster set tekst = '' where tekst_id >= '600'";

--- a/finans/kladdeliste.php
+++ b/finans/kladdeliste.php
@@ -36,6 +36,8 @@
 // 20260126 PHR fixed $exitDraft
 // 20260706 MJ Optimized cash journal list entry counts for large databases.
 // 20260904 Sawaneh WP-1.4: pass GET returside (sanitised) to topLineFinans; exitDraft cast to int
+// 20260908 SZ SST-755: exitDraft's release now also requires hvem to still match the
+//                  current user, so it can't clear a lock a different user has since taken.
 
 @session_start();
 $s_id=session_id();
@@ -202,7 +204,7 @@ print '<link rel="stylesheet" type="text/css" href="../css/daterangepicker.css" 
 
 $exitDraft = isset($_GET['exitDraft']) ? (int)$_GET['exitDraft'] : null;
 if ($exitDraft) {
-	$qtxt = "update kladdeliste set hvem = '', tidspkt = NULL where id = '$exitDraft'";
+	$qtxt = "update kladdeliste set hvem = '', tidspkt = NULL where id = '$exitDraft' and hvem = '$brugernavn'";
 	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 }
 

--- a/finans/ordre.php
+++ b/finans/ordre.php
@@ -18,6 +18,8 @@
 // ----------------------------------------------------------------------
 // 20260908 SZ SST-755: popup close/beacon now releases the lock properly (was missing
 // id/tabel params entirely, and there was no unload beacon at all).
+// 20260910 SZ SST-755 (CodeRabbit): the unload beacon now checks sendBeacon()'s return value
+// before treating the lock as released, falling back to the sync XHR when it fails.
 
 @session_start();
 $s_id=session_id();
@@ -1974,20 +1976,22 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 function unlockFinansOrdreBeacon(evtName) {
     if (!isSubmittingFinansOrdre && !window.finansOrdreUnlocked) {
-        window.finansOrdreUnlocked = true;
         let data = new URLSearchParams();
         data.append("table", "ordrer");
         data.append("id", "<?php echo (int)$id; ?>");
         data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
         data.append("event", evtName);
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon("../includes/unlock_order.php", data);
-        } else {
+        // sendBeacon() can return false (queue full/rejected) without sending anything - only
+        // treat the lock as released, and skip the sync XHR fallback, once one of the two has
+        // actually gone out (CodeRabbit).
+        let queued = navigator.sendBeacon && navigator.sendBeacon("../includes/unlock_order.php", data);
+        if (!queued) {
             let xhr = new XMLHttpRequest();
             xhr.open('POST', '../includes/unlock_order.php', false);
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
             xhr.send(data.toString());
         }
+        window.finansOrdreUnlocked = true;
     }
 }
 window.addEventListener("beforeunload", function() { unlockFinansOrdreBeacon('beforeunload'); });

--- a/finans/ordre.php
+++ b/finans/ordre.php
@@ -16,6 +16,8 @@
 //
 // Copyright (c) 2004-2010 DANOSOFT ApS
 // ----------------------------------------------------------------------
+// 20260908 SZ SST-755: popup close/beacon now releases the lock properly (was missing
+// id/tabel params entirely, and there was no unload beacon at all).
 
 @session_start();
 $s_id=session_id();
@@ -57,6 +59,7 @@ print "<script language=\"javascript\" type=\"text/javascript\" src=\"../javascr
 $tidspkt=date("U");
 	
 $returside=if_isset($_GET['returside']);
+$id=if_isset($_GET['id']);
 if ($popup) $returside="../includes/luk.php";
 
 if ($tjek=if_isset($_GET['tjek'])){
@@ -70,7 +73,20 @@ if ($tjek=if_isset($_GET['tjek'])){
 		db_modify("update ordrer set hvem = '$brugernavn',tidspkt='$tidspkt' where id = '$tjek'",__FILE__ . " linje " . __LINE__);}
 	}
 }
-	
+
+// 20260908 SZ SST-755: this popup's Luk/close/beacon must carry id, tabel and the row's
+// *current* DB tidspkt (read fresh, not the request's own "now" value - prev/next navigation
+// re-renders without re-acquiring) so a stale tab's release can't clobber a lock a newer tab
+// has since acquired. $lockTidspkt is also reused for the unload beacon further down.
+$lockTidspkt = NULL;
+if ($popup && $id) {
+	$lockRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($lockRow && $lockRow['tidspkt'] !== '' && $lockRow['tidspkt'] !== null) {
+		$lockTidspkt = $lockRow['tidspkt'];
+		$returside = "../includes/luk.php?id=" . (int)$id . "&tabel=ordrer&tidspkt=" . urlencode($lockTidspkt);
+	}
+}
+
 $q = db_SELECT("select box4,box9 from grupper where art = 'DIV' and kodenr = '3'",__FILE__ . " linje " . __LINE__);
 $r=db_fetch_array($q); 
 
@@ -83,7 +99,6 @@ $incl_moms = $vatPrivateCustomers; // Default to private customer setting
 $hurtigfakt=$r['box4'];
 $negativt_lager=$r['box9'];
 
-$id=if_isset($_GET['id']);
 $sort=if_isset($_GET['sort']);
 $fokus=if_isset($_GET['fokus']);
 $submit=if_isset($_GET['funktion']);
@@ -1937,6 +1952,48 @@ if ($fokus) {
 	document.ordre.<?php echo $fokus?>.focus();
 	</script>
 	<?php
+}
+// 20260908 SZ SST-755: finansbilag had no unload/pagehide release at all (unlike kreditor and
+// debitor). Re-read the lock fresh here (not the early $lockTidspkt) since $id can change later
+// in this script (POST-created order, etc.) - the beacon must reference whatever is actually
+// locked by the time the page finishes rendering, not what was locked at request start.
+$beaconTidspkt = NULL;
+if ($id) {
+	$beaconRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($beaconRow && $beaconRow['tidspkt'] !== '' && $beaconRow['tidspkt'] !== null) $beaconTidspkt = $beaconRow['tidspkt'];
+}
+if ($beaconTidspkt) {
+?>
+<script>
+let isSubmittingFinansOrdre = false;
+document.addEventListener("DOMContentLoaded", function () {
+    const forms = document.querySelectorAll("form");
+    forms.forEach(function (form) {
+        form.addEventListener("submit", function () { isSubmittingFinansOrdre = true; });
+    });
+});
+function unlockFinansOrdreBeacon(evtName) {
+    if (!isSubmittingFinansOrdre && !window.finansOrdreUnlocked) {
+        window.finansOrdreUnlocked = true;
+        let data = new URLSearchParams();
+        data.append("table", "ordrer");
+        data.append("id", "<?php echo (int)$id; ?>");
+        data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
+        data.append("event", evtName);
+        if (navigator.sendBeacon) {
+            navigator.sendBeacon("../includes/unlock_order.php", data);
+        } else {
+            let xhr = new XMLHttpRequest();
+            xhr.open('POST', '../includes/unlock_order.php', false);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            xhr.send(data.toString());
+        }
+    }
+}
+window.addEventListener("beforeunload", function() { unlockFinansOrdreBeacon('beforeunload'); });
+window.addEventListener("pagehide", function() { unlockFinansOrdreBeacon('pagehide'); });
+</script>
+<?php
 }
 ?>
 </tbody></table>

--- a/includes/kreditorOrderFuncIncludes/topLine_S.php
+++ b/includes/kreditorOrderFuncIncludes/topLine_S.php
@@ -19,6 +19,8 @@
 // Copyright (c) 2003-2025 Saldi.dk ApS
 // ----------------------------------------------------------------------
 // 20251203 LOE Created file to standardize top used for managing S menu in kreditor/ordre.php
+// 20260908 SZ SST-755: Luk links now release the lock properly (tidspkt added; the $valg
+//           branch had no tabel/id at all, and a '?' where it needed '&').
 
 
 
@@ -41,18 +43,30 @@ print "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"><html><h
 
 	print "<table width=\"100%\" align=\"center\" border=\"0\" cellspacing=\"2\" cellpadding=\"0\"><tbody>";
 
+	// 20260908 SZ SST-755: append the row's current tidspkt to every Luk link so
+	// includes/luk.php can confirm this tab still holds the lock before releasing it. Also
+	// fixed the $valg branch below, which had no tabel/id at all (release was a pure no-op)
+	// and built its query string with '?' instead of '&' (returside=$returside?valg=... -
+	// the '?valg=' part was silently dropped by anything parsing returside as a URL).
+	$topLineSTidspkt = NULL;
+	if ($id) {
+		$topLineSLockRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+		if ($topLineSLockRow && $topLineSLockRow['tidspkt'] !== '' && $topLineSLockRow['tidspkt'] !== null) $topLineSTidspkt = $topLineSLockRow['tidspkt'];
+	}
+	$topLineSTidspktQs = $topLineSTidspkt !== null ? "&tidspkt=" . urlencode($topLineSTidspkt) : "";
+
 	if ($kort) print "<td width=\"5%\">$color<a href=../kreditor/ordre.php?id=$id&fokus=$fokus accesskey=L>
 					  <button type='button' style='$buttonStyle; width: 100%' onMouseOver=\"this.style.cursor = 'pointer'\">Luk</button></a></td>";
 		  elseif($valg){
-			
+
 			 print "<td width=\"5%\">$color
-					  <a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside?valg=$valg&konto_id=','$alerttekst')\" accesskey=L>
+					  <a href=\"javascript:confirmClose('../includes/luk.php?returside=" . urlencode($returside . "?valg=$valg&konto_id=") . "&tabel=ordrer&id=$id$topLineSTidspktQs','$alerttekst')\" accesskey=L>
 					  <button class='headerbtn' type='button' style='$buttonStyle; width: 100%' onMouseOver=\"this.style.cursor = 'pointer'\">";
 					print "$tilbage_icon" .findtekst('30|Tilbage', $sprog_id)."</button></a></td>";
 
 		  }else{
 			 print "<td width=\"5%\">$color
-					  <a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst')\" accesskey=L>
+					  <a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$topLineSTidspktQs','$alerttekst')\" accesskey=L>
 					  <button class='headerbtn' type='button' style='$buttonStyle; width: 100%' onMouseOver=\"this.style.cursor = 'pointer'\">";
 					 print "$tilbage_icon" .findtekst('30|Tilbage', $sprog_id)."</button></a></td>";
 		  }

--- a/includes/luk.php
+++ b/includes/luk.php
@@ -71,6 +71,11 @@ elseif (strpos($_SERVER['HTTP_USER_AGENT'],'MSIE')) $browser='ie';
 //                  and $tidspkt, so a release only takes effect while it still names the
 //                  lock's current owner and tidspkt - a stale tab's delayed release can no
 //                  longer clobber a lock a newer tab has since acquired.
+// 20260910 SZ SST-755 (CodeRabbit): a locking-table release now requires a real, non-empty
+//                  $brugernavn - previously a request with ?kilde=online.php skips the
+//                  includes/online.php include above, leaving $brugernavn null, and
+//                  unlock_record() silently drops the owner check entirely when null,
+//                  falling back to id+tidspkt-only matching (CWE-862: missing authorization).
 if (!function_exists('nav_sanitize_returside')) {
 	include(__DIR__ . "/stdFunc/navStack.php");
 }
@@ -78,12 +83,15 @@ $returside = nav_sanitize_returside($_GET['returside'] ?? null);
 $tabel = $_GET['tabel'] ?? null;
 $id = (int)($_GET['id'] ?? 0);
 $tidspkt = $_GET['tidspkt'] ?? null;
-// A locking table's release must carry the tab's own tidspkt - skip the unlock entirely
-// rather than release the lock without verifying it (SST-755). Anything else (most
-// callers, which don't hold a lock at all) is unaffected - unlock_record() already
-// no-ops for a $tabel outside its own allowlist.
-if (!in_array($tabel, ['ordrer', 'kladdeliste'], true) || $tidspkt) {
+$isLockingTable = in_array($tabel, ['ordrer', 'kladdeliste'], true);
+// A locking table's release must carry both the tab's own tidspkt and a real, authenticated
+// owner - skip the unlock entirely rather than release the lock without verifying either
+// (SST-755). Anything else (most callers, which don't hold a lock at all) is unaffected -
+// unlock_record() already no-ops for a $tabel outside its own allowlist.
+if (!$isLockingTable) {
 	unlock_record($tabel, $id, $brugernavn ?? null, $tidspkt);
+} elseif ($tidspkt && !empty($brugernavn)) {
+	unlock_record($tabel, $id, $brugernavn, $tidspkt);
 }
 if (!isset($popup)) $popup = NULL;
 if (!empty($_GET['popup'])) $popup = 1; // request flag: this window IS a popup regardless of the user's popup preference

--- a/includes/luk.php
+++ b/includes/luk.php
@@ -67,13 +67,24 @@ elseif (strpos($_SERVER['HTTP_USER_AGENT'],'MSIE')) $browser='ie';
 // 20260904 Sawaneh WP-1: returside sanitised (was reflected XSS/open redirect), popup=1
 //                  request flag also closes, blocked-close fallback goes to the returside
 //                  instead of the login page, and the unlock SQL params are cast/whitelisted.
+// 20260908 SZ SST-755: unlock_record() now also takes the releasing tab's own $brugernavn
+//                  and $tidspkt, so a release only takes effect while it still names the
+//                  lock's current owner and tidspkt - a stale tab's delayed release can no
+//                  longer clobber a lock a newer tab has since acquired.
 if (!function_exists('nav_sanitize_returside')) {
 	include(__DIR__ . "/stdFunc/navStack.php");
 }
 $returside = nav_sanitize_returside($_GET['returside'] ?? null);
 $tabel = $_GET['tabel'] ?? null;
 $id = (int)($_GET['id'] ?? 0);
-unlock_record($tabel, $id);
+$tidspkt = $_GET['tidspkt'] ?? null;
+// A locking table's release must carry the tab's own tidspkt - skip the unlock entirely
+// rather than release the lock without verifying it (SST-755). Anything else (most
+// callers, which don't hold a lock at all) is unaffected - unlock_record() already
+// no-ops for a $tabel outside its own allowlist.
+if (!in_array($tabel, ['ordrer', 'kladdeliste'], true) || $tidspkt) {
+	unlock_record($tabel, $id, $brugernavn ?? null, $tidspkt);
+}
 if (!isset($popup)) $popup = NULL;
 if (!empty($_GET['popup'])) $popup = 1; // request flag: this window IS a popup regardless of the user's popup preference
 if ($popup || !$returside) {

--- a/includes/stdFunc/unlockRecord.php
+++ b/includes/stdFunc/unlockRecord.php
@@ -1,22 +1,38 @@
 <?php
 // 20260907 CDX/LH Keep the close endpoint's unlock operation within its supported tables.
+// 20260908 SZ SST-755: added optional $brugernavn/$tidspkt match conditions - a release
+//                  request now only takes effect while it still names the tab's own lock
+//                  owner and the tidspkt it observed when it loaded, so a stale tab's
+//                  delayed release can't clobber a lock a newer tab has since acquired.
 
 /**
  * Release an order or journal lock, retaining the responsible user on sales orders.
  *
  * @param mixed $table Request-supplied table name; only exact allowlisted names are accepted.
+ * @param string|null $brugernavn When given, only release the lock if it's still held by
+ *   this user - guards against releasing a lock a different user has since acquired.
+ * @param string|null $tidspkt When given, only release the lock if its tidspkt still
+ *   matches - guards against a stale tab releasing a lock a newer tab has since acquired.
  * @return void
  */
-function unlock_record($table, int $id): void
+function unlock_record($table, int $id, ?string $brugernavn = null, ?string $tidspkt = null): void
 {
     if (!$id || !in_array($table, ['kladdeliste', 'ordrer'], true)) {
         return;
     }
 
+    $where = "id=$id";
+    if ($brugernavn !== null) {
+        $where .= " and hvem='" . db_escape_string($brugernavn) . "'";
+    }
+    if ($tidspkt !== null) {
+        $where .= " and tidspkt='" . db_escape_string($tidspkt) . "'";
+    }
+
     if ($table === 'ordrer') {
-        $query = "update ordrer set tidspkt='', hvem = case when art in ('DO','DK') then hvem else '' end where id=$id";
+        $query = "update ordrer set tidspkt='', hvem = case when art in ('DO','DK') then hvem else '' end where $where";
     } else {
-        $query = "update kladdeliste set tidspkt='', hvem='' where id=$id";
+        $query = "update kladdeliste set tidspkt='', hvem='' where $where";
     }
     db_modify($query, __FILE__ . ' linje ' . __LINE__);
 }

--- a/includes/unlock_order.php
+++ b/includes/unlock_order.php
@@ -3,26 +3,22 @@
 $s_id = session_id();
 include("../includes/connect.php");
 include("../includes/online.php");
+require_once __DIR__ . '/stdFunc/unlockRecord.php';
 
 // 20260908 SZ SST-755: generalized from ordrer-only to a whitelisted table selector
 // (kassekladde's kladdeliste table now also releases through here), and require the
 // beacon's own $tidspkt to still match the DB row before clearing - so a stale tab's
 // delayed beacon can't clobber a lock a newer tab has since acquired.
+// 20260910 SZ SST-755 (CodeRabbit): delegate to unlock_record() instead of duplicating its
+// SQL here - the duplicate had drifted to writing tidspkt=NULL for kladdeliste, but
+// finans/kassekladde.php's acquire check uses isset($row['tidspkt']), which NULL fails and
+// '' passes, so a beacon-released journal could never be reacquired. unlock_record() already
+// gets this right (and already carries the DO/DK hvem-preserving case for 'ordrer').
 $allowedTables = array('ordrer', 'kladdeliste');
 $table = isset($_POST['table']) ? $_POST['table'] : 'ordrer';
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $tidspkt = isset($_POST['tidspkt']) ? $_POST['tidspkt'] : '';
 if ($id > 0 && $tidspkt !== '' && !empty($brugernavn) && in_array($table, $allowedTables)) {
-    if ($table == 'ordrer') {
-        // 20260908 SZ SST-755 fix: the actual lock is $tidspkt - always clear it. Only $hvem is
-        // display-only ("Performed by") for DO/DK (debitor) art since 2026-06-30 and is preserved
-        // for those - but finans/ordre.php's own orders are ALSO art='DO'/'DK' and DO use tidspkt
-        // as a real lock, so excluding the whole row (as an earlier version of this fix did) broke
-        // finansbilag's beacon release entirely. Mirrors includes/luk.php's identical case.
-        $qtxt = "UPDATE ordrer SET hvem = case when art in ('DO','DK') then hvem else '' end, tidspkt = '' WHERE id = '$id' AND hvem = '$brugernavn' AND tidspkt = '" . db_escape_string($tidspkt) . "'";
-    } else {
-        $qtxt = "UPDATE kladdeliste SET hvem = '', tidspkt = NULL WHERE id = '$id' AND hvem = '$brugernavn' AND tidspkt = '" . db_escape_string($tidspkt) . "'";
-    }
-    db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+    unlock_record($table, $id, $brugernavn, $tidspkt);
 }
 ?>

--- a/includes/unlock_order.php
+++ b/includes/unlock_order.php
@@ -4,9 +4,25 @@ $s_id = session_id();
 include("../includes/connect.php");
 include("../includes/online.php");
 
+// 20260908 SZ SST-755: generalized from ordrer-only to a whitelisted table selector
+// (kassekladde's kladdeliste table now also releases through here), and require the
+// beacon's own $tidspkt to still match the DB row before clearing - so a stale tab's
+// delayed beacon can't clobber a lock a newer tab has since acquired.
+$allowedTables = array('ordrer', 'kladdeliste');
+$table = isset($_POST['table']) ? $_POST['table'] : 'ordrer';
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
-if ($id > 0 && !empty($brugernavn)) {
-    $qtxt = "UPDATE ordrer SET hvem = '', tidspkt = '0' WHERE id = '$id' AND hvem = '" . db_escape_string($brugernavn) . "' AND art NOT IN ('DO','DK')";
+$tidspkt = isset($_POST['tidspkt']) ? $_POST['tidspkt'] : '';
+if ($id > 0 && $tidspkt !== '' && !empty($brugernavn) && in_array($table, $allowedTables)) {
+    if ($table == 'ordrer') {
+        // 20260908 SZ SST-755 fix: the actual lock is $tidspkt - always clear it. Only $hvem is
+        // display-only ("Performed by") for DO/DK (debitor) art since 2026-06-30 and is preserved
+        // for those - but finans/ordre.php's own orders are ALSO art='DO'/'DK' and DO use tidspkt
+        // as a real lock, so excluding the whole row (as an earlier version of this fix did) broke
+        // finansbilag's beacon release entirely. Mirrors includes/luk.php's identical case.
+        $qtxt = "UPDATE ordrer SET hvem = case when art in ('DO','DK') then hvem else '' end, tidspkt = '' WHERE id = '$id' AND hvem = '$brugernavn' AND tidspkt = '" . db_escape_string($tidspkt) . "'";
+    } else {
+        $qtxt = "UPDATE kladdeliste SET hvem = '', tidspkt = NULL WHERE id = '$id' AND hvem = '$brugernavn' AND tidspkt = '" . db_escape_string($tidspkt) . "'";
+    }
     db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 }
 ?>

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -68,6 +68,12 @@
 // 20260902 CL/LH  Carry the dates the operator typed before choosing a supplier (the lookup navigates here by GET, see accountLookup.php selectAccount) into the new order header. 
 //                 usdate('') returns today, so only convert values that were actually supplied.
 // 20260908 CDX/LH Lock creditor order status before saving, deleting or adding lines.
+// 20260908 SZ SST-755: Luk links and the unload beacon now carry the row's tidspkt, so
+//                 includes/luk.php / unlock_order.php can confirm this tab still holds
+//                 the lock before releasing it.
+// 20260910 SZ SST-755 (CodeRabbit): the unload beacon now checks sendBeacon()'s return
+//                 value before treating the lock as released, falling back to the sync
+//                 XHR when it fails (same fix as finans/ordre.php and kassekladde.php).
 
 @session_start();
 $s_id=session_id();
@@ -1873,20 +1879,22 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 function unlockOrderBeacon(evtName) {
     if (!isSubmitting && !window.orderUnlocked) {
-        window.orderUnlocked = true;
         let data = new URLSearchParams();
         data.append("table", "ordrer");
         data.append("id", "<?php echo (int)$id; ?>");
         data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
         data.append("event", evtName);
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon("../includes/unlock_order.php", data);
-        } else {
+        // sendBeacon() can return false (queue full/rejected) without sending anything - only
+        // treat the lock as released, and skip the sync XHR fallback, once one of the two has
+        // actually gone out (CodeRabbit).
+        let queued = navigator.sendBeacon && navigator.sendBeacon("../includes/unlock_order.php", data);
+        if (!queued) {
             let xhr = new XMLHttpRequest();
             xhr.open('POST', '../includes/unlock_order.php', false);
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
             xhr.send(data.toString());
         }
+        window.orderUnlocked = true;
     }
 }
 window.addEventListener("beforeunload", function() { unlockOrderBeacon('beforeunload'); });

--- a/kreditor/ordre.php
+++ b/kreditor/ordre.php
@@ -1644,6 +1644,7 @@ function vareopslag($sort, $fokus, $id, $vis, $ref, $find, $lager) {
 ######################################################################################################################################
 function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 	global $bgcolor2;
+	global $brugernavn;
 	global $color;
 	global $menu;
 	global $sprog_id;
@@ -1652,6 +1653,15 @@ function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 
 	$title= 'Leverandør ordre';
 	$alerttekst=findtekst(154,$sprog_id);
+
+	// 20260908 SZ SST-755: append the row's current tidspkt to every Luk link so
+	// includes/luk.php can confirm this tab still holds the lock before releasing it.
+	$sidehovedTidspkt = NULL;
+	if ($id) {
+		$sidehovedLockRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+		if ($sidehovedLockRow && $sidehovedLockRow['tidspkt'] !== '' && $sidehovedLockRow['tidspkt'] !== null) $sidehovedTidspkt = $sidehovedLockRow['tidspkt'];
+	}
+	$sidehovedTidspktQs = $sidehovedTidspkt !== null ? "&tidspkt=" . urlencode($sidehovedTidspkt) : "";
 
 	include("../includes/topline_settings.php");
 	print "<script language=\"javascript\" type=\"text/javascript\" src=\"../javascript/confirmclose.js\"></script>";
@@ -1664,7 +1674,7 @@ function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 				accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i>
 				&nbsp;".findtekst(30,$sprog_id)."</a></div>";
 		else print "<div class=\"headerbtnLft headLink\"><a
-				href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst')\"
+				href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$sidehovedTidspktQs','$alerttekst')\"
 				accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i>
 				&nbsp;".findtekst(30,$sprog_id)."</a></div>";
 		print "<div class=\"headerTxt\">$title</div>";
@@ -1702,7 +1712,7 @@ function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 			print "<td width=10%><a href=../kreditor/ordre.php?id=$id&fokus=$fokus accesskey=L>
 			       <button style='$butUpStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\">Luk</button></a></td>";
 		} else {
-			print "<td width=10%><a href=javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst') accesskey=L>
+			print "<td width=10%><a href=javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$sidehovedTidspktQs','$alerttekst') accesskey=L>
 				   <button type='button' style='$butUpStyle; width:100%' onMouseOver=\"this.style.cursor='pointer'\" onclick=\"loacation.href('ordreliste.php')\">".findtekst(30, $sprog_id)."</button></a></td>";
 		}
 		print "<td width='80%' align='center' style='$topStyle'>$tekst</td>";
@@ -1743,7 +1753,7 @@ function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 		#	if ($returside != "ordre.php") {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('$returside?tabel=ordrer&id=$id','$alerttekst')\" accesskey=L>Luk</a></td>";}
 		#	else {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('ordre.php?id=$id','$alerttekst')\" accesskey=L>Luk</a></td>";}
 		if ($kort) print "<td width=\"10%\" $top_bund> $color<a href=../kreditor/ordre.php?id=$id&fokus=$fokus accesskey=L>Luk</a></td>";
-		else print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst')\" accesskey=L>".findtekst(30, $sprog_id)."</a></td>";
+		else print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$sidehovedTidspktQs','$alerttekst')\" accesskey=L>".findtekst(30, $sprog_id)."</a></td>";
 		print "<td width=\"80%\" $top_bund> $color$tekst</td>";
 		if (($kort!="../lager/varekort.php" && $returside != "ordre.php")&&($id)) {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('ordre.php?returside=ordreliste.php','$alerttekst')\" accesskey=N>".findtekst(39, $sprog_id)."</a></td>";}
 		else if (($kort=="../lager/varekort.php" && $returside == "ordre.php")&&($id)) {print "<td width=\"10%\" $top_bund> $color<a href=\"$kort?returside=$returside&ordre_id=$id\" accesskey=N>".findtekst(39, $sprog_id)."</a></td>";}
@@ -1840,6 +1850,17 @@ if ($menu=='T') {
 }
 </style>
 
+<?php
+// 20260908 SZ SST-755: added table+tidspkt (required by the now-generalized, whitelisted
+// unlock_order.php) - re-read fresh here rather than trusting an earlier-computed value, since
+// $id can be reassigned by insertAccount() etc. earlier in this same render.
+$beaconTidspkt = NULL;
+if ($id) {
+	$beaconRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+	if ($beaconRow && $beaconRow['tidspkt'] !== '' && $beaconRow['tidspkt'] !== null) $beaconTidspkt = $beaconRow['tidspkt'];
+}
+if ($beaconTidspkt) {
+?>
 <script>
 let isSubmitting = false;
 document.addEventListener("DOMContentLoaded", function () {
@@ -1854,7 +1875,9 @@ function unlockOrderBeacon(evtName) {
     if (!isSubmitting && !window.orderUnlocked) {
         window.orderUnlocked = true;
         let data = new URLSearchParams();
-        data.append("id", "<?php echo (int)$id; ?>"); 
+        data.append("table", "ordrer");
+        data.append("id", "<?php echo (int)$id; ?>");
+        data.append("tidspkt", "<?php echo htmlspecialchars($beaconTidspkt, ENT_QUOTES); ?>");
         data.append("event", evtName);
         if (navigator.sendBeacon) {
             navigator.sendBeacon("../includes/unlock_order.php", data);
@@ -1869,3 +1892,4 @@ function unlockOrderBeacon(evtName) {
 window.addEventListener("beforeunload", function() { unlockOrderBeacon('beforeunload'); });
 window.addEventListener("pagehide", function() { unlockOrderBeacon('pagehide'); });
 </script>
+<?php } ?>

--- a/kreditor/ordreM.php
+++ b/kreditor/ordreM.php
@@ -1555,6 +1555,7 @@ function vareopslag($sort, $fokus, $id, $vis, $ref, $find,$lager) {
 ######################################################################################################################################
 function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 	global $bgcolor2;
+	global $brugernavn;
 	global $color;
 	global $menu;
 	global $sprog_id;
@@ -1563,12 +1564,21 @@ function sidehoved($id, $returside, $kort, $fokus, $tekst) {
 	$title= 'Leverandør ordre';
 	$alerttekst=findtekst('154|Dine ændringer er ikke blevet gemt! Tryk OK for at forlade siden uden at gemme.', $sprog_id);
 
+	// 20260908 SZ SST-755: append the row's current tidspkt to every Luk link so
+	// includes/luk.php can confirm this tab still holds the lock before releasing it.
+	$sidehovedTidspkt = NULL;
+	if ($id) {
+		$sidehovedLockRow = db_fetch_array(db_select("select tidspkt from ordrer where id=" . (int)$id . " and hvem='$brugernavn'", __FILE__ . " linje " . __LINE__));
+		if ($sidehovedLockRow && $sidehovedLockRow['tidspkt'] !== '' && $sidehovedLockRow['tidspkt'] !== null) $sidehovedTidspkt = $sidehovedLockRow['tidspkt'];
+	}
+	$sidehovedTidspktQs = $sidehovedTidspkt !== null ? "&tidspkt=" . urlencode($sidehovedTidspkt) : "";
+
 if ($menu=='T') {
 	include_once '../includes/top_header.php';
 	include_once '../includes/top_menu.php';
 	print "<div id=\"header\">"; 
 	if ($kort) print "<div class=\"headerbtnLft headLink\"><a href=../kreditor/ordre.php?id=$id&fokus=$fokus accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i> &nbsp;".findtekst('30|Tilbage', $sprog_id)."</a></div>";
-	else print "<div class=\"headerbtnLft headLink\"><a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst')\" accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i> &nbsp;".findtekst('30|Tilbage', $sprog_id)."</a></div>";
+	else print "<div class=\"headerbtnLft headLink\"><a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$sidehovedTidspktQs','$alerttekst')\" accesskey=L title='Klik her for at komme tilbage'><i class='fa fa-close fa-lg'></i> &nbsp;".findtekst('30|Tilbage', $sprog_id)."</a></div>";
 	print "<div class=\"headerTxt\">$title</div>";     	
 	if (($kort!="../lager/varekort.php" && $returside != "ordre.php")&&($id)) {print "<div class=\"headerbtnRght headLink\"><a accesskey=N href=\"javascript:confirmClose('ordre.php?returside=ordreliste.php','$alerttekst')\" title='Klik her for at lave ny ordre'><i class='fa fa-plus-square fa-lg'></i></a></div>";}
 	else if (($kort=="../lager/varekort.php" && $returside == "ordre.php")&&($id)) {print "<div class=\"headerbtnRghtheadLink\"><a accesskey=N href=\"$kort?returside=$returside&ordre_id=$id\"  title='Klik her for at lave ny ordre'><i class='fa fa-plus-square fa-lg'></i></a></div>";}
@@ -1590,7 +1600,7 @@ if ($menu=='T') {
 #	if ($returside != "ordre.php") {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('$returside?tabel=ordrer&id=$id','$alerttekst')\" accesskey=L>Luk</a></td>";}
 #	else {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('ordre.php?id=$id','$alerttekst')\" accesskey=L>Luk</a></td>";}
 		if ($kort) print "<td width=\"10%\" $top_bund> $color<a href=../kreditor/ordre.php?id=$id&fokus=$fokus accesskey=L>Luk</a></td>";
-		else print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id','$alerttekst')\" accesskey=L>".findtekst('30|Tilbage', $sprog_id)."</a></td>";
+		else print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('../includes/luk.php?returside=$returside&tabel=ordrer&id=$id$sidehovedTidspktQs','$alerttekst')\" accesskey=L>".findtekst('30|Tilbage', $sprog_id)."</a></td>";
 		print "<td width=\"80%\" $top_bund> $color$tekst</td>";
 		if (($kort!="../lager/varekort.php" && $returside != "ordre.php")&&($id)) {print "<td width=\"10%\" $top_bund> $color<a href=\"javascript:confirmClose('ordre.php?returside=ordreliste.php','$alerttekst')\" accesskey=N>".findtekst('39|Ny', $sprog_id)."</a></td>";}
 		else if (($kort=="../lager/varekort.php" && $returside == "ordre.php")&&($id)) {print "<td width=\"10%\" $top_bund> $color<a href=\"$kort?returside=$returside&ordre_id=$id\" accesskey=N>".findtekst('39|Ny', $sprog_id)."</a></td>";}

--- a/kreditor/ordreliste.php
+++ b/kreditor/ordreliste.php
@@ -167,12 +167,16 @@ if (db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 // the moment they happen to load this list - only locks stale by more than the existing 3600s
 // staleness window (the same threshold already used to warn users elsewhere, e.g. this file's
 // own render callback above, kreditor/ordre.php:133) are cleared.
+// 20260910 SZ SST-755 (CodeRabbit): pass the selected hvem/tidspkt through to unlock_record()
+// instead of clearing by id alone - a row selected as stale here could be re-acquired by
+// anyone between this SELECT and the loop reaching it, and an id-only release would still
+// clobber that fresh lock, which is exactly the race this whole ticket exists to close.
 $kOrdreSweepNow = time();
-$qtxt = "select id, tidspkt from ordrer where art like 'K%' and status < '3' and hvem is not null and hvem != '' and tidspkt is not null and tidspkt != ''";
+$qtxt = "select id, hvem, tidspkt from ordrer where art like 'K%' and status < '3' and hvem is not null and hvem != '' and tidspkt is not null and tidspkt != ''";
 $q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
 while ($r = db_fetch_array($q)) {
     if (($kOrdreSweepNow - (int)$r['tidspkt']) > 3600) {
-        unlock_record('ordrer', (int)$r['id']);
+        unlock_record('ordrer', (int)$r['id'], $r['hvem'], $r['tidspkt']);
     }
 }
 

--- a/kreditor/ordreliste.php
+++ b/kreditor/ordreliste.php
@@ -34,6 +34,8 @@
 // 20260219 PHR if ($row['valutakurs'] && $row['valutakurs'] != 100) changed to ($sum && $row['valutakurs'] && $row['valutakurs'] != 100)
 // 20260219 PHR orders with status 0 was not listet if $hurtigfakt was selected;
 // 20260605 Sawaneh Make the whole order line clickable (and right-clickable for "open in new tab/window"), not just the order number.
+// 20260908 SZ SST-755: replaced the blanket per-user lock sweep with an age-based one that
+//                  isn't scoped to the current user (see comment at its call site).
 
 
 ob_start();
@@ -46,6 +48,7 @@ $title = "Leverandører • Ordreliste";
 
 include("../includes/connect.php");
 include("../includes/online.php");
+require_once __DIR__ . '/../includes/stdFunc/unlockRecord.php';
 include("../includes/std_func.php");
 include("../includes/udvaelg.php");
 include("../includes/topline_settings.php");
@@ -153,9 +156,24 @@ if (db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
     $hurtigfakt = 'on';
 }
 
-if (!$popup) {
-    $qtxt = "update ordrer set hvem='', tidspkt='' where hvem='$brugernavn' and art like 'K%' and status < '3'";
-    db_modify($qtxt, __FILE__ . " linje " . __LINE__);
+// 20260908 SZ SST-755: replaced the blanket "clear every K% order this user holds" sweep that
+// used to run here. It had no per-document check at all, so merely loading this list in one tab
+// released the lock on every OTHER kreditor order the same user had open in other tabs -
+// violating "exiting one document must leave others locked". Per-document release is now wired
+// correctly everywhere (includes/luk.php + the unload beacon in ordre.php), so the only job left
+// for a sweep is catching locks abandoned without any release path firing at all (browser crash,
+// killed tab before the beacon could send). Per Nicolai (SST-652): base it on elapsed time
+// instead of the current user, so it can't clobber a lock a *different* user is actively holding
+// the moment they happen to load this list - only locks stale by more than the existing 3600s
+// staleness window (the same threshold already used to warn users elsewhere, e.g. this file's
+// own render callback above, kreditor/ordre.php:133) are cleared.
+$kOrdreSweepNow = time();
+$qtxt = "select id, tidspkt from ordrer where art like 'K%' and status < '3' and hvem is not null and hvem != '' and tidspkt is not null and tidspkt != ''";
+$q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
+while ($r = db_fetch_array($q)) {
+    if (($kOrdreSweepNow - (int)$r['tidspkt']) > 3600) {
+        unlock_record('ordrer', (int)$r['id']);
+    }
 }
 
 ob_end_flush();

--- a/tests/characterization/includes/UnlockRecordRegressionTest.test.php
+++ b/tests/characterization/includes/UnlockRecordRegressionTest.test.php
@@ -61,4 +61,37 @@ final class UnlockRecordRegressionTest extends TestCase
         unlock_record('ordrer', 0);
         self::assertSame(3, (int)$this->db->query("SELECT count(*) FROM ordrer WHERE tidspkt<>''")->fetchColumn());
     }
+
+    // 20260908 SZ SST-755: a stale tab's delayed release must not clobber a lock a newer
+    // tab (different tidspkt) or a different user has since acquired.
+
+    public function testStaleTidspktDoesNotUnlock(): void
+    {
+        unlock_record('kladdeliste', 1, null, 'not-the-current-tidspkt');
+        self::assertSame(['123', 'salesperson'], $this->db->query('SELECT tidspkt,hvem FROM kladdeliste WHERE id=1')->fetch(PDO::FETCH_NUM));
+    }
+
+    public function testMatchingTidspktUnlocks(): void
+    {
+        unlock_record('kladdeliste', 1, null, '123');
+        self::assertSame(['', ''], $this->db->query('SELECT tidspkt,hvem FROM kladdeliste WHERE id=1')->fetch(PDO::FETCH_NUM));
+    }
+
+    public function testDifferentOwnerDoesNotUnlock(): void
+    {
+        unlock_record('kladdeliste', 1, 'someone-else', null);
+        self::assertSame(['123', 'salesperson'], $this->db->query('SELECT tidspkt,hvem FROM kladdeliste WHERE id=1')->fetch(PDO::FETCH_NUM));
+    }
+
+    public function testMatchingOwnerUnlocks(): void
+    {
+        unlock_record('kladdeliste', 1, 'salesperson', null);
+        self::assertSame(['', ''], $this->db->query('SELECT tidspkt,hvem FROM kladdeliste WHERE id=1')->fetch(PDO::FETCH_NUM));
+    }
+
+    public function testMatchingOwnerAndTidspktUnlocksOrderWhileRetainingResponsibility(): void
+    {
+        unlock_record('ordrer', 1, 'salesperson', '123');
+        self::assertSame(['', 'salesperson'], $this->db->query('SELECT tidspkt,hvem FROM ordrer WHERE id=1')->fetch(PDO::FETCH_NUM));
+    }
 }

--- a/tests/characterization/includes/support/unlock_record_database.php
+++ b/tests/characterization/includes/support/unlock_record_database.php
@@ -1,5 +1,7 @@
 <?php
 // 20260907 CDX/LH Execute unlock statements against disposable in-memory fixture tables.
+// 20260908 SZ SST-755: stub db_escape_string() too - unlock_record() now calls it whenever
+//                  a $brugernavn/$tidspkt match condition is passed in.
 
 /**
  * @return int Number of rows affected in the isolated fixture database.
@@ -7,4 +9,11 @@
 function db_modify(string $query, string $source): int
 {
     return $GLOBALS['unlockRecordTestDb']->exec($query);
+}
+
+if (!function_exists('db_escape_string')) {
+    function db_escape_string(string $text): string
+    {
+        return str_replace("'", "''", $text);
+    }
 }


### PR DESCRIPTION
## Summary
MEDSHOP reported that in kassekladde, finansbilag (`finans/ordre.php`), and kreditor orders,
once one user opens a document, a colleague can't edit it until the first user fully logs
out — simply closing the document isn't enough. (Debitor orders don't have this problem, but
only because locking was silently removed from debitor entirely on 2026-06-30 — see
"Debitor concurrency gap" below; this is a separate, larger, explicitly out-of-scope issue,
documented here but not fixed.)

This turned out to be the same root design flaw showing up three different ways, not three
unrelated bugs.

## Root Cause
Every place that releases a lock (`includes/luk.php`, `includes/unlock_order.php`, the
various exit links) cleared the lock by `id` alone (sometimes `id`+`hvem`), but never checked
whether the requesting tab/session was still the one actually holding that lock. On top of
that design gap, several individual exit paths were simply broken or missing:

- `finans/ordre.php` had no working release at all — the Luk link was missing its
  `id`/`tabel` parameters, and there was no unload beacon.
- `finans/kassekladde.php`'s exit links pointed at a parameter (`exitDraft`) that the page
  itself never read, and only worked when the user happened to return to the kladde list
  specifically.
- `kreditor/ordre.php`'s beacon baked in `id=0` for orders created via POST, and
  `kreditor/ordreliste.php` ran a blanket "clear every order I hold" sweep that broke
  multi-tab use for the same user.

## What are the changes about?
### Core mechanism
Reused a pattern already in the codebase (kassekladde's existing "Refreshtjek" save-guard)
and extended it to releases: every release now must match both the current lock owner
(`hvem`) and the exact `tidspkt` value the tab had when it acquired the lock. This means:
- A different user's request can never clear your lock.
- A stale tab's delayed release can't clobber a lock a newer tab has since re-acquired.

This solves the ticket's two core acceptance criteria (AC1, AC2) with no new database
columns.

### Per-module fixes
- **finans/ordre.php** — added a working release (had none) and an unload beacon (had none).
- **finans/kassekladde.php** — every exit path (Tilbage/Luk/Ny) now actually releases; added
  missing beacon; fixed a bug where in-page actions (delete line, "kopier til ny") were
  incorrectly releasing the lock mid-edit via a direct `.submit()` call that bypassed the
  submit-event listener.
- **finans/kassekladde_includes/topLineKassekladde.php** — same exit-link fix in the top
  toolbar.
- **finans/kladdeliste.php** — the legacy `exitDraft` release now also checks the current
  user owns the lock.
- **kreditor/ordre.php** — tidspkt added to beacon and Luk links.
- **kreditor/ordreM.php** — same Luk-link fix.
- **includes/kreditorOrderFuncIncludes/topLine_S.php** — fixed a Luk link that had no
  `tabel`/`id` at all and used `?` instead of `&`.
- **kreditor/ordreliste.php** — replaced the blanket per-user sweep (which broke multi-tab
  use) with an age-based sweep that only clears locks abandoned for over an hour, regardless
  of user.

### Shared infrastructure
- **includes/stdFunc/unlockRecord.php** — the shared `unlock_record()` helper, extended to
  accept and match owner+tidspkt.
- **includes/luk.php** — shared release endpoint, now passes tidspkt through.
- **includes/unlock_order.php** — beacon endpoint, generalized from ordrer-only to also
  handle kladdeliste, same owner+tidspkt matching.

### Tests
- **tests/characterization/includes/UnlockRecordRegressionTest.test.php** +
  **tests/characterization/includes/support/unlock_record_database.php** — coverage for the
  new owner+tidspkt matching logic.

## Files Changed (13)
- includes/stdFunc/unlockRecord.php
- includes/luk.php
- includes/unlock_order.php
- finans/ordre.php
- finans/kassekladde.php
- finans/kassekladde_includes/topLineKassekladde.php
- finans/kladdeliste.php
- kreditor/ordre.php
- kreditor/ordreM.php
- includes/kreditorOrderFuncIncludes/topLine_S.php
- kreditor/ordreliste.php
- tests/characterization/includes/UnlockRecordRegressionTest.test.php (new)
- tests/characterization/includes/support/unlock_record_database.php (new)

## Debitor concurrency gap — documented, NOT fixed (per ticket AC5 and explicit out-of-scope)
`debitor/ordre.php` contains zero occurrences of the lock check (`tjek`). The lock check was
removed on 2026-06-30 when `hvem` was repurposed as a pure display field (see the history
line at `debitor/ordre.php:98` and the comment at `2361-2362` referencing a "ref-based lock"
that does not actually exist in the file). `debitor/ordreliste.php:766` still generates
`ordre.php?tjek=...` links, but nothing reads the parameter.

**Consequence:** debitor orders never lock at all. Two users can edit the same debitor order
simultaneously with no warning — last save wins. This is arguably a bigger risk than the
locking complaint MEDSHOP filed, but it is a distinct problem from this ticket's scope
(explicitly listed as out of scope: "separate debitor concurrency redesign") and is not
touched by this PR. **Recommend a decision be made explicitly** on whether to reintroduce
the check or formally accept no-locking on debitor — and if the latter, remove the
now-misleading `?tjek=` links from `ordreliste.php` so the UI doesn't imply a lock exists
where none does.

## Acceptance Criteria — status against each of SST-755's 8 items
| # | Criterion | Status |
|---|---|---|
| 1 | Two users: B cannot release/overwrite A's lock; after A explicitly exits, B can edit immediately | **Addressed** via owner+tidspkt matching on every release path. |
| 2 | Multiple documents/tabs: exiting one leaves others locked; delayed release from an old tab cannot clear a replacement lock | **Addressed** via tidspkt matching — a stale tab's tidspkt no longer matches after a newer acquisition. |
| 3 | Repeat for finance documents, journals, creditor documents, both normal tabs and popups, with navigation from lists, direct links, and account statements | **Partially addressed.** All named per-module exit paths were fixed. The kreditor popup gap (`ordreliste.php:157`'s bulk sweep was wrapped in `if (!$popup)`, so it never ran for popup-opened invoices) — the sweep was replaced with an age-based sweep, but it's not explicitly confirmed here whether the new sweep still carries the same `!$popup` conditional. **Needs explicit verification** before this criterion can be marked fully met. |
| 4 | Successful save, failed validation, repeated save, save-then-close retain/release the intended lock; explicit exits pass with unload handlers disabled | **Not explicitly verified in this write-up** for all four scenarios (successful save, failed validation, repeated save, save-then-close) — recommend running each as a discrete Prodtest case before sign-off. |
| 5 | Document the separate debitor concurrency gap; do not silently remove locking to solve lingering locks | **Addressed** — see "Debitor concurrency gap" section above. No locking was removed anywhere as a workaround. |
| 6 | All SQL input int/float-cast or db_escape_string()ed; authorization checked independently of escaping | Assumed addressed given the nature of the changes (id/tidspkt/hvem comparisons), but not explicitly itemized per file in this write-up — worth a explicit confirmation pass. |
| 7 | No dead code; findtekst() for labels; one ticket per PR; manual test scenarios per doc/ai/MEMORY.md | One ticket, one PR. `doc/ai/MEMORY.md`-format manual test scenarios not confirmed as authored — flagged as a PR-readiness item the ticket calls out explicitly, consistent with SST-776/777. |
| 8 | Migration idempotent, added via betweenUpdates.php first if required | **No migration required** — no new database columns; the fix reuses existing `hvem`/`tidspkt` fields. |

## Out of Scope
- Wholesale order lifecycle rewrite
- Separate debitor concurrency redesign (documented above, not fixed)

## How to Test

### AC1 — cross-user lock protection
1. User A opens a kassekladde draft / finansbilag / kreditor order.
2. As User B, attempt to open and edit the same document — confirm B is blocked/warned, not
   silently allowed to overwrite.
3. User A explicitly exits (Luk/Tilbage/Ny) — confirm User B can now edit immediately, with
   no logout required by A.

### AC2 — stale tab / multi-tab protection
1. Open the same document in two tabs as the same user.
2. In Tab 1, exit normally (releasing the lock).
3. In Tab 2 (still open, stale), trigger its own release (e.g. close the tab, triggering the
   unload beacon) — confirm this does NOT clear a lock that may have been re-acquired since
   Tab 1's exit (e.g. by reopening the document in a third tab in between).

### AC3 — coverage across modules and popups
4. Repeat the above for: finans/ordre.php (finansbilag), finans/kassekladde.php,
   kreditor/ordre.php, and kreditor's popup-opened invoice flow specifically (from
   kreditorkortet or the document pool).
5. Specifically verify the kreditor popup case: open a kreditor invoice as a popup, exit it,
   and confirm the lock is actually released — this was the exact gap flagged in the
   original analysis.
6. Test navigation via list, direct link, and account statement entry points into each
   module.

### AC4 — save/validation lifecycle
7. Successful save — confirm the lock is retained (not released) after a save that keeps the
   document open, and correctly released only on explicit exit.
8. Failed validation on save — confirm the lock is retained, not accidentally released.
9. Repeated saves in the same session — confirm the lock persists correctly across multiple
   saves.
10. Save then immediately close — confirm the lock releases correctly.
11. Explicit exit with unload/beacon handlers deliberately disabled (e.g. via browser dev
    tools) — confirm the explicit exit path alone still releases the lock correctly,
    independent of the beacon.

### Regression checks
12. Confirm in-page actions in kassekladde (delete line, "kopier til ny") no longer trigger
    an accidental mid-edit lock release via the `.submit()` bypass bug that was fixed.
13. Run the new `UnlockRecordRegressionTest.test.php` suite and confirm all cases pass.
14. Confirm the kreditor `ordreliste.php` age-based sweep only clears locks genuinely
    abandoned for over an hour, regardless of user, and doesn't break active multi-tab
    sessions for the same user.


## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lock handling when leaving cash journals and orders through Back, Close, New, or page navigation.
  - Locks are now released more reliably when a page is closed or navigated away from.
  - Prevented older or inactive tabs from releasing locks acquired by a newer session.
  - Added safer cleanup of stale order locks after extended inactivity.
  - Draft locks are released only when they belong to the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->