### PR TITLE
SST-768 JOB-117: Add offline replay tool for Shoptec order amount rec…

### DIFF
--- a/tests/characterization/tools/ShopOrderReconcileTest.test.php
+++ b/tests/characterization/tools/ShopOrderReconcileTest.test.php
@@ -50,6 +50,37 @@ final class ShopOrderReconcileTest extends TestCase
         self::assertSame(12.345, stored_line_price(12.345, 100));
     }
 
+    public function testNonDkkOrderWithoutRateIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        reconcile([
+            parse_request('action=insert_shop_order&shop_ordre_id=4&valuta=SEK&nettosum=1&momssum=0&momssats=25'),
+        ]);
+    }
+
+    public function testMissingOrderIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        reconcile([parse_request('action=insert_shop_orderline&varenr=A&antal=1&pris=1')]);
+    }
+
+    public function testRequestRatesAreFlaggedAndOverridesAreNot(): void
+    {
+        $requests = [
+            parse_request('action=insert_shop_order&shop_ordre_id=5&valuta=DKK&momssats=25&nettosum=100&momssum=25'),
+            parse_request('action=insert_shop_orderline&varenr=A&antal=1&pris=100&rabat=0'),
+        ];
+        self::assertStringContainsString('momssats 25 taken from the request', reconcile($requests));
+        self::assertStringNotContainsString('taken from the request', reconcile($requests, ['momssats' => 25.0]));
+    }
+
+    public function testMainRejectsInvalidOverrideAndUnreadableLog(): void
+    {
+        self::assertSame(1, main(['x', '--momssats=abc', '/dev/null']));
+        self::assertSame(1, main(['x', '--valutakurs=', '/dev/null']));
+        self::assertSame(1, main(['x', '--log', '/nonexistent/rest_api.log']));
+    }
+
     public function testVatFreeLineCarriesNoVat(): void
     {
         $requests = [

--- a/tests/characterization/tools/ShopOrderReconcileTest.test.php
+++ b/tests/characterization/tools/ShopOrderReconcileTest.test.php
@@ -1,0 +1,63 @@
+<?php
+// 20260911 CL/Sawaneh Cover tools/shop_order_reconcile.php: the replay must mirror fakturer_ordre's
+//                     amount check, reproduce the SST-187 rejection (743/186 vs 185.75) and keep a
+//                     foreign-currency price intact through the DKK round trip (SST-406) (SST-768/JOB-117).
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 3) . '/tools/shop_order_reconcile.php';
+
+final class ShopOrderReconcileTest extends TestCase
+{
+    public function testSaldiTotalsMirrorFakturerOrdre(): void
+    {
+        $t = saldi_totals([
+            ['antal' => 2, 'pris' => 35.00, 'rabat' => 0, 'momssats' => 25],
+            ['antal' => 1, 'pris' => 350.75, 'rabat' => 10, 'momssats' => 25],
+        ]);
+        self::assertEqualsWithDelta(70 + 315.675, $t['varesum'], 0.0001);
+        self::assertEqualsWithDelta(17.5 + 78.919, $t['varemoms'], 0.0001);
+    }
+
+    public function testSst187TotalsAreRejectedAndExplainedByWholeUnitGrossRounding(): void
+    {
+        $requests = [
+            parse_request('action=insert_shop_order&shop_ordre_id=1&valuta=DKK&momssats=25&nettosum=743&momssum=186&ekstra2=929.000000&key=secret'),
+            parse_request('action=insert_shop_orderline&varenr=A&antal=1&pris=743&rabat=0&momsfri='),
+        ];
+        $report = reconcile($requests);
+        self::assertStringContainsString('RESULT: REJECTED', $report);
+        self::assertStringContainsString('Error in amount (743+186) vs. item amount (743+185.75)', $report);
+        self::assertStringContainsString('= 0.0000 -> ok', $report);
+        self::assertMatchesRegularExpression('/=> E gross total rounded to whole unit/', $report);
+        self::assertStringNotContainsString('secret', $report);
+    }
+
+    public function testMatchingTotalsAreAccepted(): void
+    {
+        $requests = [
+            parse_request('action=insert_shop_order&shop_ordre_id=2&valuta=DKK&nettosum=385.675&momssum=96.419&momssats=25'),
+            parse_request('action=insert_shop_orderline&varenr=A&antal=2&pris=35&rabat=0'),
+            parse_request('action=insert_shop_orderline&varenr=B&antal=1&pris=350.75&rabat=10'),
+        ];
+        self::assertStringContainsString('RESULT: accepted', reconcile($requests));
+    }
+
+    public function testForeignCurrencyPriceSurvivesTheDkkRoundTrip(): void
+    {
+        self::assertSame(129.5, stored_line_price(129.5, 68.53));
+        self::assertSame(99.99, stored_line_price(99.99, 745.12));
+        self::assertSame(12.345, stored_line_price(12.345, 100));
+    }
+
+    public function testVatFreeLineCarriesNoVat(): void
+    {
+        $requests = [
+            parse_request('action=insert_shop_order&shop_ordre_id=3&valuta=NOK&valutakurs=68.53&nettosum=200&momssum=0&momssats=25'),
+            parse_request('action=insert_shop_orderline&varenr=N&antal=1&pris=200&rabat=0&momsfri=on'),
+        ];
+        $report = reconcile($requests);
+        self::assertStringContainsString('RESULT: accepted', $report);
+        self::assertStringContainsString('varemoms 0.0000', $report);
+    }
+}

--- a/tools/shop_order_reconcile.php
+++ b/tools/shop_order_reconcile.php
@@ -1,0 +1,338 @@
+<?php
+//                ___   _   _   ___  _     ___  _ _
+//               / __| / \ | | |   \| |   |   \| / /
+//               \__ \/ _ \| |_| |) | | _ | |) |  <
+//               |___/_/ \_|___|___/|_||_||___/|_\_\
+//
+// --- tools/shop_order_reconcile.php --- 2026.09.11
+// LICENSE
+//
+// This program is free software. You can redistribute it and / or
+// modify it under the terms of the GNU General Public License (GPL)
+// which is published by The Free Software Foundation; either in version 2
+// of this license or later version of your choice.
+// However, respect the following:
+//
+// It is forbidden to use this program in competition with Saldi.DK ApS
+// or other proprietor of the program without prior written agreement.
+//
+// The program is published with the hope that it will be beneficial,
+// but WITHOUT ANY KIND OF CLAIM OR WARRANTY.
+// See GNU General Public License for more details.
+// http://www.saldi.dk/dok/GNU_GPL_v2.html
+//
+// Copyright (c) 2003-2026 Saldi.dk ApS
+// ----------------------------------------------------------------------
+// 20260911 CL/Sawaneh Created: offline replay of the shop-order arithmetic in
+//                     api/rest_api.php (insert_shop_orderline -> opret_ordrelinje
+//                     -> fakturer_ordre) for one raw request set, plus a scanner
+//                     for "Error in amount" rejections in rest_api.log. Reports
+//                     the line-by-line reconciliation and which shop-side
+//                     rounding rule reproduces the shop totals (SST-768/JOB-117).
+//                     Reads nothing from the database and changes nothing.
+
+require_once __DIR__ . '/../includes/std_func.php';
+
+const RECONCILE_TOLERANCE = 0.01;
+const REDACTED_PARAMS = ['key', 'password', 'pass', 'token'];
+
+/**
+ * Parse one raw request (full URL or bare query string) into its parameters.
+ *
+ * @param string $raw
+ * @return array<string,string> parameter => value, secrets replaced by '***'
+ */
+function parse_request($raw)
+{
+    $raw = trim($raw);
+    if ($raw === '' || $raw[0] === '#') {
+        return [];
+    }
+    $query = (strpos($raw, '?') !== false) ? substr($raw, strpos($raw, '?') + 1) : $raw;
+    parse_str($query, $params);
+    foreach (REDACTED_PARAMS as $secret) {
+        if (isset($params[$secret])) {
+            $params[$secret] = '***';
+        }
+    }
+    return $params;
+}
+
+/**
+ * Currency rates come from grupper (art VK) and may carry a Danish decimal
+ * comma; rest_api.php runs those through usdecimal(). Request values never are.
+ *
+ * @param string|float $value
+ * @return float
+ */
+function rate_value($value)
+{
+    $value = (string)$value;
+    return (float)(strpos($value, ',') !== false ? usdecimal($value) : $value);
+}
+
+/**
+ * Mirror of the price path in api/rest_api.php insert_shop_orderline() and
+ * includes/ordrefunc.php opret_ordrelinje(): shop price -> DKK -> order
+ * currency, then stored through PHP's default float-to-string conversion.
+ *
+ * @param float $shopPrice
+ * @param float $valutakurs
+ * @return float the value that ends up in ordrelinjer.pris
+ */
+function stored_line_price($shopPrice, $valutakurs)
+{
+    $pris = (float)$shopPrice;
+    if ($valutakurs && $valutakurs != 100) {
+        $pris = $pris * $valutakurs / 100;
+        $pris = $pris * 100 / $valutakurs;
+    }
+    return (float)(string)$pris;
+}
+
+/**
+ * Mirror of the settlement check in api/rest_api.php fakturer_ordre().
+ *
+ * @param array<int,array{antal:float,pris:float,rabat:float,momssats:float}> $lines
+ * @return array{varesum:float,varemoms:float,lines:array<int,array{linjepris:float,linjemoms:float}>}
+ */
+function saldi_totals($lines)
+{
+    $varesum = $varemoms = 0;
+    $detail = [];
+    foreach ($lines as $l) {
+        $linjepris = $l['antal'] * ($l['pris'] - $l['pris'] * $l['rabat'] / 100);
+        $linjemoms = $linjepris * $l['momssats'] / 100;
+        $varesum += afrund($linjepris, 3);
+        $varemoms += afrund($linjemoms, 3);
+        $detail[] = ['linjepris' => $linjepris, 'linjemoms' => $linjemoms];
+    }
+    return ['varesum' => $varesum, 'varemoms' => $varemoms, 'lines' => $detail];
+}
+
+/**
+ * Candidate shop-side rounding rules, evaluated on the shop's own line data.
+ *
+ * @param array<int,array{antal:float,pris:float,rabat:float,momssats:float}> $lines
+ * @param float $momssats order-level VAT rate used by rule B
+ * @return array<string,array{net:float,vat:float}> rule name => totals
+ */
+function shop_hypotheses($lines, $momssats)
+{
+    $rate0 = $momssats / 100;
+    $exactNet = $exactVat = 0;
+    $net2 = $vat2 = 0;
+    $gross2 = $net2b = 0;
+    foreach ($lines as $l) {
+        $net = $l['antal'] * ($l['pris'] - $l['pris'] * $l['rabat'] / 100);
+        $rate = $l['momssats'] / 100;
+        $exactNet += $net;
+        $exactVat += $net * $rate;
+        $net2 += round($net, 2);
+        $vat2 += round(round($net, 2) * $rate, 2);
+        $lineGross = round($l['pris'] * (1 + $rate), 2) * $l['antal'];
+        $lineGross -= $lineGross * $l['rabat'] / 100;
+        $gross2 += round($lineGross, 2);
+        $net2b += round($lineGross / (1 + $rate), 2);
+    }
+    $grossWhole = round($exactNet + $exactVat, 0);
+    return [
+        'A exact, no rounding'                       => ['net' => $exactNet, 'vat' => $exactVat],
+        'B lines net rounded 2, VAT on total'        => ['net' => $net2, 'vat' => round($net2 * $rate0, 2)],
+        'C lines net rounded 2, VAT per line 2'      => ['net' => $net2, 'vat' => $vat2],
+        'D gross per line 2, net = gross/(1+rate)'   => ['net' => $net2b, 'vat' => $gross2 - $net2b],
+        'E gross total rounded to whole unit'        => ['net' => round($exactNet, 2), 'vat' => $grossWhole - round($exactNet, 2)],
+        'F VAT rounded up to whole unit'             => ['net' => round($exactNet, 2), 'vat' => ceil($exactVat)],
+    ];
+}
+
+/**
+ * Replay one order: the insert_shop_order request plus its insert_shop_orderline requests.
+ *
+ * @param array<int,array<string,string>> $requests parsed requests in call order
+ * @param array{momssats?:float,valutakurs?:float} $overrides values Saldi takes from its own
+ *        settings rather than the request (customer-group VAT rate, currency rate)
+ * @return string report
+ */
+function reconcile($requests, $overrides = [])
+{
+    $order = null;
+    $lines = [];
+    foreach ($requests as $p) {
+        $action = $p['action'] ?? '';
+        if ($action === 'insert_shop_order') {
+            $order = $p;
+        } elseif ($action === 'insert_shop_orderline') {
+            $lines[] = $p;
+        }
+    }
+    if (!$order) {
+        return "No insert_shop_order request found.\n";
+    }
+    $valuta = $order['valuta'] ?: 'DKK';
+    $valutakurs = ($valuta === 'DKK') ? 100 : (float)($overrides['valutakurs'] ?? rate_value($order['valutakurs'] ?? 100));
+    $momssats = (float)($overrides['momssats'] ?? ($order['momssats'] ?? 25));
+    $nettosum = (float)($order['nettosum'] ?? 0);
+    $momssum = (float)($order['momssum'] ?? 0);
+    $betalt = isset($order['ekstra2']) ? (float)$order['ekstra2'] : null;
+
+    $out = [];
+    $out[] = sprintf("Shop order %s  currency %s  rate %s  order VAT rate %s%%", $order['shop_ordre_id'] ?? '?', $valuta, $valutakurs, $momssats);
+    $out[] = sprintf("Shop totals: nettosum %.4f  momssum %.4f  gross %.4f%s", $nettosum, $momssum, $nettosum + $momssum, $betalt !== null ? sprintf("  ekstra2 (paid) %.4f", $betalt) : '');
+    $out[] = str_repeat('-', 100);
+    $out[] = sprintf("%-4s %-14s %10s %12s %12s %8s %7s %14s %12s", '#', 'varenr', 'antal', 'shop pris', 'saldi pris', 'rabat', 'moms%', 'linjepris', 'linjemoms');
+
+    $saldiLines = [];
+    $flags = [];
+    foreach ($lines as $i => $l) {
+        $antal = (float)($l['antal'] ?? 0);
+        $shopPris = (float)($l['pris'] ?? 0);
+        $rabat = (float)($l['rabat'] ?? 0);
+        $momsfri = !empty($l['momsfri']);
+        $stored = stored_line_price($shopPris, $valutakurs);
+        $lineRate = $momsfri ? 0 : $momssats;
+        $saldiLines[] = ['antal' => $antal, 'pris' => $stored, 'rabat' => $rabat, 'momssats' => $lineRate];
+        if ($stored != $shopPris) {
+            $flags[] = sprintf("line %d: price changed by the currency round trip (%s -> %s)", $i + 1, $shopPris, $stored);
+        }
+        if ($rabat == 0) {
+            $flags[] = sprintf("line %d: rabat=0 sent, Saldi may apply its own customer/item discount table (rabat) instead", $i + 1);
+        }
+        if (round($shopPris, 3) != $shopPris) {
+            $flags[] = sprintf("line %d: shop price has more than 3 decimals (%s)", $i + 1, $shopPris);
+        }
+    }
+    $saldi = saldi_totals($saldiLines);
+    foreach ($saldiLines as $i => $l) {
+        $out[] = sprintf("%-4d %-14s %10s %12s %12s %8s %7s %14.4f %12.4f", $i + 1, $lines[$i]['varenr'] ?? '', $l['antal'], $lines[$i]['pris'] ?? '', $l['pris'], $l['rabat'], $l['momssats'], $saldi['lines'][$i]['linjepris'], $saldi['lines'][$i]['linjemoms']);
+    }
+    $out[] = str_repeat('-', 100);
+    $diffNet = $nettosum - $saldi['varesum'];
+    $diffVat = $momssum - $saldi['varemoms'];
+    $out[] = sprintf("Saldi:  varesum %.4f  varemoms %.4f  gross %.4f", $saldi['varesum'], $saldi['varemoms'], $saldi['varesum'] + $saldi['varemoms']);
+    $out[] = sprintf("Diff (shop - Saldi):  net %+.4f  VAT %+.4f  (tolerance %.2f)", $diffNet, $diffVat, RECONCILE_TOLERANCE);
+    $rejected = abs($diffNet) > RECONCILE_TOLERANCE || abs($diffVat) > RECONCILE_TOLERANCE;
+    $out[] = $rejected
+        ? sprintf("RESULT: REJECTED by fakturer_ordre: Error in amount (%s+%s) vs. item amount (%s+%s)", $nettosum, $momssum, $saldi['varesum'], $saldi['varemoms'])
+        : "RESULT: accepted by the amount check";
+    if ($betalt !== null) {
+        $payDiff = abs($nettosum + $momssum - $betalt);
+        $out[] = sprintf("Payment check (pos_betaling): |nettosum+momssum - ekstra2| = %.4f -> %s", $payDiff, $payDiff >= RECONCILE_TOLERANCE ? "REJECTED (Error in amount vs. paid amount)" : "ok");
+    }
+    if ($flags) {
+        $out[] = "";
+        $out[] = "Notes:";
+        foreach ($flags as $f) {
+            $out[] = "  - " . $f;
+        }
+    }
+    $out[] = "";
+    $out[] = "Which shop-side rule reproduces the shop totals?";
+    foreach (shop_hypotheses($saldiLines, $momssats) as $name => $h) {
+        $match = abs($h['net'] - $nettosum) < 0.005 && abs($h['vat'] - $momssum) < 0.005;
+        $out[] = sprintf("  %s %-44s net %10.4f  vat %10.4f", $match ? '=>' : '  ', $name, $h['net'], $h['vat']);
+    }
+    return implode("\n", $out) . "\n";
+}
+
+/**
+ * Scan a rest_api.log for amount rejections and print each with the line
+ * arithmetic fakturer_ordre logged just before it.
+ *
+ * @param string $path
+ * @return string report
+ */
+function scan_log($path)
+{
+    $fh = fopen($path, 'r');
+    if (!$fh) {
+        return "Cannot open $path\n";
+    }
+    $out = [];
+    $block = [];
+    $count = 0;
+    while (($line = fgets($fh)) !== false) {
+        $line = rtrim($line, "\r\n");
+        if (strpos($line, 'base currency:') !== false) {
+            $block = [];
+        }
+        if (preg_match('/^\d+ Svar : [-\d.]+=/', $line) || strpos($line, 'select * from ordrelinjer where ordre_id=') !== false) {
+            $block[] = $line;
+        }
+        if (strpos($line, 'Error in amount') !== false) {
+            $count++;
+            $out[] = str_repeat('=', 100);
+            foreach ($block as $b) {
+                $out[] = "  " . $b;
+            }
+            $out[] = $line;
+            $block = [];
+        }
+    }
+    fclose($fh);
+    $out[] = str_repeat('=', 100);
+    $out[] = "$count amount rejection(s) found in $path";
+    return implode("\n", $out) . "\n";
+}
+
+function usage()
+{
+    return <<<TXT
+Usage:
+  php tools/shop_order_reconcile.php REQUESTS.txt [--momssats=25] [--valutakurs=100]
+      REQUESTS.txt holds the raw requests for ONE shop order, one per line
+      (full URL or query string): the insert_shop_order call followed by its
+      insert_shop_orderline calls. Lines starting with # are ignored. Keys are
+      redacted in the output. --momssats/--valutakurs override what Saldi takes
+      from the customer group / currency table instead of the request.
+
+  php tools/shop_order_reconcile.php --log temp/<db>/rest_api.log
+      Lists every "Error in amount" rejection with the line arithmetic that
+      fakturer_ordre logged for it.
+
+TXT;
+}
+
+function main($argv)
+{
+    $file = null;
+    $log = null;
+    $overrides = [];
+    foreach (array_slice($argv, 1) as $arg) {
+        if (preg_match('/^--log=(.+)$/', $arg, $m)) {
+            $log = $m[1];
+        } elseif ($arg === '--log') {
+            $log = '';
+        } elseif ($log === '') {
+            $log = $arg;
+        } elseif (preg_match('/^--(momssats|valutakurs)=(.+)$/', $arg, $m)) {
+            $overrides[$m[1]] = rate_value($m[2]);
+        } elseif ($arg === '-h' || $arg === '--help') {
+            fwrite(STDOUT, usage());
+            return 0;
+        } else {
+            $file = $arg;
+        }
+    }
+    if ($log) {
+        fwrite(STDOUT, scan_log($log));
+        return 0;
+    }
+    if (!$file || !is_readable($file)) {
+        fwrite(STDERR, usage());
+        return 1;
+    }
+    $requests = [];
+    foreach (file($file) as $raw) {
+        $p = parse_request($raw);
+        if ($p) {
+            $requests[] = $p;
+        }
+    }
+    fwrite(STDOUT, reconcile($requests, $overrides));
+    return 0;
+}
+
+if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === __FILE__) {
+    exit(main($argv));
+}

--- a/tools/shop_order_reconcile.php
+++ b/tools/shop_order_reconcile.php
@@ -30,6 +30,9 @@
 //                     the line-by-line reconciliation and which shop-side
 //                     rounding rule reproduces the shop totals (SST-768/JOB-117).
 //                     Reads nothing from the database and changes nothing.
+//                     Review: non-DKK orders need a rate and every order a VAT
+//                     rate (override or request, request flagged), overrides are
+//                     validated, and failures exit 1 (CodeRabbit on PR #594).
 
 require_once __DIR__ . '/../includes/std_func.php';
 
@@ -153,6 +156,7 @@ function shop_hypotheses($lines, $momssats)
  * @param array{momssats?:float,valutakurs?:float} $overrides values Saldi takes from its own
  *        settings rather than the request (customer-group VAT rate, currency rate)
  * @return string report
+ * @throws InvalidArgumentException when the input cannot be replayed faithfully
  */
 function reconcile($requests, $overrides = [])
 {
@@ -167,11 +171,34 @@ function reconcile($requests, $overrides = [])
         }
     }
     if (!$order) {
-        return "No insert_shop_order request found.\n";
+        throw new InvalidArgumentException('No insert_shop_order request found.');
     }
     $valuta = $order['valuta'] ?: 'DKK';
-    $valutakurs = ($valuta === 'DKK') ? 100 : (float)($overrides['valutakurs'] ?? rate_value($order['valutakurs'] ?? 100));
-    $momssats = (float)($overrides['momssats'] ?? ($order['momssats'] ?? 25));
+    $warnings = [];
+    if ($valuta === 'DKK') {
+        $valutakurs = 100.0;
+    } elseif (isset($overrides['valutakurs'])) {
+        $valutakurs = $overrides['valutakurs'];
+    } elseif (isset($order['valutakurs']) && $order['valutakurs'] !== '') {
+        $valutakurs = rate_value($order['valutakurs']);
+        $warnings[] = "valutakurs $valutakurs taken from the request; Saldi uses its own currency table (grupper VK), pass --valutakurs to replay what Saldi did";
+    } else {
+        throw new InvalidArgumentException("Order is in $valuta but no rate is available; pass --valutakurs=<rate from grupper VK>.");
+    }
+    if ($valutakurs <= 0) {
+        throw new InvalidArgumentException("valutakurs must be greater than zero, got $valutakurs.");
+    }
+    if (isset($overrides['momssats'])) {
+        $momssats = $overrides['momssats'];
+    } elseif (isset($order['momssats']) && $order['momssats'] !== '') {
+        $momssats = (float)$order['momssats'];
+        $warnings[] = "momssats $momssats taken from the request; Saldi uses the customer group rate (DG -> SM), pass --momssats to replay what Saldi did";
+    } else {
+        throw new InvalidArgumentException('No VAT rate available; pass --momssats=<customer group rate>.');
+    }
+    if ($momssats < 0) {
+        throw new InvalidArgumentException("momssats cannot be negative, got $momssats.");
+    }
     $nettosum = (float)($order['nettosum'] ?? 0);
     $momssum = (float)($order['momssum'] ?? 0);
     $betalt = isset($order['ekstra2']) ? (float)$order['ekstra2'] : null;
