### PR TITLE
JOB-115: Store integration placeholder "dummyvalue" as blank on every…

### DIFF
--- a/api/hent_ordrer.php
+++ b/api/hent_ordrer.php
@@ -26,6 +26,7 @@
 // Copyright (c) 2003-2017 saldi.dk ApS
 // ----------------------------------------------------------------------
 // 20250130 migrate utf8_en-/decode() to mb_convert_encoding
+// 20260911 Sawaneh Blank the literal "dummyvalue" sent for empty address fields (JOB-115)
 
 @session_start();
 $s_id=session_id();
@@ -189,6 +190,10 @@ function overfoer_data($shopurl,$shop_ordre_id){
 	$tlf=trim($tlf);
 	$cvrnr=trim($cvrnr);
 	$email=trim($email);
+	$firmanavn=strip_placeholder_value($firmanavn);
+	$adresse=strip_placeholder_value($adresse);
+	$postnr=strip_placeholder_value($postnr);
+	$bynavn=strip_placeholder_value($bynavn);
 	if (!$fornavn) $fornavn=$ordre_fornavn;
 	if (!$efternavn) $efternavn=$ordre_efternavn;
 	if (!$email) $email=$ordre_email;
@@ -207,6 +212,10 @@ function overfoer_data($shopurl,$shop_ordre_id){
 	$lev_tlf=trim($lev_tlf);
 	$lev_cvrnr=trim($lev_cvrnr);
 	$lev_email=trim($lev_email);
+	$lev_firmanavn=strip_placeholder_value($lev_firmanavn);
+	$lev_adresse=strip_placeholder_value($lev_adresse);
+	$lev_postnr=strip_placeholder_value($lev_postnr);
+	$lev_bynavn=strip_placeholder_value($lev_bynavn);
 	if (!$lev_firmanavn) $lev_firmanavn=$fornavn." ".$efternavn;
 	if ($lev_postnr && !$lev_bynavn) $lev_bynavn=bynavn($lev_postnr);
 	$lev_tlf=str_replace(" ","",$lev_tlf);

--- a/api/restApiIncludes/createDebitor.php
+++ b/api/restApiIncludes/createDebitor.php
@@ -23,6 +23,8 @@
 //
 // Copyright (c) 2016-2022 saldi.dk aps
 // ----------------------------------------------------------------------
+// 20260911 Sawaneh Blank the literal "dummyvalue" Shoptech sends for empty address
+//                     fields via strip_placeholder_value(); if_isset converted to ifset (JOB-115)
 
 function CreateDebitor() {
 	global $db;
@@ -30,36 +32,36 @@ function CreateDebitor() {
 	$log=fopen("../temp/$db/rest_api.log","a");
 	fwrite($log,__line__." ". date("H:i:s") ." kontonr $kontonr\n");
 	
-	$addr1         = if_isset($_GET['addr1']);
-	$addr2         = if_isset($_GET['addr2']);
-	$afd           = if_isset($_GET['afd'])*1;
-	$betalingsbet  = if_isset($_GET['betalingsbet']);
-	$betalingsdage = if_isset($_GET['betalingsdage']);
-	$bynavn        = if_isset($_GET['bynavn']);
-	$cvr           = if_isset($_GET['cvr']);
-	$firmanavn     = if_isset($_GET['firmanavn']);
-	$efternavn     = if_isset($_GET['efternavn']);
-	$fornavn       = if_isset($_GET['fornavn']);
-	$gruppe        = if_isset($_GET['gruppe']);
-	$kontakt       = if_isset($_GET['kontakt']);
-	$kontonr       = if_isset($_GET['kontonr']);
-	$kundetype     = if_isset($_GET['kundetype']);
-	$land          = if_isset($_GET['land']);
-	$lev_firmanavn = if_isset($_GET['lev_firmanavn']);
-	$lev_addr1     = if_isset($_GET['lev_addr1']);
-	$lev_addr2     = if_isset($_GET['lev_addr2']);
-	$lev_postnr    = if_isset($_GET['lev_postnr']);
-	$lev_bynavn    = if_isset($_GET['lev_bynavn']);
-	$lev_land      = if_isset($_GET['lev_land']);
-	$lev_tlf       = if_isset($_GET['lev_tlf']);
-	$lev_email     = if_isset($_GET['lev_email']);
-	$lev_kontakt   = if_isset($_GET['lev_kontakt']);
-	$minNo         = if_isset($_GET['minNo']);
-	$maxNo         = if_isset($_GET['maxNo']);
-	$postnr        = if_isset($_GET['postnr']);
-	$tlf           = if_isset($_GET['tlf']);
-	$email         = if_isset($_GET['email']);
-	$email_type    = if_isset($_GET['email_type']);
+	$addr1         = strip_placeholder_value(ifset($_GET, 'addr1'));
+	$addr2         = strip_placeholder_value(ifset($_GET, 'addr2'));
+	$afd           = ifset($_GET, 'afd')*1;
+	$betalingsbet  = ifset($_GET, 'betalingsbet');
+	$betalingsdage = ifset($_GET, 'betalingsdage');
+	$bynavn        = strip_placeholder_value(ifset($_GET, 'bynavn'));
+	$cvr           = strip_placeholder_value(ifset($_GET, 'cvr'));
+	$firmanavn     = strip_placeholder_value(ifset($_GET, 'firmanavn'));
+	$efternavn     = ifset($_GET, 'efternavn');
+	$fornavn       = ifset($_GET, 'fornavn');
+	$gruppe        = ifset($_GET, 'gruppe');
+	$kontakt       = strip_placeholder_value(ifset($_GET, 'kontakt'));
+	$kontonr       = ifset($_GET, 'kontonr');
+	$kundetype     = ifset($_GET, 'kundetype');
+	$land          = strip_placeholder_value(ifset($_GET, 'land'));
+	$lev_firmanavn = strip_placeholder_value(ifset($_GET, 'lev_firmanavn'));
+	$lev_addr1     = strip_placeholder_value(ifset($_GET, 'lev_addr1'));
+	$lev_addr2     = strip_placeholder_value(ifset($_GET, 'lev_addr2'));
+	$lev_postnr    = strip_placeholder_value(ifset($_GET, 'lev_postnr'));
+	$lev_bynavn    = strip_placeholder_value(ifset($_GET, 'lev_bynavn'));
+	$lev_land      = strip_placeholder_value(ifset($_GET, 'lev_land'));
+	$lev_tlf       = strip_placeholder_value(ifset($_GET, 'lev_tlf'));
+	$lev_email     = strip_placeholder_value(ifset($_GET, 'lev_email'));
+	$lev_kontakt   = strip_placeholder_value(ifset($_GET, 'lev_kontakt'));
+	$minNo         = ifset($_GET, 'minNo');
+	$maxNo         = ifset($_GET, 'maxNo');
+	$postnr        = strip_placeholder_value(ifset($_GET, 'postnr'));
+	$tlf           = ifset($_GET, 'tlf');
+	$email         = ifset($_GET, 'email');
+	$email_type    = ifset($_GET, 'email_type');
 	if (!$email_type) $email_type = 'hoved';
 
 	if (!$kontonr) {

--- a/api/rest_api.php
+++ b/api/rest_api.php
@@ -69,6 +69,9 @@
 //                surface) and narrowed fetch_from_table() to the one known
 //                query shape actually used; hardened the access_check() API
 //                key comparison (SD-589)
+// 20260911 Sawaneh insert_shop_order dispatch: blank the literal "dummyvalue" Shoptech
+//                     sends for empty address fields via strip_placeholder_value(); if_isset
+//                     calls in that block converted to ifset (JOB-115)
 
 
 // ----------------------------------------------------------------------
@@ -1125,61 +1128,61 @@ if (isset($_GET['action'])){# && in_array($_GET['action'], $possible_url)){
 			else $value = "missing orderId";
 ##############################################
 		}	elseif ($action=='insert_shop_order') {
-			$addr1         = if_isset($_GET['addr1']);
-			$addr2         = if_isset($_GET['addr2']);
-			$afd           = (int)if_isset($_GET['afd']);
-			$betalings_id  = if_isset($_GET['betalings_id']);
-			$betalingsbet  = if_isset($_GET['betalingsbet']);
-			$betalingsdage = if_isset($_GET['betalingsdage']);
-			$bynavn        = if_isset($_GET['bynavn']);
-			$cvr           = if_isset($_GET['cvr']);
-			$firmanavn     = if_isset($_GET['firmanavn']);
-			$land          = if_isset($_GET['land']);
-			$shop_addr_id  = if_isset($_GET['shop_addr_id']);
-			$shopOrderId   = if_isset($_GET['shop_ordre_id']);
+			$addr1         = strip_placeholder_value(ifset($_GET, 'addr1'));
+			$addr2         = strip_placeholder_value(ifset($_GET, 'addr2'));
+			$afd           = (int)ifset($_GET, 'afd');
+			$betalings_id  = ifset($_GET, 'betalings_id');
+			$betalingsbet  = ifset($_GET, 'betalingsbet');
+			$betalingsdage = ifset($_GET, 'betalingsdage');
+			$bynavn        = strip_placeholder_value(ifset($_GET, 'bynavn'));
+			$cvr           = strip_placeholder_value(ifset($_GET, 'cvr'));
+			$firmanavn     = strip_placeholder_value(ifset($_GET, 'firmanavn'));
+			$land          = strip_placeholder_value(ifset($_GET, 'land'));
+			$shop_addr_id  = ifset($_GET, 'shop_addr_id');
+			$shopOrderId   = ifset($_GET, 'shop_ordre_id');
 			if (!$shopOrderId) $shopOrderId = 0;
-			$shop_fakturanr = if_isset($_GET['shop_fakturanr']);
+			$shop_fakturanr = ifset($_GET, 'shop_fakturanr');
 			if (!$shop_fakturanr) $shop_fakturanr=$shopOrderId;
-			$postnr         = if_isset($_GET['postnr']);
-			$ean            = (int)if_isset($_GET['ean']);
+			$postnr         = strip_placeholder_value(ifset($_GET, 'postnr'));
+			$ean            = (int)ifset($_GET, 'ean');
 			if (!$ean) $ean = '';
-			$institution    = if_isset($_GET['institution']);
-			$tlf            = if_isset($_GET['tlf']);
-			$email          = if_isset($_GET['email']);
-			$udskriv_til    = if_isset($_GET['udskriv_til']);
-			$ref            = if_isset($_GET['ref']);
-			$kontakt        = if_isset($_GET['kontakt']);
-			$lager          = if_isset($_GET['lager']);
+			$institution    = strip_placeholder_value(ifset($_GET, 'institution'));
+			$tlf            = ifset($_GET, 'tlf');
+			$email          = ifset($_GET, 'email');
+			$udskriv_til    = ifset($_GET, 'udskriv_til');
+			$ref            = ifset($_GET, 'ref');
+			$kontakt        = strip_placeholder_value(ifset($_GET, 'kontakt'));
+			$lager          = ifset($_GET, 'lager');
 			if (!$lager) $lager = 1;
-			$lev_firmanavn  = if_isset($_GET['lev_firmanavn']);
-			$lev_addr1      = if_isset($_GET['lev_addr1']);
-			$lev_addr2      = if_isset($_GET['lev_addr2']);
-			$lev_postnr     = if_isset($_GET['lev_postnr']);
-			$lev_bynavn     = if_isset($_GET['lev_bynavn']);
-			$lev_land       = if_isset($_GET['lev_land']);
-			$lev_tlf        = if_isset($_GET['lev_tlf']);
-			$lev_email      = if_isset($_GET['lev_email']);
-			$lev_kontakt    = if_isset($_GET['lev_kontakt']);
-			$ordredate      = if_isset($_GET['ordredate']);
-			$lev_date       = if_isset($_GET['lev_date']);
-			$momssats       = if_isset($_GET['momssats']);
-			$valuta         = if_isset($_GET['valuta']);
-			$valutakurs     = if_isset($_GET['valutakurs']);
-			$gruppe         = if_isset($_GET['gruppe']);
-			$nettosum       = if_isset($_GET['nettosum'])*1;
-			$momssum        = if_isset($_GET['momssum'])*1;
-			$projekt        = if_isset($_GET['projekt']);
-			$ekstra1        = if_isset($_GET['ekstra1']);
-			$ekstra2        = if_isset($_GET['ekstra2']);
-			$ekstra3        = if_isset($_GET['ekstra3']);
-			$ekstra4        = if_isset($_GET['ekstra4']);
-			$ekstra5        = if_isset($_GET['ekstra5']);
-			$notes          = if_isset($_GET['notes']);
-			$sprog          = if_isset($_GET['sprog']);
-			$saldi_kontonr  = if_isset($_GET['saldi_kontonr']);
-			$pos_betaling   = if_isset($_GET['pos_betaling']);
-			$shop_status    = if_isset($_GET['shop_status']);
-			$art            = if_isset($_GET['art']);
+			$lev_firmanavn  = strip_placeholder_value(ifset($_GET, 'lev_firmanavn'));
+			$lev_addr1      = strip_placeholder_value(ifset($_GET, 'lev_addr1'));
+			$lev_addr2      = strip_placeholder_value(ifset($_GET, 'lev_addr2'));
+			$lev_postnr     = strip_placeholder_value(ifset($_GET, 'lev_postnr'));
+			$lev_bynavn     = strip_placeholder_value(ifset($_GET, 'lev_bynavn'));
+			$lev_land       = strip_placeholder_value(ifset($_GET, 'lev_land'));
+			$lev_tlf        = strip_placeholder_value(ifset($_GET, 'lev_tlf'));
+			$lev_email      = strip_placeholder_value(ifset($_GET, 'lev_email'));
+			$lev_kontakt    = strip_placeholder_value(ifset($_GET, 'lev_kontakt'));
+			$ordredate      = ifset($_GET, 'ordredate');
+			$lev_date       = ifset($_GET, 'lev_date');
+			$momssats       = ifset($_GET, 'momssats');
+			$valuta         = ifset($_GET, 'valuta');
+			$valutakurs     = ifset($_GET, 'valutakurs');
+			$gruppe         = ifset($_GET, 'gruppe');
+			$nettosum       = ifset($_GET, 'nettosum')*1;
+			$momssum        = ifset($_GET, 'momssum')*1;
+			$projekt        = ifset($_GET, 'projekt');
+			$ekstra1        = ifset($_GET, 'ekstra1');
+			$ekstra2        = ifset($_GET, 'ekstra2');
+			$ekstra3        = ifset($_GET, 'ekstra3');
+			$ekstra4        = ifset($_GET, 'ekstra4');
+			$ekstra5        = ifset($_GET, 'ekstra5');
+			$notes          = ifset($_GET, 'notes');
+			$sprog          = ifset($_GET, 'sprog');
+			$saldi_kontonr  = ifset($_GET, 'saldi_kontonr');
+			$pos_betaling   = ifset($_GET, 'pos_betaling');
+			$shop_status    = ifset($_GET, 'shop_status');
+			$art            = ifset($_GET, 'art');
 			if (!$art) $art = 'DO';
 
 			$fil = fopen('../temp/addr1.php','w');

--- a/api/v2/addresses.php
+++ b/api/v2/addresses.php
@@ -1,6 +1,7 @@
 <?php
 require_once('../../includes/connect.php');
 require_once('../../includes/db_query.php');
+require_once(__DIR__ . '/../../includes/std_func.php');
 require_once('includes/AuthMiddleware.php');
 
 // Set headers
@@ -83,7 +84,7 @@ function handlePost() {
     foreach ($data as $field => $value) {
         if ($field !== 'id') { // Skip id as it's auto-generated
             $fields[] = $field;
-            $values[] = "'" . db_escape_string($value) . "'";
+            $values[] = "'" . db_escape_string(strip_placeholder_value($value)) . "'";
         }
     }
     
@@ -119,9 +120,13 @@ function handlePut() {
     // Build update query
     $updates = [];
     foreach ($data as $field => $value) {
-        if ($field !== 'id') { // Skip id as it shouldn't be updated
-            $updates[] = $field . " = '" . db_escape_string($value) . "'";
+        if ($field === 'id') { // Skip id as it shouldn't be updated
+            continue;
         }
+        if (strip_placeholder_value($value) !== $value) { // Placeholder must not overwrite existing data (JOB-115)
+            continue;
+        }
+        $updates[] = $field . " = '" . db_escape_string($value) . "'";
     }
     
     $query = "UPDATE adresser SET " . implode(', ', $updates) . " WHERE id = " . $id;

--- a/includes/std_func.php
+++ b/includes/std_func.php
@@ -79,6 +79,8 @@
 // 20260908 CL/NTR Added is_input_too_long(): character-count (mb_strlen) limit check shared by every
 //                  place that creates or renames a username (80) or account name (60), matching login.php
 // 20260908 CDX/LH Let order-number allocation retain a caller-owned transaction (SST-765).
+// 20260911 Sawaneh Added strip_placeholder_value() / strip_placeholder_sql_literals(): blank the
+//                     literal "dummyvalue" Shoptech sends for empty address fields (JOB-115)
 
 include(__DIR__ . '/stdFunc/dkDecimal.php');
 include(__DIR__ . '/stdFunc/nrCast.php');
@@ -259,6 +261,48 @@ if (!function_exists('if_isset')) {
          */
 		return ifset($arrayOrVar, $key, $default);
     }
+}
+
+if (!function_exists('integration_placeholder_values')) {
+	/**
+	 * Literal placeholder strings some integrations send for fields the shop
+	 * customer left empty. Saldi must never store them (JOB-115).
+	 *
+	 * @return string[] lowercase placeholders
+	 */
+	function integration_placeholder_values() {
+		return array('dummyvalue');
+	}
+}
+
+if (!function_exists('strip_placeholder_value')) {
+	/**
+	 * Returns '' when the value is a known integration placeholder such as
+	 * "dummyvalue" (trimmed, case-insensitive); otherwise the value untouched.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	function strip_placeholder_value($value) {
+		if (is_string($value) && in_array(strtolower(trim($value)), integration_placeholder_values(), true)) {
+			return '';
+		}
+		return $value;
+	}
+}
+
+if (!function_exists('strip_placeholder_sql_literals')) {
+	/**
+	 * Blanks quoted placeholder literals ('dummyvalue') inside a raw SQL
+	 * fragment supplied by a client, for the generic SOAP insert/update facade.
+	 *
+	 * @param string $sql
+	 * @return string
+	 */
+	function strip_placeholder_sql_literals($sql) {
+		$pattern = "/'\\s*(" . implode('|', array_map('preg_quote', integration_placeholder_values())) . ")\\s*'/i";
+		return preg_replace($pattern, "''", $sql);
+	}
 }
 
 if (!function_exists('usdate')) {

--- a/restapi/services/CustomerService.php
+++ b/restapi/services/CustomerService.php
@@ -1,13 +1,18 @@
 <?php
 
+require_once __DIR__ . '/../../includes/std_func.php';
 require_once __DIR__ . '/../models/customers/CustomerModel.php';
 
 class CustomerService
 {
     /**
      * Map English property names to Danish database column names
+     *
+     * @param object $data
+     * @param bool   $dropPlaceholders Omit fields whose value is an integration placeholder
+     * @return stdClass
      */
-    private static function mapApiToDanish($data)
+    private static function mapApiToDanish($data, $dropPlaceholders = false)
     {
         $mapping = [
             // Basic info
@@ -56,8 +61,14 @@ class CustomerService
         
         $mappedData = new stdClass();
         
-        // Map English properties to Danish, but keep Danish properties as-is for backward compatibility
-        foreach ($data as $key => $value) {
+        // Map English properties to Danish, but keep Danish properties as-is for backward compatibility.
+        // Placeholder values such as "dummyvalue" are stored blank (JOB-115); when $dropPlaceholders
+        // is set they are left out entirely so an update keeps the existing value.
+        foreach ($data as $key => $original) {
+            $value = strip_placeholder_value($original);
+            if ($dropPlaceholders && $value !== $original) {
+                continue;
+            }
             if (isset($mapping[$key])) {
                 // Use Danish property name
                 $danishKey = $mapping[$key];
@@ -208,7 +219,7 @@ class CustomerService
             }
 
             // Map English property names to Danish
-            $mappedData = self::mapApiToDanish($data);
+            $mappedData = self::mapApiToDanish($data, true);
 
             // Load existing customer with art parameter
             $customer = new CustomerModel($data->id, $art);

--- a/restapi/services/OrderService.php
+++ b/restapi/services/OrderService.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../../includes/std_func.php';
 require_once __DIR__ . '/../models/orders/OrderModel.php';
 
 class OrderService
@@ -57,8 +58,10 @@ class OrderService
         
         $mappedData = new stdClass();
         
-        // Map English properties to Danish, but keep Danish properties as-is for backward compatibility
+        // Map English properties to Danish, but keep Danish properties as-is for backward compatibility.
+        // Placeholder values such as "dummyvalue" are stored blank (JOB-115).
         foreach ($data as $key => $value) {
+            $value = strip_placeholder_value($value);
             if (isset($mapping[$key])) {
                 // Use Danish property name
                 $danishKey = $mapping[$key];

--- a/soapserver/singleinsert.php
+++ b/soapserver/singleinsert.php
@@ -21,6 +21,7 @@
 // Copyright (c) 2004-2011 DANOSOFT ApS
 // ----------------------------------------------------------------------
 // 2014.01.06 Fejl hvis paranteser i variabel. Søg 20140106
+// 20260911 Sawaneh Blank quoted "dummyvalue" literals in client SQL (JOB-115)
 
 ini_set("soap.wsdl_cache_enabled", "1");
 
@@ -33,6 +34,7 @@ function singleinsert($string) {
 #	include("../includes/select.php");
 	include ("../includes/connect.php");
 	include ("../includes/online.php");
+	include_once(__DIR__ . '/../includes/std_func.php');
 
 	$linje=NULL;
 	$fp=fopen("../temp/soap.log","a");
@@ -41,6 +43,7 @@ function singleinsert($string) {
 	$singleinsert=str_replace(chr(9),"",$singleinsert);
 	$singleinsert=str_replace(chr(10),"",$singleinsert);
 	$singleinsert=str_replace(chr(13),"",$singleinsert);
+	$singleinsert=strip_placeholder_sql_literals($singleinsert);
 #	$singleinsert=str_replace(" ","",$singleinsert);
 	list($table,$tmp)=explode("(",$singleinsert,2);
 	$table=trim($table);

--- a/soapserver/singleupdate.php
+++ b/soapserver/singleupdate.php
@@ -20,6 +20,7 @@
 //
 // Copyright (c) 2004-2011 DANOSOFT ApS
 // ----------------------------------------------------------------------
+// 20260911 Sawaneh Blank quoted "dummyvalue" literals in client SQL (JOB-115)
 ini_set("soap.wsdl_cache_enabled", "1");
 
 function singleupdate($string) {
@@ -30,6 +31,7 @@ function singleupdate($string) {
 #	include("../includes/select.php");
 	include ("../includes/connect.php");
 	include ("../includes/online.php");
+	include_once(__DIR__ . '/../includes/std_func.php');
 
 	$linje=NULL;
 	$tabels=array('grupper','varianter','variant_typer','shop_ordrer','shop_varer','adresser','shop_adresser');
@@ -37,6 +39,7 @@ function singleupdate($string) {
 	$singleupdate=str_replace(chr(9),"",$singleupdate);
 	$singleupdate=str_replace(chr(10),"",$singleupdate);
 	$singleupdate=str_replace(chr(13),"",$singleupdate);
+	$singleupdate=strip_placeholder_sql_literals($singleupdate);
 #	$singleupdate=str_replace(" ","",$singleupdate);
 	$singleupdate=strtolower($singleupdate);
 	list($table,$tmp)=explode("set",$singleupdate,2);

--- a/tests/characterization/includes/PlaceholderValueTest.test.php
+++ b/tests/characterization/includes/PlaceholderValueTest.test.php
@@ -1,0 +1,40 @@
+<?php
+// 20260911 Sawaneh Cover strip_placeholder_value() / strip_placeholder_sql_literals(): the literal
+//                     "dummyvalue" Shoptech sends for empty address fields must be stored blank (JOB-115).
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 3) . '/includes/std_func.php';
+
+final class PlaceholderValueTest extends TestCase
+{
+    public function testPlaceholderIsBlankedCaseInsensitiveAndTrimmed(): void
+    {
+        self::assertSame('', strip_placeholder_value('dummyvalue'));
+        self::assertSame('', strip_placeholder_value('Dummyvalue'));
+        self::assertSame('', strip_placeholder_value(' DUMMYVALUE '));
+    }
+
+    public function testRealValuesPassThroughUntouched(): void
+    {
+        self::assertSame('Teatergade 23', strip_placeholder_value('Teatergade 23'));
+        self::assertSame(' 4700 ', strip_placeholder_value(' 4700 '));
+        self::assertSame('', strip_placeholder_value(''));
+        self::assertSame('dummyvalue 2', strip_placeholder_value('dummyvalue 2'));
+        self::assertNull(strip_placeholder_value(null));
+        self::assertSame(42, strip_placeholder_value(42));
+    }
+
+    public function testQuotedPlaceholderLiteralsAreBlankedInSql(): void
+    {
+        $sql = "adresser(addr1,bynavn,postnr) VALUES ('Dummyvalue','dummyvalue ','4700')";
+        self::assertSame(
+            "adresser(addr1,bynavn,postnr) VALUES ('','','4700')",
+            strip_placeholder_sql_literals($sql)
+        );
+        self::assertSame(
+            "adresser set addr1='Teatergade 23' where id=1",
+            strip_placeholder_sql_literals("adresser set addr1='Teatergade 23' where id=1")
+        );
+    }
+}


### PR DESCRIPTION
… inbound address path

## What are the changes about?
Provide a brief explanation of the changes you have made
## JOB-115: Store integration placeholder "dummyvalue" as blank on every inbound address path

### Problem

MEDSHOP (saldi_390) receives orders and customer creations from Shoptech with the literal text `dummyvalue` in the invoice address (`addr1`, `bynavn`, occasionally `firmanavn`/`postnr`) whenever the shop customer has no separate billing address. Saldi stored the text as received, so it ended up on the debitor card and the invoice and had to be corrected by hand. This has happened about twice a month since February 2023; the dump from 2026-09-03 holds 78 orders and 71 debitor cards with the placeholder. Earlier tickets (SST-683, SST-638, SST-567) fixed individual records, never the flow.

The word `dummyvalue` does not exist anywhere in Saldi's code. It arrives from the sender. Order 137221 had a clean order but a polluted card, which shows Shoptech creates the customer through a separate call from the order, so a single-endpoint fix would not have been enough.

### Change

A defensive sanitiser at the receiving end. Any inbound field whose value is `dummyvalue` (trimmed, case-insensitive) is stored blank. Nothing else in the same call is touched.

- **Shared helper** in `includes/std_func.php`: `strip_placeholder_value()` for single values and `strip_placeholder_sql_literals()` for the raw-SQL SOAP facade. The placeholder list lives in one function, `integration_placeholder_values()`, so any future string is a one-line addition.
- **Create paths blank the field**: `insert_shop_order` dispatch in `api/rest_api.php`, `api/restApiIncludes/createDebitor.php`, `api/hent_ordrer.php`, REST `CustomerService`/`OrderService` (applied in `mapApiToDanish`, so it covers `createNewDebtor` as well), `soapserver/singleinsert.php`, and the v2 addresses POST.
- **Update paths drop the field instead** (`CustomerService::updateCustomer`, v2 addresses PUT, `soapserver/singleupdate.php`), so a placeholder never overwrites an existing correct address. A genuine empty string still behaves as before.
- The two `if_isset` blocks that were edited are converted to `ifset` per convention; history lines added.
- Unit test `tests/characterization/includes/PlaceholderValueTest.test.php`.

### Testing

- New test passes. The full suite has 7 failures and 1 error in the usdecimal characterization tests that are identical on master.
- Verified on ssl12 (test_2) before and after upload via the shop API:
  - Before: `insert_shop_order` and `createDebitor` with `addr1=dummyvalue&bynavn=Dummyvalue` produced cards and orders carrying the literal text, delivery address correct (bug reproduced on both paths).
  - After: same calls produced empty `addr1`/`bynavn` on card and order, delivery address and all other fields intact.

### Not in this PR

- **Data cleanup** of the existing 78 orders and 71 cards on the live saldi_390 base. Run after review, on the live base, not the dump:

  ```sql
  update adresser set addr1=''     where lower(trim(addr1))='dummyvalue';
  update adresser set bynavn=''    where lower(trim(bynavn))='dummyvalue';
  update adresser set postnr=''    where lower(trim(postnr))='dummyvalue';
  update adresser set firmanavn='' where lower(trim(firmanavn))='dummyvalue';
  update ordrer   set addr1=''     where lower(trim(addr1))='dummyvalue';
  update ordrer   set bynavn=''    where lower(trim(bynavn))='dummyvalue';
  update ordrer   set postnr=''    where lower(trim(postnr))='dummyvalue';
  update ordrer   set firmanavn='' where lower(trim(firmanavn))='dummyvalue';
  ```

Four orders have a dummy company name and will end up with a blank `firmanavn`; those may want a manual name.
- Shoptech has been asked why the placeholder is sent. This fix does not depend on their answer.



## Have you checked the following? 
- [x] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing
