### PR TITLE
JOB-124: Return to the order after printing a partial-delivery packing slip, and fix order Back button landing on the login page

### DIFF
--- a/debitor/formularprint.php
+++ b/debitor/formularprint.php
@@ -31,6 +31,7 @@
 // 20260102 LOE Added department support for background files
 // 20260309 PHR Fixed error in $returside after printing
 // 20260309 PHR Fixed another error in $returside after printing
+// 20260909 Sawaneh JOB-124: accept returside from GET as well as POST.
 
 
 session_start();
@@ -89,8 +90,10 @@ function find_background_file($background, $file_type, $department) {
 
     return null;
 }
-//check Post for returside
-$returside = if_isset($_POST['returside']);
+$returside = ifset($_POST, 'returside');
+if (!$returside) {
+    $returside = nav_sanitize_returside(ifset($_GET, 'returside'));
+}
 $sag_id = 0;
 $sag_q = '';
 if (isset($_GET['id']) && $_GET['id']){

--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -108,6 +108,9 @@
 //                  is credited than invoiced, so it can be reduced. Handles invoice lines that are
 //                  themselves negative. Shows the max in the alert. Removed debug_kreditnota logging.
 // 20260907 CDX/LH Share the invoice payment gate with the assistant's saved-state reader.
+// 20260909 Sawaneh JOB-124: partial-delivery packing-slip buttons pass a returside back to the order.
+// 20260910 Sawaneh Back button: luk.php returside only on the popup=1 request flag (was the popup
+//                  preference, which sent inline/iframe users to the login page); GET returside sanitised.
 
 @session_start();
 $s_id = session_id();
@@ -409,11 +412,15 @@ if (isset($_GET['kundeordnr']) && $_GET['kundeordnr']) { #20200407
 	$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 	$id = $r['id'];
 }
-$returside = if_isset($_GET, NULL, 'returside');
+$returside = nav_sanitize_returside(ifset($_GET, 'returside'));
 if (isset($sag_id)) { // Returside sættes til 'sager' fra sager.php #20210715
 	#  $returside=urlencode("../sager/sager.php?funktion=vis_sag&amp;sag_id=$sag_id");
 }
-if ($popup) $returside = "../includes/luk.php?id=$id&tabel=ordrer";
+// luk.php only when THIS window is a popup (popup=1 flag), not on the user's popup
+// preference: inside the new-design iframe luk.php cannot close anything and
+// used to end on the login page.
+$isPopupRequest = !empty($_GET['popup']) || !empty($_POST['popup']);
+if ($isPopupRequest) $returside = "../includes/luk.php?id=$id&tabel=ordrer";
 
 if (($ret_tekst = if_isset($_GET, NULL, 'ret_tekst')) && ($id = if_isset($_GET, NULL, 'id'))) tekstopslag($sort, $id);
 
@@ -3299,7 +3306,7 @@ function ordreside($id, $regnskab)
 	global $incl_moms;
 	global $lagerantal, $lagernavn, $lagernr, $localPrint;
 	global $oio, $oioubl, $omkunde, $ordresum;
-	global $popup, $procentfakt, $procenttillag, $procentvare;
+	global $popup, $isPopupRequest, $procentfakt, $procenttillag, $procentvare;
 	global $regnaar, $returside, $rvid, $rvnr;
 	global $samlet_pris, $samlet_rabat, $samlet_rabatpct, $showLocalPrint, $sprog_id, $sprog, $svnr;
 	global $txt370, $txt283;
@@ -3338,7 +3345,7 @@ function ordreside($id, $regnskab)
 		$returside = urlencode("../sager/sager.php?funktion=vis_sag&amp;sag_id=$sag_id&amp;konto_id=$konto_id");
 	}
 	if (!$returside) {
-		if ($popup) $returside = "../includes/luk.php?id=$id&tabel=ordrer";
+		if ($isPopupRequest) $returside = "../includes/luk.php?id=$id&tabel=ordrer";
 		else $returside = "ordreliste.php";
 	}
 	$addr1 = $addr2 = NULL;
@@ -4167,9 +4174,10 @@ function ordreside($id, $regnskab)
 			}
 		}
 		if ($lev_max > 0) {
+			$printReturside = urlencode("../debitor/ordre.php?id=$id&returside=$returside");
 			print "<tr class='tableTexting2'><td colspan=\"2\">&nbsp;</td></tr>\n";
 			for ($levnr = 1; $levnr <= $lev_max; $levnr++) {
-				print "<tr><td colspan=\"2\" style='border:0;border-radius:4px;text-align:center;'><button type='button' onclick=\"window.location.href='udskriftsvalg.php?id=$id&valg=$levnr&formular=3'\" style='$buttonStyle;cursor: pointer; padding: 0.2rem; width: 125px;'>" . findtekst('576|Følgeseddel', $sprog_id) . " $levnr</button></td></tr>\n";
+				print "<tr><td colspan=\"2\" style='border:0;border-radius:4px;text-align:center;'><button type='button' onclick=\"window.location.href='udskriftsvalg.php?id=$id&valg=$levnr&formular=3&returside=$printReturside'\" style='$buttonStyle;cursor: pointer; padding: 0.2rem; width: 125px;'>" . findtekst('576|Følgeseddel', $sprog_id) . " $levnr</button></td></tr>\n";
 			}
 		}
 		
@@ -5606,10 +5614,11 @@ function ordreside($id, $regnskab)
 			}
 		}
 		if ($lev_max > 0) {
+			$printReturside = urlencode("../debitor/ordre.php?id=$id&returside=$returside");
 			print "<tr class='tableTexting2'><td colspan=\"2\">&nbsp;</td></tr>\n";
 			for ($levnr = 1; $levnr <= $lev_max; $levnr++) {
 				include("../includes/topline_settings.php");
-				print "<tr><td colspan=\"2\" style='border:0;border-radius:4px;text-align:center;'><button type='button' onclick=\"window.location.href='udskriftsvalg.php?id=$id&valg=$levnr&formular=3'\" style='$buttonStyle;cursor: pointer; padding: 0.2rem; width: 125px;'>" . findtekst('576|Følgeseddel', $sprog_id) . " $levnr</button></td></tr>\n";
+				print "<tr><td colspan=\"2\" style='border:0;border-radius:4px;text-align:center;'><button type='button' onclick=\"window.location.href='udskriftsvalg.php?id=$id&valg=$levnr&formular=3&returside=$printReturside'\" style='$buttonStyle;cursor: pointer; padding: 0.2rem; width: 125px;'>" . findtekst('576|Følgeseddel', $sprog_id) . " $levnr</button></td></tr>\n";
 			}
 		}
 		print "</td></tr></tbody></table></td></tr>\n"; #<- Tabel 4.3

--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -113,7 +113,7 @@
 // 20260909 Sawaneh JOB-124: partial-delivery packing-slip buttons pass a returside back to the order.
 // 20260910 CL/NTR SST-763: tekst ids 5170-5190 moved to 3385-3404; 5180 replaced by existing 828 (Fakturanr.).
 // 20260910 Sawaneh Back button: luk.php returside only on the popup=1 request flag (was the popup
-//                  preference, which sent inline/iframe users to the login page); GET returside sanitised.
+//                  preference, which sent inline/iframe users to the login page); GET, POST and stored returside sanitised.
 
 @session_start();
 $s_id = session_id();
@@ -422,7 +422,7 @@ if (isset($sag_id)) { // Returside sættes til 'sager' fra sager.php #20210715
 // luk.php only when THIS window is a popup (popup=1 flag), not on the user's popup
 // preference: inside the new-design iframe luk.php cannot close anything and
 // used to end on the login page.
-$isPopupRequest = !empty($_GET['popup']) || !empty($_POST['popup']);
+$isPopupRequest = ifset($_GET, 'popup') === '1' || ifset($_POST, 'popup') === '1';
 if ($isPopupRequest) $returside = "../includes/luk.php?id=$id&tabel=ordrer";
 
 if (($ret_tekst = if_isset($_GET, NULL, 'ret_tekst')) && ($id = if_isset($_GET, NULL, 'id'))) tekstopslag($sort, $id);
@@ -1141,7 +1141,7 @@ if ($b_submit) {
 	$datotid         = if_isset($_POST, NULL, 'datotid');
 	$nr              = if_isset($_POST, NULL, 'nr');
 
-	$returside = if_isset($_POST, NULL, 'returside');
+	$returside = nav_sanitize_returside(ifset($_POST, 'returside'));
 	if ($status < 3) $status = if_isset($_POST, NULL, 'status');
 	$godkend = if_isset($_POST, NULL, 'godkend');
 	$restordre = if_isset($_POST, NULL, 'restordre');
@@ -1607,7 +1607,7 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 		if ($sag_id) { #20140507-2
 			header("location:../sager/sager.php?funktion=vis_sag&sag_id=$sag_id");
 		} else {
-			if (!$returside) $returside = if_isset($_GET['returside']);
+			if (!$returside) $returside = nav_sanitize_returside(ifset($_GET, 'returside'));
 			print "<meta http-equiv=\"refresh\" content=\"0;URL=$returside\">\n";
 			exit;
 		}
@@ -3664,7 +3664,7 @@ function ordreside($id, $regnskab)
 		$datotid = if_isset($row, '', 'datotid');
 		$nr = if_isset($row, 0, 'nr') * 1;
 		if (!$returside && if_isset($row, false, 'returside')) {
-			$returside = $row['returside'];
+			$returside = nav_sanitize_returside($row['returside']);
 		}
 		$omkunde = if_isset($row, '', 'omvbet') ? 'on' : '';
 		$betalt = if_isset($row, 0, 'betalt');

--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -56,6 +56,7 @@
 // 20260630 CDX/NTR Fixed land (country) column from printing the countries outside the table and searchable bar not existing.
 // 20260701 Sawaneh Fixed: 'Performed by' is display-only and no longer cleared on return to the list.
 // 20260701 CDX/NTR Fixed the default search to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
+// 20260910 Sawaneh Order links carry the popup=1 request flag so a real popup window still closes on Back.
 
 @session_start();
 $s_id = session_id();
@@ -763,7 +764,7 @@ $custom_columns = array(
 
             file_put_contents("../temp/$db/ordrlst$bruger_id.txt","$row[id];",FILE_APPEND);
 
-            $href = "ordre.php?tjek={$row['id']}&id={$row['id']}&valg=$valg&returside=" . urlencode($_SERVER["REQUEST_URI"]);
+            $href = "ordre.php?" . nav_popup_query($_GET, $_POST) . "tjek={$row['id']}&id={$row['id']}&valg=$valg&returside=" . urlencode($_SERVER["REQUEST_URI"]);
             
             $timestamp = $row['tidspkt'];
             if (strpos($timestamp, ':')) {

--- a/debitor/udskriftsvalg.php
+++ b/debitor/udskriftsvalg.php
@@ -29,6 +29,7 @@
 // 2013.01.17 Oprydning i forb. med fejlsøgning i ret_genfakt.php
 // 2014.01.12 Fremover vises plukliste og følgeseddel kun for lagervarer.
 // 2017.05.05 Ved $udskriv_til=='ingen' returneres uden udskrift.
+// 20260909 Sawaneh JOB-124: forward returside to formularprint.php so print close returns to the order.
 
 
 @session_start();
@@ -46,25 +47,27 @@ $id=if_isset($_GET['id']);
 $valg=if_isset($_GET['valg']);
 $formular=if_isset($_GET['formular']);
 $udskriv_til=if_isset($_GET['udskriv_til']);
+$returside=nav_sanitize_returside(ifset($_GET, 'returside'));
+$returQuery=$returside ? '&returside=' . urlencode($returside) : '';
 
 if ($valg=="tilbage" || $udskriv_til=='ingen') {
 	if ($popup) print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
-	else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php??tjek=$id&id=$id\">";
+	else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?tjek=$id&id=$id\">";
 	exit;
 }
 
 if ($valg) {
 	$query = db_select("select box1, box2 from grupper where art='PV'",__FILE__ . " linje " . __LINE__);
 	$row = db_fetch_array($query);
-	if ($valg==-1)	$ps_fil="formularprint.php?id=$id&formular=$formular";
-	else $ps_fil="formularprint.php?id=$id&formular=3";
+	if ($valg==-1)	$ps_fil="formularprint.php?id=$id&formular=$formular$returQuery";
+	else $ps_fil="formularprint.php?id=$id&formular=3$returQuery";
 
 #	if ((!file_exists($ps_fil))&&($ps_fil!="udskriftsvalg.php"))	{
 #		if (!file_exists("../formularer/$db_id")) {mkdir("../formularer/$db_id",0777);}
 #		$kildefil=str_replace("/$db_id", "", $ps_fil);
 #		copy($kildefil, $ps_fil);
 #	}
-	if ($valg!=-1) $ps_fil="formularprint.php?id=$id&formular=3&lev_nr=$valg";
+	if ($valg!=-1) $ps_fil="formularprint.php?id=$id&formular=3&lev_nr=$valg$returQuery";
 	echo "<meta http-equiv=refresh content=0;url=$ps_fil>";
 	exit;
 #	print "<BODY onLoad=\"JavaScript:window.open('$ps_fil&id=$id' , '' , ',statusbar=no,menubar=no,titlebar=no,toolbar=no,scrollbars=yes, location=1');\">";

--- a/debitor/udskriftsvalg.php
+++ b/debitor/udskriftsvalg.php
@@ -52,6 +52,7 @@ $returQuery=$returside ? '&returside=' . urlencode($returside) : '';
 
 if ($valg=="tilbage" || $udskriv_til=='ingen') {
 	if ($popup) print "<meta http-equiv=\"refresh\" content=\"0;URL=../includes/luk.php\">";
+	elseif ($returside) print "<meta http-equiv=\"refresh\" content=\"0;URL=" . htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\">";
 	else print "<meta http-equiv=\"refresh\" content=\"0;URL=ordre.php?tjek=$id&id=$id\">";
 	exit;
 }
@@ -76,14 +77,14 @@ if ($valg) {
 
 if (db_fetch_array(db_select("select id from grupper where art = 'DIV' and kodenr = '3' and box4='on'",__FILE__ . " linje " . __LINE__))) {
 #	$hurtigfakt='on';
-	print "<meta http-equiv=refresh content=0;url='udskriftsvalg.php?id=$id&valg=-1&formular=2'>";
+	print "<meta http-equiv=refresh content=0;url='udskriftsvalg.php?id=$id&valg=-1&formular=2$returQuery'>";
 	exit;
 }
 
 print "<table width=\"100%\" height=\"100%\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\"><tbody>";
 print "<tr><td align=\"center\" valign=\"top\">";
 print "<table width=\"100%\" height=\"1%\" align=\"center\" border=\"0\" cellspacing=\"2\" cellpadding=\"0\"><tbody>";
-print "<td width=\"10%\" $top_bund><a href=udskriftsvalg.php?valg=tilbage&id=$id accesskey=L>Luk</a></td>";
+print "<td width=\"10%\" $top_bund><a href=\"udskriftsvalg.php?valg=tilbage&id=$id$returQuery\" accesskey=L>Luk</a></td>";
 print "<td width=\"80%\" $top_bund align=\"center\">Udskriftsvalg</td>";
 print "<td width=\"10%\" $top_bund align = \"right\"><br></td>";
 print "</tbody></table>";
@@ -100,10 +101,10 @@ $q = db_select("select * from batch_salg where ordre_id = $id",__FILE__ . " linj
 while ($r = db_fetch_array($q)) {
 	if ($r['lev_nr']>$lev_nr) {$lev_nr=$r['lev_nr'];}
 }
-if ($leveres) print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=-1&formular=9'>Plukliste</a></td></tr>";
-print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=-1&formular=2'>Ordrebekr&aelig;ftelse</a></td></tr>";
+if ($leveres) print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=-1&formular=9$returQuery'>Plukliste</a></td></tr>";
+print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=-1&formular=2$returQuery'>Ordrebekr&aelig;ftelse</a></td></tr>";
 for ($x=1; $x<=$lev_nr; $x++) {
-	print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=$x&formular=3'>F&oslash;lgeseddel $x</a></td></tr>";
+	print "<tr><td align=center> <a href='udskriftsvalg.php?id=$id&valg=$x&formular=3$returQuery'>F&oslash;lgeseddel $x</a></td></tr>";
 }
 print "</tbody></table></td>";
 print "</tbody></table>";

--- a/includes/luk.php
+++ b/includes/luk.php
@@ -20,6 +20,7 @@
 // Copyright (c) 2004-2011 DANOSOFT ApS
 // ------------------------------------------------------------------------------
 // 20260907 CDX/LH Restrict record unlocking to supported tables and escape refresh targets.
+// 20260910 Sawaneh Blocked-close fallback without returside goes to nav_back_url(), not the login page.
 ?>
 <head>
 
@@ -82,8 +83,9 @@ if ($popup || !$returside) {
 	if ($browser=='ie') print  "<body onload=\"javascript:closeIE();\">";
 	print "<body onload=\"javascript:window.opener.focus();window.close();\">";
 	// When window.close() is blocked (page not script-opened, e.g. inside the
-	// new-design iframe), fall back to the returside instead of the login page.
-	$lukFallback = $returside ? $returside : "../index/index.php";
+	// new-design iframe), fall back to the returside, else to the previous page
+	// from the nav stack - never to the login page.
+	$lukFallback = $returside ? $returside : nav_back_url();
 	$lukFallback = htmlspecialchars($lukFallback, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 	print "<meta http-equiv=\"refresh\" content=\"1;URL=$lukFallback\">";
 } elseif ($returside) {

--- a/includes/udskriv.php
+++ b/includes/udskriv.php
@@ -45,6 +45,7 @@
 // 20260820 CX/PHR Return reminder prints to the reminder instead of the debtor order form.
 // 20260901 CL/LH SD-664: ret <?= i dobbelt-quoted streng (redirect ved manglende pdftk blev aldrig udfort)
 //             og giv retur-link ved 'PDF-fil ikke fundet' i stedet for blindgyde (browser-Back re-POSTer)
+// 20260909 Sawaneh JOB-124: menu S honours a returside pointing at the debtor order instead of forcing the order list.
 
 @session_start();
 $s_id=session_id();
@@ -446,7 +447,9 @@ if (file_exists("../temp/$ps_fil.pdf")) {
 					$href = "../debitor/rykker.php?rykker_id=" . (int)$id;
 				 } elseif (substr($art,0,1)=='K'){
 					$href="\"../kreditor/ordre.php?tjek=$id&id=$id&returside=" . urlencode($returside) . "\" accesskey=\"L\"";
-				 }elseif ($art == ('DO' || 'PO') && (strpos($returside, "ordreliste.php") !== false) && $locat) {
+				 } elseif (strpos($returside, '../debitor/ordre.php?') === 0) {
+					$href = "\"" . htmlspecialchars($returside, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\" accesskey=\"L\"";
+				 } elseif ($art == ('DO' || 'PO') && (strpos($returside, "ordreliste.php") !== false) && $locat) {
 					$href = "../debitor/ordreliste.php";
 				 } else {
 					if($art == 'DO'){


### PR DESCRIPTION
## What are the changes about?
Provide a brief explanation of the changes you have made

## What are the changes about?

**JOB-124 (MEDSHOP):** after printing a følgeseddel for a partial delivery from the order, "Luk" landed on the order list instead of the order.

Root cause: the two "Følgeseddel N" buttons in `debitor/ordre.php` were the only print links without a `returside`. `udskriftsvalg.php` never forwarded one and `formularprint.php` only read it from POST, so `includes/udskriv.php` fell back to its PDF default of `../debitor/ordreliste.php`. The menu-S close button also hardcoded the order list for DO orders.

Fix: the buttons pass a sanitised `returside` pointing at the order (preserving the order's own returside), `udskriftsvalg.php` forwards it, `formularprint.php` accepts GET as well as POST, and the menu-S close button honours a returside that points at the debtor order. The ordreliste default in `udskriv.php` is untouched, so prints started from the order list, plukliste and ordrebekræftelse behave as before. Also fixes the `ordre.php??tjek=` typo in `udskriftsvalg.php`.

**Order Back button → login page (found while testing):** with the user's pop-up preference on (grupper USET box2), `ordre.php` replaced any returside with a bare `luk.php` link. Inside the new-design iframe `luk.php` cannot close the window, had no returside, and fell back to `index.php`, whose frame-buster then showed the login form in the whole window while the session was still alive.

Fix: `ordre.php` only uses `luk.php` on the `popup=1` request flag (WP-1.3c pattern) and sanitises the GET returside; `ordreliste.php` carries `popup=1` into order links so real popup windows still close on Back; `luk.php`'s blocked-close fallback goes to `nav_back_url()` instead of the login page.

## Files

- `debitor/ordre.php` – returside on the two Følgeseddel buttons; popup=1 request flag instead of preference; GET returside sanitised
- `debitor/udskriftsvalg.php` – read/sanitise/forward returside; `??tjek` typo
- `debitor/formularprint.php` – returside from POST, else sanitised GET
- `includes/udskriv.php` – menu-S close honours a `../debitor/ordre.php?` returside
- `debitor/ordreliste.php` – order links carry `popup=1` when the list itself is a popup
- `includes/luk.php` – blocked-close fallback → `nav_back_url()`

## Test scenarios

Done on ssl12 (2026-09-10):
- [x] test_12, admin user with pop-ups on: order Back returns to the order list, no login page
- [x] Order 216043: partial delivery of line 1, "Delivery note 1", Luk returns to the order (URL carries `returside=../debitor/ordre.php?id=…&returside=ordreliste.php`)


## Have you checked the following?
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines


## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved return navigation when viewing, printing, or packing partial deliveries from an order.
- Preserved return destinations across order lists, print selections, delivery notes, and forms.
- Popup order windows now close correctly when navigating back.
- Return destinations are handled more consistently and securely across supported navigation paths.
- Back navigation uses the most relevant previous page instead of redirecting to the login page when no return destination is available.
- Added support for returning directly to the originating debtor order from the relevant menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->