### PR TITLE
Job 128 split order keep ordrenr

### DIFF
--- a/index/main.php
+++ b/index/main.php
@@ -35,6 +35,10 @@
 // 20260907 CDX/LH Fjernede gammel widget-loader, saa SALDI Assist kun indlaeses en gang
 // 20260907 CDX/LH Preserve iframe navigation while merging the current shell integration.
 // 20260907 CDX/LH Enable the saved-record bridge when the installation opts in.
+// 20260910 Sawaneh JOB-128: hash sync raced its setTimeout(0) guard, so a page rendered on a POST
+//                 response (kreditor split view, bare ordre.php URL) got reloaded from the hash as
+//                 ordre.php?inframe=1 = empty new order. Track the shell-written hash explicitly and
+//                 ignore the inframe flag when deciding whether the iframe already shows the target.
 @session_start();
 $s_id = session_id();
 
@@ -529,6 +533,18 @@ function brightenColor($color, $amount = 0.2) {
     }
   }
 
+  // Compare shell paths without the inframe flag: a page reached by an in-frame
+  // redirect (ordre.php?id=X) has no inframe=1 yet still is the requested page.
+  const strip_inframe = (path) => {
+    try {
+      const url = new URL(path, location.origin);
+      url.searchParams.delete('inframe');
+      return url.pathname + url.search;
+    } catch (e) {
+      return path;
+    }
+  }
+
   const update_iframe = (uri) => {
     const iframe = document.querySelector(".content-iframe")
     const baseUrl = (location + "").split("/").splice(0, 4).join("/");
@@ -542,7 +558,7 @@ function brightenColor($color, $amount = 0.2) {
     }
     const targetPath = parsedTargetUrl.pathname + parsedTargetUrl.search;
 
-    if (get_iframe_path() === targetPath) {
+    if (strip_inframe(get_iframe_path()) === strip_inframe(targetPath)) {
       return;
     }
 
@@ -562,13 +578,20 @@ function brightenColor($color, $amount = 0.2) {
   // Check for page reloads and manage inital load of iframe
   update_iframe(window.location.hash == "" ? "/index/dashboard.php" : window.location.hash.replace("#", ""));
 
-  let manualHashChange = true;
+  // Hash the shell wrote itself from an iframe load. hashchange is dispatched
+  // asynchronously, so a timer-based flag could reset before the event arrived
+  // and the shell would then reload the iframe from the hash - fatal for pages
+  // rendered straight on a POST response (e.g. kreditor split view), whose URL
+  // carries no id and reloads as an empty form.
+  let shellWrittenHash = null;
   addEventListener("hashchange", (event) => {
-    if (manualHashChange) {
-      const newHash = event.newURL.split("#")[1];
-      if (newHash && newHash !== "/") {
-        update_iframe(newHash);
-      }
+    const newHash = event.newURL.split("#")[1];
+    if (shellWrittenHash !== null && newHash === shellWrittenHash) {
+      shellWrittenHash = null;
+      return;
+    }
+    if (newHash && newHash !== "/") {
+      update_iframe(newHash);
     }
   });
 
@@ -577,14 +600,8 @@ function brightenColor($color, $amount = 0.2) {
     const path = "/" + iframe.contentWindow.document.location.href.split("/").slice(4).join("/");
 
     if (window.location.hash !== "#" + path) {
-      // Prevent iframe load hashchange from triggering update_iframe
-      manualHashChange = false;
+      shellWrittenHash = path;
       window.location.hash = path;
-
-      // Reset manualHashChange flag after the hash has been set
-      setTimeout(() => {
-        manualHashChange = true;
-      }, 0);
     }
 
     setCookie('last-sidebar-location', path, 1);

--- a/kreditor/orderIncludes/moveOrderLines.php
+++ b/kreditor/orderIncludes/moveOrderLines.php
@@ -45,6 +45,10 @@
 // 20260905 SZ MB-38/CodeRabbit: GET_LOCK() returns 0 on timeout / NULL on error, which the earlier
 //             fix ignored - check for a return of 1 and abort the split with an alert instead of
 //             risking a duplicate ordrenr if the lock wasn't actually acquired.
+// 20260910 Sawaneh JOB-128: reverted the MB-38 ordrenr reassignment (and its advisory lock). MEDSHOP
+//                 splits supplier orders so the back-ordered lines can be received later on the
+//                 ORIGINAL order number; a split-off order must therefore keep the source ordrenr,
+//                 exactly as the restordre flow in kreditor/ordre.php already does at partial delivery.
 
 print "<!-- BEGIN orderIncludes/moveOrderLines.php -->";
 #print "moveOrderLines.php<br>";
@@ -80,30 +84,12 @@ else {
 	$newId = $_POST['MoveItemsTo'];
 	# Create new order if it is not selected
 	if ($newId == '0') {
-		# MB-38/CodeRabbit: serialize ordrenr allocation so two concurrent splits can't compute the
-		# same "next free number" - hold the lock until this transaction actually commits (below),
-		# since a concurrent transaction's MAX(ordrenr) can't see our new row until then anyway.
-		if ($db_type == 'mysql' || $db_type == 'mysqli') {
-			$lockResult = db_fetch_array(db_select("SELECT GET_LOCK('kreditor_ordre_split_ordrenr', 10) AS lock_ok", __FILE__ . " linje " . __LINE__));
-			if ($lockResult['lock_ok'] != 1) {
-				# GET_LOCK returns 0 on timeout or NULL on error - don't risk allocating a
-				# duplicate ordrenr, make the user retry the split instead.
-				alert("Kunne ikke oprette ny ordre lige nu (ordrenummer var l&aring;st af en anden bruger). Pr&oslash;v igen.");
-				transaktion('rollback');
-				exit;
-			}
-		} else {
-			# pg_advisory_xact_lock blocks until it can acquire the lock (no timeout/failure case)
-			db_select("SELECT pg_advisory_xact_lock(hashtext('kreditor_ordre_split_ordrenr'))", __FILE__ . " linje " . __LINE__);
-		}
-		$newOrderCreated = true;
 		$qtxt = "select max(id) as new_id FROM ordrer";
 		$r = db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__));
 		$newId = $r['new_id'] + 1;
-		$newOrdrenr = "select max(ordrenr) + 1 FROM ordrer WHERE art = 'KO' OR art = 'KK'";	# MB-38 - kreditor order numbering is its own sequence, scoped like kreditor/ublimport.php's next-number lookup
 		$qtxt = "CREATE TEMPORARY TABLE temp_table AS SELECT * FROM ordrer WHERE id='$id'";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
-		$qtxt = "UPDATE temp_table SET id='$newId', ordrenr=($newOrdrenr) WHERE id='$id'";	# MB-38 - give the split-off order its own number instead of cloning the source's
+		$qtxt = "UPDATE temp_table SET id='$newId' WHERE id='$id'";	# JOB-128 - the split-off order keeps the source ordrenr on purpose (same as restordre in ordre.php)
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		$qtxt = "INSERT INTO ordrer SELECT * FROM temp_table";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -249,11 +235,6 @@ else {
 		}
 	}
 	transaktion('commit');
-	# MB-38/CodeRabbit: pg_advisory_xact_lock releases itself on commit above; GET_LOCK is
-	# connection-scoped, not transaction-scoped, so release it explicitly now the row is visible.
-	if (!empty($newOrderCreated) && ($db_type == 'mysql' || $db_type == 'mysqli')){
-		db_select("SELECT RELEASE_LOCK('kreditor_ordre_split_ordrenr')", __FILE__ . " linje " . __LINE__);
-	}
 	/*
 	$qtxt = "SELECT MAX(id) - nextval('ordrer_id_seq') as nextval FROM ordrer"; #20230206
 	$r = db_fetch_array(db_select($qtxt,__FILE__ . " linje " . __LINE__));


### PR DESCRIPTION
## What are the changes about?
Provide a brief explanation of the changes you have made
## Problem

MEDSHOP (saldi_390): "Opdel -> Opret ny ordre" on supplier order K16288 created K16601
instead of a second K16288. Deliveries arriving later on the original number no longer
match. Reproduced on ssl12: splitting 944 created 945.

## Root cause

MB-38 (#556) made moveOrderLines.php assign the split-off order the next free kreditor
ordrenr, plus an advisory lock around the allocation. Duplicate numbers across split and
restordre rows are intended: the partial-delivery flow in kreditor/ordre.php has always
cloned the source ordrenr, and customers receive later deliveries on that number.

While testing, a second bug blocked the split view in the new shell: index/main.php
mirrors the iframe URL into the hash and guarded its own write with a setTimeout(0)
flag. The async hashchange event could outrun it, so the split view (rendered on a bare
ordre.php POST response) was reloaded as ordre.php?inframe=1, an empty new order.

## Changes

- kreditor/orderIncludes/moveOrderLines.php: revert the MB-38 ordrenr reassignment and
  the GET_LOCK / pg_advisory_xact_lock code. Runtime code is byte-identical to pre-MB-38.
- index/main.php: track the shell-written hash explicitly and skip that one hashchange;
  compare iframe path and target with the inframe flag stripped so redirect targets like
  ordre.php?id=X are not loaded twice.

## Test (ssl12, Firefox)

- Before: split 944, move 1 x 7001016 to "Opret ny ordre" -> new order 945.
- After: split 943 the same way -> order list shows two 943 rows, moved line 1 x 7001016
  on the new one, 431 left on the original. Split view stays on screen inside the shell.
- Moving lines to an existing open order via the dropdown unchanged.
- Menu navigation, Gem, Close still update the address bar with no double load.




## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-app navigation to prevent pages from reloading unexpectedly when opened through redirects or direct links.
  - Fixed hash synchronization between embedded views and the main application.
  - Split creditor orders now retain the source order number, improving continuity when creating split orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->