@@ -219,6 +246,7 @@ function reconcile($requests, $overrides = [])
         $payDiff = abs($nettosum + $momssum - $betalt);
         $out[] = sprintf("Payment check (pos_betaling): |nettosum+momssum - ekstra2| = %.4f -> %s", $payDiff, $payDiff >= RECONCILE_TOLERANCE ? "REJECTED (Error in amount vs. paid amount)" : "ok");
     }
+    $flags = array_merge($warnings, $flags);
     if ($flags) {
         $out[] = "";
         $out[] = "Notes:";
@@ -241,12 +269,13 @@ function reconcile($requests, $overrides = [])
  *
  * @param string $path
  * @return string report
+ * @throws InvalidArgumentException when the log cannot be opened
  */
 function scan_log($path)
 {
-    $fh = fopen($path, 'r');
+    $fh = @fopen($path, 'r');
     if (!$fh) {
-        return "Cannot open $path\n";
+        throw new InvalidArgumentException("Cannot open $path");
     }
     $out = [];
     $block = [];
@@ -305,7 +334,11 @@ function main($argv)
             $log = '';
         } elseif ($log === '') {
             $log = $arg;
-        } elseif (preg_match('/^--(momssats|valutakurs)=(.+)$/', $arg, $m)) {
+        } elseif (preg_match('/^--(momssats|valutakurs)=(.*)$/', $arg, $m)) {
+            if (!preg_match('/^\d+([.,]\d+)?$/', $m[2])) {
+                fwrite(STDERR, "Invalid value for --{$m[1]}: '{$m[2]}' (expected a number)\n");
+                return 1;
+            }
             $overrides[$m[1]] = rate_value($m[2]);
         } elseif ($arg === '-h' || $arg === '--help') {
             fwrite(STDOUT, usage());
@@ -314,23 +347,28 @@ function main($argv)
             $file = $arg;
         }
     }
-    if ($log) {
-        fwrite(STDOUT, scan_log($log));
+    try {
+        if ($log) {
+            fwrite(STDOUT, scan_log($log));
+            return 0;
+        }
+        if (!$file || !is_readable($file)) {
+            fwrite(STDERR, usage());
+            return 1;
+        }
+        $requests = [];
+        foreach (file($file) as $raw) {
+            $p = parse_request($raw);
+            if ($p) {
+                $requests[] = $p;
+            }
+        }
+        fwrite(STDOUT, reconcile($requests, $overrides));
         return 0;
-    }
-    if (!$file || !is_readable($file)) {
-        fwrite(STDERR, usage());
+    } catch (InvalidArgumentException $e) {
+        fwrite(STDERR, $e->getMessage() . "\n");
         return 1;
     }
-    $requests = [];
-    foreach (file($file) as $raw) {
-        $p = parse_request($raw);
-        if ($p) {
-            $requests[] = $p;
-        }
-    }
-    fwrite(STDOUT, reconcile($requests, $overrides));
-    return 0;
 }
 
 if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === __FILE__) {


### PR DESCRIPTION
…onciliation

## What are the changes about?
Provide a brief explanation of the changes you have made

## SST-768 / JOB-117: Offline replay tool for Shoptec order amount reconciliation

### Background

MEDSHOP (saldi_390) reports recurring 2-øre differences between the Shoptec shop and Saldi, corrected by hand each time. Shoptec proposed three fixes and asked us to choose. The ticket gates any change to the arithmetic or the 0.01 tolerance in `api/rest_api.php` behind two things we did not have: a replayable failing request and an agreed set of rounding rules with Shoptec. SST-187 was closed without a cause for exactly that reason.

This PR delivers the evidence side. No production behaviour changes.

### What was verified in the code

- `fakturer_ordre()` recomputes net and VAT from the order lines (Σ `afrund(line, 3)`) and only uses the shop's `nettosum`/`momssum` as a control. A difference above 0.01 on either rejects the order with "Error in amount". This is the mechanism behind the manual corrections.
- Saldi ignores the request's `momssats` and `valutakurs`. The VAT rate comes from the customer group (DG → SM), the currency rate from `grupper` (VK). Verified on test_2: a request with `momssats=25` was settled at 21% because that is the group's rate.
- When the shop sends `rabat=0`, `opret_ordrelinje()` looks up Saldi's own customer/item discount table. Second divergence source besides rounding, invisible to Shoptec.
- The line price goes shop → DKK → order currency as floats (`rest_api.php` ↔ `ordrefunc.php:4205`) and is stored in `ordrelinjer.pris`, which is unbounded `numeric`, not `numeric(15,3)` as the ticket states.
- Shoptec's December numbers (nettosum 743, momssum 186, ekstra2 929) are reproduced exactly by one rule: gross total rounded to whole kroner, VAT = gross − net.
- The raw failing requests already exist: every `insert_shop_order`/`insert_shop_orderline` parameter and the settlement arithmetic are written to `temp/saldi_390/rest_api.log` on ssl5.

### Change

- `tools/shop_order_reconcile.php` (CLI, no database access, keys redacted):
  - `php tools/shop_order_reconcile.php REQUESTS.txt [--momssats=N] [--valutakurs=N]` replays one order's raw requests through the same arithmetic as `insert_shop_orderline` → `opret_ordrelinje` → `fakturer_ordre`, prints the line-by-line table, the first divergence, the payment check, and which of six shop-side rounding rules reproduces the shop's totals.
  - `php tools/shop_order_reconcile.php --log temp/<db>/rest_api.log` lists every "Error in amount" rejection with the arithmetic logged for it.
- `tests/characterization/tools/ShopOrderReconcileTest.test.php`: mirrors the settlement check, reproduces the SST-187 rejection, keeps a SEK/NOK price intact through the currency round trip (SST-406 regression case), covers a VAT-free line.

### Testing

- New tests pass. Full suite unchanged from master (7 failures + 1 error pre-existing in the usdecimal characterization tests).
- On ssl12 / test_2: created shop order 910001 with `nettosum=743&momssum=186`, one line B16 × 1 at 743, invoiced via `fakturer_ordre`. Server replied `Error in amount (743.000+186.000) vs. item amount (743+156.03)`. The tool, given the same two requests and `--momssats=21`, printed the identical rejection and table. Without the override it shows the 25% case, 185.75 vs 186, with rule E as the match.

### Next steps (outside this PR)

- Run the `--log` scan on ssl5 against `temp/saldi_390/rest_api.log` and attach one replayed rejected order to the ticket.
- Reply to Shoptec: option 1 no (SST-406 double VAT), option 2 only if their totals follow the same rule as the lines; ask them to confirm the whole-krone gross rounding and to send discount and VAT rate explicitly per line.
- Decide tolerance/arithmetic only after that agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [ ] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [ ] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line utility for reconciling shop-order totals with calculated amounts.
  - Supports currency conversion, VAT handling, rounding-rule comparisons, payment discrepancy reporting, and log analysis.
  - Protects sensitive request values in generated reports and provides clear usage guidance for invalid input.

- **Tests**
  - Added coverage for matching and mismatched totals, foreign-currency prices, VAT-free lines, rounding behavior, and sensitive-data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->