### PR TITLE
SD-686: grid filter defaults are honoured

### DIFF
--- a/includes/grid.php
+++ b/includes/grid.php
@@ -22,6 +22,7 @@ Regards:) 20260220 LOE
 // 20260817 Sawaneh Sort descending columns NULLS LAST, honor defaultSortDirection on
 //                  first header click and validate the request-sourced sort value.
 // 20260910 CDX/PHR Preserve a literal zero search in both row and count queries.
+// 20260911 LOE SD-686: grid filter defaults declared with "checked" are honoured.
 ######################### >>>>>>>EndNotice<<<<<<<<<<<<##############################
 /**
  * Extracts values from a specific column in a multi-dimensional array.
@@ -560,7 +561,11 @@ function fetch_grid_setup($id, $columns_filtered, $search_setup, $filters) {
 
         // Encode configurations as JSON for storage
         $columns_json = db_escape_string(json_encode($columns_save));
-        $filters_json = db_escape_string(json_encode($filters));
+        // SD-686: a fresh grid row starts with an empty *selection* map. Filter
+        // defaults belong to the page's $filters definition and are applied by
+        // updateCheckedValues(); storing the definitions here left the declared
+        // defaults unreadable on the first page view.
+        $filters_json = '{}';
         $search_json  = db_escape_string(json_encode($search_setup));
 
         // Insert the new grid setup into the database
@@ -621,16 +626,18 @@ function fill_missing_values($firstArray, $secondArray) {
  * @return array The updated first array with the 'checked' values for options updated.
  */
 function updateCheckedValues(array $firstArray, array $secondArray) {
+    // SD-686: only a saved *selection* map may override a filter option's declared
+    // default. Where nothing (or only a legacy definition list) has been saved, the
+    // declared value stays in force instead of being forced back to ''.
     foreach ($firstArray as &$filter) {
         $filterName = $filter['filterName'];
-        if (isset($secondArray[$filterName])) {
-            $updatesForFilter = $secondArray[$filterName];
-            foreach ($filter['options'] as &$option) {
-                $option['checked'] = isset($updatesForFilter[$option['name']]) ? $updatesForFilter[$option['name']] : '';
-            }
-        } else {
-            foreach ($filter['options'] as &$option) {
+        $updatesForFilter = isset($secondArray[$filterName]) ? $secondArray[$filterName] : array();
+        foreach ($filter['options'] as &$option) {
+            if (!isset($option['checked'])) {
                 $option['checked'] = '';
+            }
+            if (isset($updatesForFilter[$option['name']])) {
+                $option['checked'] = $updatesForFilter[$option['name']];
             }
         }
     }
@@ -1631,7 +1638,8 @@ function render_filters($id, $filters, $all_filters) {
             <span><b>{$filter["filterName"]} ({$filter["joinOperator"]})</b></span>
 HTML;
         foreach ($filter["options"] as $filterItem) {
-            print "<div><label><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
+            // SD-686: submit unticked options too, so turning a declared default off persists.
+            print "<div><label><input type='hidden' name='filter[$id][$filter[filterName]][$filterItem[name]]' value=''><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
         }
 
         echo <<<HTML

--- a/includes/kreditorOrderFuncIncludes/creditor_orderlist_grid.php
+++ b/includes/kreditorOrderFuncIncludes/creditor_orderlist_grid.php
@@ -2,6 +2,7 @@
 //..kreditorOrderFuncIncludes/creditor_orderlist_grid.php
 // 20260630 CDX/NTR Fixed land (country) column from printing the countries outside the table and searchable bar not existing.
 //                  As well as making the table footer a proper page footer and fixing scrollbar weirdness with footer.
+// 20260911 LOE SD-686: grid filter defaults declared with "checked" are honoured.
 
 function is_ajax_request() {
     return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && 
@@ -627,7 +628,11 @@ function fetch_grid_setup($id, $columns_filtered, $search_setup, $filters) {
 
         // Encode configurations as JSON for storage
         $columns_json = db_escape_string(json_encode($columns_save));
-        $filters_json = db_escape_string(json_encode($filters));
+        // SD-686: a fresh grid row starts with an empty *selection* map. Filter
+        // defaults belong to the page's $filters definition and are applied by
+        // updateCheckedValues(); storing the definitions here left the declared
+        // defaults unreadable on the first page view.
+        $filters_json = '{}';
         $search_json  = db_escape_string(json_encode($search_setup));
 
         // Insert the new grid setup into the database
@@ -685,16 +690,18 @@ function fill_missing_values($firstArray, $secondArray) {
  * @return array The updated first array with the 'checked' values for options updated.
  */
 function updateCheckedValues(array $firstArray, array $secondArray) {
+    // SD-686: only a saved *selection* map may override a filter option's declared
+    // default. Where nothing (or only a legacy definition list) has been saved, the
+    // declared value stays in force instead of being forced back to ''.
     foreach ($firstArray as &$filter) {
         $filterName = $filter['filterName'];
-        if (isset($secondArray[$filterName])) {
-            $updatesForFilter = $secondArray[$filterName];
-            foreach ($filter['options'] as &$option) {
-                $option['checked'] = isset($updatesForFilter[$option['name']]) ? $updatesForFilter[$option['name']] : '';
-            }
-        } else {
-            foreach ($filter['options'] as &$option) {
+        $updatesForFilter = isset($secondArray[$filterName]) ? $secondArray[$filterName] : array();
+        foreach ($filter['options'] as &$option) {
+            if (!isset($option['checked'])) {
                 $option['checked'] = '';
+            }
+            if (isset($updatesForFilter[$option['name']])) {
+                $option['checked'] = $updatesForFilter[$option['name']];
             }
         }
     }
@@ -1633,7 +1640,8 @@ function render_filters($id, $filters, $all_filters) {
             <span><b>{$filter["filterName"]} ({$filter["joinOperator"]})</b></span>
 HTML;
         foreach ($filter["options"] as $filterItem) {
-            print "<div><label><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
+            // SD-686: submit unticked options too, so turning a declared default off persists.
+            print "<div><label><input type='hidden' name='filter[$id][$filter[filterName]][$filterItem[name]]' value=''><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
         }
 
         echo <<<HTML

--- a/includes/orderFuncIncludes/grid_account_lookup.php
+++ b/includes/orderFuncIncludes/grid_account_lookup.php
@@ -26,6 +26,7 @@
 // 20260513 CL/PHR Solved double order creation problem
 // 20260827 CDX/PHR Preserve KO in supplier lookup AJAX and POS navigation.
 // 20260901 CL/LH Pass o_art=KO along on AJAX row click so supplier choice survives
+// 20260911 LOE SD-686: grid filter defaults declared with "checked" are honoured.
 
 /**
  * Extracts values from a specific column in a multi-dimensional array.
@@ -564,7 +565,11 @@ function fetch_grid_setup($id, $columns_filtered, $search_setup, $filters) {
 
         // Encode configurations as JSON for storage
         $columns_json = db_escape_string(json_encode($columns_save));
-        $filters_json = db_escape_string(json_encode($filters));
+        // SD-686: a fresh grid row starts with an empty *selection* map. Filter
+        // defaults belong to the page's $filters definition and are applied by
+        // updateCheckedValues(); storing the definitions here left the declared
+        // defaults unreadable on the first page view.
+        $filters_json = '{}';
         $search_json  = db_escape_string(json_encode($search_setup));
 
         // Insert the new grid setup into the database
@@ -622,16 +627,18 @@ function fill_missing_values($firstArray, $secondArray) {
  * @return array The updated first array with the 'checked' values for options updated.
  */
 function updateCheckedValues(array $firstArray, array $secondArray) {
+    // SD-686: only a saved *selection* map may override a filter option's declared
+    // default. Where nothing (or only a legacy definition list) has been saved, the
+    // declared value stays in force instead of being forced back to ''.
     foreach ($firstArray as &$filter) {
         $filterName = $filter['filterName'];
-        if (isset($secondArray[$filterName])) {
-            $updatesForFilter = $secondArray[$filterName];
-            foreach ($filter['options'] as &$option) {
-                $option['checked'] = isset($updatesForFilter[$option['name']]) ? $updatesForFilter[$option['name']] : '';
-            }
-        } else {
-            foreach ($filter['options'] as &$option) {
+        $updatesForFilter = isset($secondArray[$filterName]) ? $secondArray[$filterName] : array();
+        foreach ($filter['options'] as &$option) {
+            if (!isset($option['checked'])) {
                 $option['checked'] = '';
+            }
+            if (isset($updatesForFilter[$option['name']])) {
+                $option['checked'] = $updatesForFilter[$option['name']];
             }
         }
     }
@@ -1249,7 +1256,8 @@ function render_filters($id, $filters, $all_filters) {
             <span><b>{$filter["filterName"]} ({$filter["joinOperator"]})</b></span>
 HTML;
         foreach ($filter["options"] as $filterItem) {
-            print "<div><label><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
+            // SD-686: submit unticked options too, so turning a declared default off persists.
+            print "<div><label><input type='hidden' name='filter[$id][$filter[filterName]][$filterItem[name]]' value=''><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
         }
 
         echo <<<HTML

--- a/includes/orderFuncIncludes/grid_order.php
+++ b/includes/orderFuncIncludes/grid_order.php
@@ -7,6 +7,7 @@
 // 20260701 CDX/NTR - Changed DEFAULT_GENERATE_SEARCH to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
 // 20260817 Sawaneh Sort descending columns NULLS LAST so rows without a date no longer
 //                  displace the newest rows, and validate the request-sourced sort value.
+// 20260911 LOE SD-686: grid filter defaults declared with "checked" are honoured.
 
 /** 
  * Extracts values from a specific column in a multi-dimensional array.
@@ -683,7 +684,11 @@ function fetch_grid_setup($id, $columns_filtered, $search_setup, $filters) {
 
         // Encode configurations as JSON for storage
         $columns_json = db_escape_string(json_encode($columns_save));
-        $filters_json = db_escape_string(json_encode($filters));
+        // SD-686: a fresh grid row starts with an empty *selection* map. Filter
+        // defaults belong to the page's $filters definition and are applied by
+        // updateCheckedValues(); storing the definitions here left the declared
+        // defaults unreadable on the first page view.
+        $filters_json = '{}';
         $search_json  = db_escape_string(json_encode($search_setup));
 
         // Insert the new grid setup into the database
@@ -751,16 +756,18 @@ function fill_missing_values($firstArray, $secondArray) {
  * @return array The updated first array with the 'checked' values for options updated.
  */
 function updateCheckedValues(array $firstArray, array $secondArray) {
+    // SD-686: only a saved *selection* map may override a filter option's declared
+    // default. Where nothing (or only a legacy definition list) has been saved, the
+    // declared value stays in force instead of being forced back to ''.
     foreach ($firstArray as &$filter) {
         $filterName = $filter['filterName'];
-        if (isset($secondArray[$filterName])) {
-            $updatesForFilter = $secondArray[$filterName];
-            foreach ($filter['options'] as &$option) {
-                $option['checked'] = isset($updatesForFilter[$option['name']]) ? $updatesForFilter[$option['name']] : '';
-            }
-        } else {
-            foreach ($filter['options'] as &$option) {
+        $updatesForFilter = isset($secondArray[$filterName]) ? $secondArray[$filterName] : array();
+        foreach ($filter['options'] as &$option) {
+            if (!isset($option['checked'])) {
                 $option['checked'] = '';
+            }
+            if (isset($updatesForFilter[$option['name']])) {
+                $option['checked'] = $updatesForFilter[$option['name']];
             }
         }
     }
@@ -1820,7 +1827,8 @@ function render_filters($id, $filters, $all_filters) {
             <span><b>{$filter["filterName"]} ({$filter["joinOperator"]})</b></span>
 HTML;
         foreach ($filter["options"] as $filterItem) {
-            print "<div><label><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
+            // SD-686: submit unticked options too, so turning a declared default off persists.
+            print "<div><label><input type='hidden' name='filter[$id][$filter[filterName]][$filterItem[name]]' value=''><input type='checkbox' $filterItem[checked] name='filter[$id][$filter[filterName]][$filterItem[name]]'>$filterItem[name]</label></div>";
         }
 
         echo <<<HTML

--- a/tests/characterization/includes/UpdateCheckedValuesTest.test.php
+++ b/tests/characterization/includes/UpdateCheckedValuesTest.test.php
@@ -1,0 +1,137 @@
+<?php
+// 20260911 LOE Cover SD-686: declared grid filter defaults are honoured and saved selections still win.
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+// grid.php defines updateCheckedValues() unconditionally (no function_exists guard),
+// so it is loaded in a process of its own.
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class UpdateCheckedValuesTest extends TestCase
+{
+    /** @var string[] */
+    private array $phpWarnings = array();
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/includes/grid.php';
+    }
+
+    /**
+     * Builds the filter definition a page hands to create_datagrid().
+     *
+     * @return array<int, array{filterName: string, joinOperator: string, options: array<int, array<string, mixed>>}>
+     */
+    private function declaredFilter($checked, $withCheckedKey = true)
+    {
+        $option = array('name' => 'Vis udgået');
+        if ($withCheckedKey) {
+            $option['checked'] = $checked;
+        }
+        $option['sqlOn'] = '';
+        $option['sqlOff'] = "(v.lukket IS NULL OR v.lukket = '0')";
+
+        return array(array(
+            'filterName'   => 'Misc',
+            'joinOperator' => 'and',
+            'options'      => array($option),
+        ));
+    }
+
+    /**
+     * @param mixed $stored filter_setup as read from the datatables row (already decoded, or null)
+     * @return mixed the resolved 'checked' state of the single option
+     */
+    private function resolvedChecked($checked, $stored, $withCheckedKey = true)
+    {
+        $setup = is_array($stored) ? $stored : array();
+        $out = updateCheckedValues($this->declaredFilter($checked, $withCheckedKey), $setup);
+
+        return $out[0]['options'][0]['checked'];
+    }
+
+    public static function nothingSavedProvider(): array
+    {
+        return array(
+            'fresh grid row ({})'                  => array(array()),
+            'stored as NULL'                       => array(null),
+            'legacy definition list (pre-fix row)' => array(array(array('filterName' => 'Misc', 'options' => array()))),
+            'empty string'                         => array(''),
+        );
+    }
+
+    /**
+     * The SD-686 defect: a stored setup that carries no selection map forced every
+     * option back to '', so a page's declared default never took effect.
+     */
+    #[DataProvider('nothingSavedProvider')]
+    public function testDeclaredCheckedIsHonouredWhenNothingIsSaved($stored): void
+    {
+        self::assertSame('checked', $this->resolvedChecked('checked', $stored));
+    }
+
+    #[DataProvider('nothingSavedProvider')]
+    public function testDeclaredEmptyStaysUnchecked($stored): void
+    {
+        self::assertSame('', $this->resolvedChecked('', $stored));
+    }
+
+    public static function savedSelectionProvider(): array
+    {
+        return array(
+            'saved ticked'   => array('{"Misc":{"Vis udgået":"checked"}}', 'checked'),
+            'saved unticked' => array('{"Misc":{"Vis udgået":""}}', ''),
+        );
+    }
+
+    #[DataProvider('savedSelectionProvider')]
+    public function testSavedSelectionWinsOverDeclaredDefault($json, $expected): void
+    {
+        self::assertSame($expected, $this->resolvedChecked('checked', json_decode($json, true)));
+    }
+
+    public function testOptionWithoutDeclaredCheckedKeyResolvesToEmptyString(): void
+    {
+        self::assertSame('', $this->resolvedChecked(null, null, false));
+    }
+
+    /**
+     * An unticked checkbox is not submitted at all, so without a hidden companion the
+     * panel would store an empty map and a declared default could never be turned off.
+     */
+    public function testFilterPanelSubmitsUntickedOptionsSoAnUntickPersists(): void
+    {
+        $filters = $this->declaredFilter('checked');
+
+        ob_start();
+        render_filters('ordrestat', $filters, $filters);
+        $html = ob_get_clean();
+
+        $hidden = "<input type='hidden' name='filter[ordrestat][Misc][Vis udgået]' value=''>";
+        $hiddenPos = strpos($html, $hidden);
+        self::assertNotFalse($hiddenPos, 'Unticked options must still be submitted.');
+        self::assertLessThan(strpos($html, "<input type='checkbox'"), $hiddenPos, 'The hidden value must precede the checkbox so a ticked box wins.');
+    }
+
+    public function testResolvingFilterStateRaisesNoPhpWarnings(): void
+    {
+        $this->phpWarnings = array();
+        set_error_handler(function ($severity, $message, $file, $line) {
+            $this->phpWarnings[] = $message . ' (' . $file . ':' . $line . ')';
+            return true;
+        }, E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE);
+
+        try {
+            $this->resolvedChecked('checked', null);
+            $this->resolvedChecked('', array('Misc' => array('Vis udgået' => '')));
+            $this->resolvedChecked(null, null, false);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(array(), $this->phpWarnings);
+    }
+}


### PR DESCRIPTION
## What are the changes about?

A grid filter option can be declared active from the start with `"checked" => "checked"` — or with a value computed from page state, e.g. `$skjul_lukkede ? "" : "checked"` — but that default never took effect: on a user's first view the checkbox was always empty, and the filter only worked after the user ticked it and saved.

**Cause.** `fetch_grid_setup()` wrote the filter *definitions* (`json_encode($filters)`) into `datatables.filter_setup`, while `updateCheckedValues()` — the only reader of that column — expects the saved *selection* map (`{"Misc":{"Vis udgået":"checked"}}`) that `save_filter_setup()` writes. A definition list has no `$secondArray[$filterName]` key, so the else-branch forced every option back to `''`; that also flipped `build_query()` to the `sqlOff` branch (`includes/grid.php:709-714`).

**Fix.**
- `fetch_grid_setup()` stores an empty selection map (`'{}'`) instead of the definitions — definitions are not selections.
- `updateCheckedValues()` lets a saved selection win per option, and where nothing has been saved it now honours the declared default; an option with no declared `checked` key resolves to `''` (no new undefined-key warnings).
- `render_filters()` gives every checkbox a hidden companion input, so an **unticked** option is submitted too. An unchecked box is not posted at all, so without this the panel stored an empty map — indistinguishable from "never saved" — and a declared default could never be turned off once saved.
- Applied to all four grid implementations: `includes/grid.php`, `includes/kreditorOrderFuncIncludes/creditor_orderlist_grid.php`, `includes/orderFuncIncludes/grid_order.php`, `includes/orderFuncIncludes/grid_account_lookup.php`.

**Behaviour consequence (intended).** Any page that declares a checked default now honours it on the first view: `lager/lister/{ordrestatus,indkøb,vareliste}` ("Vis udgået" ticked ⇒ discontinued items shown), `debitor/debitor.php` (`$skjul_lukkede`), `debitor/ordreliste.php` (`$valg`). A user's own saved selection always wins — including an explicit untick, which now persists across reloads.

## How I verified this

**Reproduced on master** (`c06274da`, tenant `tenant_db`, user `username`, grid `ordrestat`): with no `datatables` row for that user + grid, opening Lager → Ordrevisning → Redigér → Filtre showed "Vis udgået" **unchecked**, although `lager/lister/ordrestatus.php:491` declares `"checked" => "checked"`; the list hid discontinued items. The row that page load created held the definition list (`[{"filterName":"Misc",…"checked":"checked"…}]`), the format the reader cannot use (visible in the application's modify/query log).

**After the fix:** the same first view renders the option **checked**, and the row holds `{}`.

**Automated test:** new `tests/characterization/includes/UpdateCheckedValuesTest.test.php` — 13 assertions covering declared default (fresh `{}` / legacy definition-list row / NULL / empty), declared `""`, saved-selection precedence (ticked and unticked), the hidden companion input that makes an untick persist, an option with no declared `checked` key, and a warning trap. Result here: `OK, Tests: 13, Assertions: 14` (PHPUnit 10.5 phar on PHP 8.1).
**`composer test` was not run on this machine:** `composer.lock` pins PHPUnit 11.5.56, which requires PHP ≥ 8.2, and this box only has PHP 8.1 (no `vendor/`). The new test is picked up by the `characterization` suite in CI (`phpunit.xml`, `.test.php` discovery).

**Manual scenarios per affected file/function (pre-PR test report):**

| File / grid | Scenario |
|---|---|
| `lager/lister/ordrestatus.php` (`ordrestat`) | Remove the user's `datatables` row → open the filter panel: "Vis udgået" ticked, discontinued items (`lukket='1'`) listed. |
| `lager/lister/ordrestatus.php` (`ordrestat`) | Untick "Vis udgået" → Gem → reload the list: stays unticked and discontinued items stay hidden; `filter_setup` = `{"Misc":{"Vis udgået":""}}`. Also try "Fjern alle" → Gem → reload: stays off. |
| `lager/lister/indkøb.php` (`indkøb`), `lager/lister/vareliste.php` (`varelst1`) | Same first-visit check (tick is honoured on a fresh row). |
| `debitor/debitor.php` (`debitor_list`) | View setup that does *not* hide closed debtors → Misc "Vis udgået" ticked, closed debtors listed; with `$skjul_lukkede` set → unticked. |
| `debitor/ordreliste.php` (`ordrelst_<valg>`) | `?valg=ordrer` / `faktura` / `tilbud` / `pbs` → Redigér → Filtre: the matching Ordretype checkbox reflects the mode. |
| `kreditor/productLookup.php` | Filter panel: Base/Find/Supplier defaults ticked. Results unchanged — the same conditions are hard-coded in the page's `$where_conditions`, so they were already applied. |
| Regression | Users with saved filters: selections still win. Grids with no declared default: unchanged. |

**Note for existing saved setups:** rows saved before this change contain only *ticked* options. For such a row, an option the user had unticked was never recorded, so it will show the declared default once — saving the panel again (now with the hidden companion inputs) records it explicitly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Grid filters now honor their configured default selections on first load.
  - Saved filter choices correctly override defaults when present.
  - Clearing a default filter is now preserved after saving.
  - Unselected filter options are submitted reliably.

- **Tests**
  - Added coverage for default handling, saved selections, cleared filters, and warning-free filter processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->