### PR TITLE
SD-186: Fix Udført af invoice output, selection and filtering

### DIFF
--- a/debitor/orderIncludes/renderEmployeeFields.php
+++ b/debitor/orderIncludes/renderEmployeeFields.php
@@ -1,0 +1,42 @@
+<?php
+// 20260911 CDX/LH SD-186 Render independent employee fields beside each other.
+
+/**
+ * Render the order's two employee selections from the same master-data list.
+ * Keep historical selections available even after an employee has been closed.
+ *
+ * @param string[] $employees Active employee names from the current regnskab.
+ * @param string|null $reference Current Vor ref. value.
+ * @param string|null $performedBy Current Udført af value.
+ * @param string $referenceLabel Translated Vor ref. label.
+ * @param bool $disabled Whether the order fields are locked for editing.
+ * @return string HTML table row with independent, optional employee selections.
+ */
+function renderOrderEmployeeFields($employees, $reference, $performedBy, $referenceLabel, $disabled = false)
+{
+    $fields = array(
+        'ref' => array('label' => $referenceLabel, 'value' => $reference, 'old' => 'oldRef'),
+        'hvem' => array('label' => 'Udført af', 'value' => $performedBy, 'old' => 'oldhvem'),
+    );
+    $html = '<tr>';
+    foreach ($fields as $name => $field) {
+        $selected = (string) $field['value'];
+        $options = array_values(array_unique(array_merge(array(''), $employees)));
+        if (!in_array($selected, $options, true)) {
+            $options[] = $selected;
+        }
+        $label = htmlspecialchars($field['label'], ENT_QUOTES, 'UTF-8');
+        $oldValue = htmlspecialchars($selected, ENT_QUOTES, 'UTF-8');
+        $html .= "<td style='white-space:nowrap'><label for='order-$name'>$label</label></td><td>";
+        $html .= "<input type='hidden' name='{$field['old']}' value='$oldValue'>";
+        $html .= "<select id='order-$name' name='$name' class='inputbox' style='width:130px;'";
+        $html .= " onchange='docChange = true;'" . ($disabled ? ' disabled' : '') . '>';
+        foreach ($options as $employee) {
+            $value = htmlspecialchars($employee, ENT_QUOTES, 'UTF-8');
+            $isSelected = ($employee === $selected) ? ' selected' : '';
+            $html .= "<option value='$value'$isSelected>$value</option>";
+        }
+        $html .= '</select></td>';
+    }
+    return $html . '</tr>';
+}

--- a/debitor/ordre.php
+++ b/debitor/ordre.php
@@ -111,6 +111,8 @@
 // 20260908 CL/Sawaneh SST-763: PBS button on posted PBS invoices opens debitor/pbs_gensend.php
 //                     (attempt history + resend after a Nets rejection).
 // 20260910 CL/NTR SST-763: tekst ids 5170-5190 moved to 3385-3404; 5180 replaced by existing 828 (Fakturanr.).
+// 20260911 CDX/LH SD-186 Place Udført af beside Vor ref. using the same employee options.
+//                  Escape employee selections when saving names containing apostrophes.
 
 @session_start();
 $s_id = session_id();
@@ -803,7 +805,7 @@ if (!$id && $konto_id && $kontonr && !strstr($b_submit, 'Opslag')) {
 	$qtxt .= "lev_kontakt,vis_lev_addr,felt_1,felt_2,felt_3,felt_4,felt_5,procenttillag,omvbet)";
 	$qtxt .= " values ";
 	$qtxt .= "($ordrenr,'$konto_id','$kontonr','$firmanavn','$addr1','$addr2','$postnr','$bynavn','$land','$betalingsdage','$betalingsbet',";
-	$qtxt .= "'$cvrnr','$ean','$institution','$email','$mail_fakt','$phone','$notes','DO','$ordredate','$momssats','$tidspkt','$ref','$hvem',";
+	$qtxt .= "'$cvrnr','$ean','$institution','$email','$mail_fakt','$phone','$notes','DO','$ordredate','$momssats','$tidspkt','" . db_escape_string((string) $ref) . "','" . db_escape_string((string) $hvem) . "',";
 	$qtxt .= "'$valuta','$formularsprog','$kontakt','$pbs','$afd','0','0','$lev_firmanavn','$lev_addr1','$lev_addr2','$lev_postnr','$lev_bynavn','$lev_land','$lev_email',";
 	$qtxt .= "'$lev_kontakt','$vis_lev_addr','$felt_1','$felt_2','$felt_3','$felt_4','$felt_5','$default_procenttillag','$omkunde')";
 	db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -834,7 +836,7 @@ if (!$id && $konto_id && $kontonr && !strstr($b_submit, 'Opslag')) {
 			$qtxt .= "lev_postnr='$lev_postnr',lev_bynavn='$lev_bynavn',lev_kontakt='$lev_kontakt',lev_land='$lev_land',lev_email='$lev_email',vis_lev_addr='$vis_lev_addr',";
 			$qtxt .= "felt_1='$felt_1',felt_2='$felt_2',felt_3='$felt_3',felt_4='$felt_4',felt_5='$felt_5',betalingsdage='$betalingsdage',";
 			$qtxt .= "betalingsbet='$betalingsbet',cvrnr='$cvrnr',ean='$ean',momssats='$momssats',institution='$institution',email='$email',";
-			$qtxt .= "mail_fakt='$mail_fakt',phone='$phone',udskriv_til='$udskriv_til',notes='$notes',hvem = '$hvem',tidspkt='$tidspkt',";
+			$qtxt .= "mail_fakt='$mail_fakt',phone='$phone',udskriv_til='$udskriv_til',notes='$notes',hvem = '" . db_escape_string((string) $hvem) . "',tidspkt='$tidspkt',";
 			$qtxt .= "pbs='$pbs',afd='$afd',restordre='$restordre' where id='$id'";
 			db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 		}
@@ -1786,7 +1788,7 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 		$qtxt .= "'$bynavn', '$land', '$kontakt', '$lev_firmanavn', '$lev_addr1', '$lev_addr2', '$lev_postnr', ";
 		$qtxt .= "'$lev_bynavn', '$lev_kontakt', '$lev_land', '$lev_email', '$betalingsdage', '$betalingsbet', ";
 		$qtxt .= "'$cvrnr', '$ean', '$institution', '$email', '$mail_fakt', '$phone', '$notes', '$art', '$ordredate', ";
-		$qtxt .= "'$momssats', $status, '$ref','$hvem', '$lev_adr', '$valuta', '$masterprojekt', '$formularsprog', '$pbs', '$afd', ";
+		$qtxt .= "'$momssats', $status, '" . db_escape_string((string) $ref) . "','" . db_escape_string((string) $hvem) . "', '$lev_adr', '$valuta', '$masterprojekt', '$formularsprog', '$pbs', '$afd', ";
 		$qtxt .= "'0', '$felt_1', '$felt_2', '$felt_3', '$felt_4', '$felt_5', '$vis_lev_addr')";
 		db_modify($qtxt, __FILE__ . " linje " . __LINE__);
 
@@ -2395,8 +2397,8 @@ if (($status < 3 || strstr($b_submit, "Kopi") || strstr($b_submit, "Kred")) && $
 				$qtxt .= "betalingsdage='$betalingsdage',betalingsbet='$betalingsbet',cvrnr='$cvrnr',momssats='$momssats',";
 				$qtxt .= "procenttillag='$procenttillag',ean='$ean',institution='$institution',email='$email',mail_fakt='$mail_fakt',";
 				$qtxt .= "phone='$phone',udskriv_til='$udskriv_til',notes='" . db_escape_string($notes) . "', ";
-				$qtxt .= "ordredate='$ordredate',status='$status',ref='$ref',";
-				$qtxt .= "fakturanr='$fakturanr',lev_adr='$lev_adr',hvem='$hvem',tidspkt='$tidspkt',projekt='$projekt[0]',";
+				$qtxt .= "ordredate='$ordredate',status='$status',ref='" . db_escape_string((string) $ref) . "',";
+				$qtxt .= "fakturanr='$fakturanr',lev_adr='$lev_adr',hvem='" . db_escape_string((string) $hvem) . "',tidspkt='$tidspkt',projekt='$projekt[0]',";
 				$qtxt .= "sprog='$formularsprog',pbs='$pbs',afd='$afd',restordre='$restordre',mail_subj='$mail_subj',mail_text='$mail_text' $tmp ";
 				$qtxt .= "where id=$id";
 				db_modify($qtxt, __FILE__ . " linje " . __LINE__);
@@ -2580,7 +2582,7 @@ if ((strstr($b_submit, 'Kopi')) || (strstr($b_submit, 'Kred'))) {
 		$qtxt .= " values ";
 		$qtxt .= "($ordrenr,'$konto_id','$kontonr','$kundeordnr','$firmanavn','$addr1','$addr2','$postnr','$bynavn','$land','$kontakt',";
 		$qtxt .= "'$lev_navn','$lev_addr1','$lev_addr2','$lev_postnr','$lev_bynavn','$lev_kontakt','$lev_email','$lev_land','$betalingsdage','$betalingsbet',";
-		$qtxt .= "'$cvrnr','$ean','$institution','$email','$mail_fakt','$phone','$notes','$art','$ordredate','$momssats','$status','$ref','$hvem','$lev_adr',";
+		$qtxt .= "'$cvrnr','$ean','$institution','$email','$mail_fakt','$phone','$notes','$art','$ordredate','$momssats','$status','" . db_escape_string((string) $ref) . "','" . db_escape_string((string) $hvem) . "','$lev_adr',";
 		$qtxt .= "'$valuta','$projekt[0]','$formularsprog','$pbs',".($afd==""?"NULL":"'$afd'").",'0','$procenttillag',".($sag_id==""?"NULL":"'$sag_id'").",".($sagsnr==""?"NULL":"'$sagsnr'").",".($tilbudnr==""?"NULL":"'$tilbudnr'").",'$datotid',";
 		$qtxt .= "".($nr==""?"NULL":"'$nr'").",'$returside','$omkunde',";
 		($art == 'PO') ? $qtxt .= "'','','','','')" : $qtxt .= "'$felt_1','$felt_2','$felt_3','$felt_4','$felt_5')"; #20191004
@@ -4058,8 +4060,8 @@ function ordreside($id, $regnskab)
 		else print $betalingsbet;
 		print "&nbsp;+&nbsp;$betalingsdage\n";
 		print "</td></tr>";
-		print "<tr class='tableTexting2'><td><b>" . findtekst('1097|Vor ref.', $sprog_id) . "</b></td><td>$ref &nbsp; $afd_navn</td></tr>\n";
-		print "<tr class='tableTexting2'><td><b>Performed by.</b></td><td>$hvem</td></tr>\n";
+		print "<tr class='tableTexting2'><td><b>" . findtekst('1097|Vor ref.', $sprog_id) . "</b></td><td>$ref &nbsp; $afd_navn</td>";
+		print "<td><b>Udført af</b></td><td>" . htmlspecialchars((string) $hvem, ENT_QUOTES, 'UTF-8') . "</td></tr>\n";
 		print "<tr class='tableTexting'><td><b>" . findtekst('828|Fakturanr.', $sprog_id) . "</b></td><td>$fakturanr</td></tr>\n";
 		$tmp = dkdecimal($valutakurs, 2);
 		if ($valuta) print "<tr class='tableTexting2'><td><b>" . findtekst('552|Valuta / Kurs', $sprog_id) . "</b></td><td>$valuta / $tmp</td></tr>\n";
@@ -5115,6 +5117,7 @@ function ordreside($id, $regnskab)
 			print "</td>\n";
 		} else //print "<tr><td colspan=\"2\" width=\"200\">\n"; # udkommenteret 15052014
 			print "</tr>\n";
+		$ansat = array();
 		$r = db_fetch_array(db_select("select id from adresser where art = 'S'", __FILE__ . " linje " . __LINE__));
 		if (isset($r['id'])) {
 			$adr_id = intval($r['id']);
@@ -5127,39 +5130,14 @@ function ordreside($id, $regnskab)
 				$a_afd[$x] = $r['afd'];
 				$x++;
 			}
-			if (!in_array($ref,$ansat)) {
-				$r=db_fetch_array(db_select("select ansatte.navn from ansatte,brugere where brugere.brugernavn='$ref' and ansatte.id=".nr_cast('brugere.ansat_id')."",__FILE__ . " linje " . __LINE__));
-				if (!empty($r['navn'])) $ref=$r['navn']; #20210715
+			if (!in_array($ref, $ansat)) {
+				$escapedRef = db_escape_string((string) $ref);
+				$r = db_fetch_array(db_select("select ansatte.navn from ansatte,brugere where brugere.brugernavn='$escapedRef' and ansatte.id=" . nr_cast('brugere.ansat_id'), __FILE__ . " linje " . __LINE__));
+				if (!empty($r['navn'])) $ref = $r['navn']; #20210715
 			}
-			print "<INPUT TYPE = 'hidden' NAME = 'oldRef' VALUE = \"$ref\">";
-			for ($x=0;$x<count($ansat);$x++) {
-				if (!$x) {
-				print "<tr><td>".findtekst(1097,$sprog_id)."</td>\n";
-				print "<td><select style=\"width:130px;\" class = 'inputbox' name=\"ref\" $disabled>\n";
-				print "<option>$ref</option>\n";
-				}
-				if ($ref!=$ansat[$x]) print "<option> $ansat[$x]</option>\n";
-			}
-
-			#####
-			print "<INPUT TYPE = 'hidden' NAME = 'oldhvem' VALUE = \"$hvem\">";
-			for ($x=0;$x<count($ansat);$x++) {
-				if (!$x) {
-				print "<tr><td>Performed by</td>\n";
-				print "<td><select style=\"width:130px;\" class = 'inputbox' name=\"hvem\" $disabled>\n";
-				print "<option>$hvem</option>\n";
-				// Always offer a blank option so 'Performed by' can be cleared back to blank. #20260629
-				if (trim($hvem) != '') print "<option value=\"\"></option>\n";
-				    if ($brugernavn != $hvem && !in_array($brugernavn, $ansat)) {
-						print "<option value=\"$brugernavn\">$brugernavn</option>\n";
-					}
-				}
-				if ($hvem!=$ansat[$x]) print "<option> $ansat[$x]</option>\n";
-			}
-			####
-
-					
 		}
+		include_once(__DIR__ . '/orderIncludes/renderEmployeeFields.php');
+		print renderOrderEmployeeFields($ansat, $ref, $hvem, findtekst(1097, $sprog_id), !empty($disabled));
 		$x = 0;
 		$afd_navn = array();
 		$afd_nr[$x] = array();
@@ -5169,7 +5147,7 @@ function ordreside($id, $regnskab)
 			$afd_navn[$x] = $r['beskrivelse'];
 			$x++;
 		}
-		print "</td>";
+		print "<tr><td colspan='2'>";
 		// Ensure afd is set from user settings for new orders before rendering dropdown
 		/* Do not enable - does nor work !!!
 		 *		if (!$id) {
@@ -5179,7 +5157,7 @@ function ordreside($id, $regnskab)
 		*/
 		print "<input type = 'hidden' name='extAfd' value='$afd'>";
 		if (count($afd_nr) > 1) {
-			print "</td><td></td>\n";
+			print "</td>\n";
 			print "<td>" . findtekst('1198|Afd.', $sprog_id) . "</td><td><select style=\"width:130px;\" class = 'inputbox' name=\"afd\">";
 			for ($x = 0; $x < count($afd_nr); $x++) {
 				if ($afd_nr[$x] == $afd) print "<option value=\"$afd_nr[$x]\" selected>$afd_nr[$x] $afd_navn[$x]</option>";

--- a/debitor/ordreliste.php
+++ b/debitor/ordreliste.php
@@ -56,6 +56,8 @@
 // 20260630 CDX/NTR Fixed land (country) column from printing the countries outside the table and searchable bar not existing.
 // 20260701 Sawaneh Fixed: 'Performed by' is display-only and no longer cleared on return to the list.
 // 20260701 CDX/NTR Fixed the default search to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
+// 20260911 CDX/LH SD-186 Label the searchable employee column Udført af in order and invoice lists.
+//                  Define it in the column pool so saved layouts use the same field configuration.
 
 @session_start();
 $s_id = session_id();
@@ -1009,6 +1011,19 @@ $custom_columns = array(
         }
     ),
     
+    "hvem" => array(
+        "field" => "hvem",
+        "headerName" => 'Udført af',
+        "width" => "1",
+        "type" => "text",
+        "sqlOverride" => "o.hvem",
+        "searchable" => true,
+        "render" => function ($value, $row, $column) {
+            $value = htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+            return "<td align='{$column['align']}'>$value</td>";
+        }
+    ),
+
     "sum_m_moms" => array(
         "field" => "sum_m_moms",
         "headerName" => "Sum m. moms",
@@ -1621,22 +1636,6 @@ $columns[] = array(
         return $actions;
     }
 );
- if ($sprog_id == 2) {
-        $columnHd = 'Performed by'; //TODO: findtekst
- } else{
-        $columnHd = 'Hvem';
- }
- $columns[] = array(
-        "field" => "hvem",
-        "headerName" => $columnHd,
-        "width" => "1",
-        "type" => "text",
-        "hidden" => true,
-        "searchable" => true,
-        "render" => function ($value, $row, $column) {
-            return "<td align='{$column['align']}'>$value</td>";
-        }
-    );
 // === END DYNAMIC COLUMN DEFINITION ===
 
 

--- a/includes/formfunk.php
+++ b/includes/formfunk.php
@@ -61,6 +61,7 @@
 // 20260820 Sawaneh Supplier order print totals now match the printed line sums and the
 //                  booked amounts: sum of rounded line sums, VAT on the total (1-3 oere diff).
 //                  Supplier orders no longer print VAT-inclusive prices (customer setting).
+// 20260911 CDX/LH SD-186 Load performed-by value when printing or emailing order documents.
 
 #use PHPMailer\PHPMailer\PHPMailer;
 #use PHPMailer\PHPMailer\Exception; 
@@ -1175,7 +1176,7 @@ if (!function_exists('formularprint')) {
 				$email[0] = 'Kundens email';
 				$pbs = '';
 			} else {
-				$qtxt = "select afd,status,email,ordrenr,fakturanr,mail_fakt,pbs,art,ref,sprog,udskriv_til,mail_subj,mail_text,dokument,procenttillag ";
+				$qtxt = "select afd,status,email,ordrenr,fakturanr,mail_fakt,pbs,art,ref,hvem,sprog,udskriv_til,mail_subj,mail_text,dokument,procenttillag ";
 				$qtxt .= "from ordrer where id = '$ordre_id[$o]'";
 				$q = db_select($qtxt, __FILE__ . " linje " . __LINE__);
 				$row = db_fetch_array($q);

--- a/includes/orderFuncIncludes/grid_order.php
+++ b/includes/orderFuncIncludes/grid_order.php
@@ -7,6 +7,7 @@
 // 20260701 CDX/NTR - Changed DEFAULT_GENERATE_SEARCH to handle numeric comparisons and fixed TEXT searches from throwing fatal errors.
 // 20260817 Sawaneh Sort descending columns NULLS LAST so rows without a date no longer
 //                  displace the newest rows, and validate the request-sourced sort value.
+// 20260911 CDX/LH SD-186 Escape search ordering with the DB driver; pass raw terms to search callbacks.
 
 /** 
  * Extracts values from a specific column in a multi-dimensional array.
@@ -858,14 +859,14 @@ function prepare_grid_order_sort($sort, $columns) {
  * @param array $grid_data An array containing the base query and other data for constructing the query.
  * @param array $columns An array of column definitions used for sorting, searching, and filtering.
  * @param array $filters An array of filter definitions.
- * @param array $searchTerms (optional) An associative array of search terms where the key is the column field name and the value is the search term.
+ * @param array $searchTerms An associative array of search terms where the key is the column field name and the value is the search term.
  * @param string $sort The sorting condition (e.g., "field ASC" or "field DESC").
  * @param int $rowCount The number of rows to return.
  * @param int $offset The starting point for the result set (used for pagination).
  * @return string The final SQL query with all conditions applied.
  *
  */
-function build_query($id, $grid_data, $columns, $filters, $searchTerms = [], $sort, $rowCount, $offset) {
+function build_query($id, $grid_data, $columns, $filters, $searchTerms, $sort, $rowCount, $offset) {
     $query = $grid_data['query'];
     
     $filterstring = "";
@@ -906,7 +907,7 @@ function build_query($id, $grid_data, $columns, $filters, $searchTerms = [], $so
         $searchConditions = [];
         foreach ($searchableColumns as $column) {
             if (isset($searchTerms[$column['field']]) && $searchTerms[$column['field']] !== '') {
-                $term = addslashes($searchTerms[$column['field']]);
+                $term = $searchTerms[$column['field']];
                 // Convert both the column value and the search term to lowercase
                 if ($term !== '') {
                     $searchConditions[] = $column['generateSearch']($column, $term);
@@ -934,7 +935,7 @@ function build_query($id, $grid_data, $columns, $filters, $searchTerms = [], $so
         $orderCases = array();
         foreach ($searchableColumns as $column) {
             if (isset($searchTerms[$column['field']]) && $searchTerms[$column['field']] !== '') {
-                $term = addslashes($searchTerms[$column['field']]);
+                $term = db_escape_string($searchTerms[$column['field']]);
                 $field = $column['sqlOverride'] == '' ? $column['field'] : $column['sqlOverride'];
                 
                 if ($term === '' && $term !== '0') {
@@ -993,11 +994,11 @@ function build_query($id, $grid_data, $columns, $filters, $searchTerms = [], $so
  * @param array $grid_data An array containing the base query and other data for constructing the query.
  * @param array $columns An array of column definitions used for sorting, searching, and filtering.
  * @param array $filters An array of filter definitions.
- * @param array $searchTerms (optional) An associative array of search terms where the key is the column field name and the value is the search term.
+ * @param array $searchTerms An associative array of search terms where the key is the column field name and the value is the search term.
  * @param string $sort The sorting condition (although not needed for counting, it's included for consistency).
  * @return string The final count query to return the total number of rows.
  */
-function build_count_query($grid_data, $columns, $filters, $searchTerms = [], $sort) {
+function build_count_query($grid_data, $columns, $filters, $searchTerms, $sort) {
     // Start with the original query and modify it for counting rows
     $query = $grid_data['query'];
 
@@ -1039,7 +1040,7 @@ function build_count_query($grid_data, $columns, $filters, $searchTerms = [], $s
         $searchConditions = [];
         foreach ($searchableColumns as $column) {
             if (isset($searchTerms[$column['field']]) && $searchTerms[$column['field']] !== '') {
-                $term = addslashes($searchTerms[$column['field']]);
+                $term = $searchTerms[$column['field']];
                 if ($term !== '') {
                     $searchConditions[] = $column['generateSearch']($column, $term);
                 }

--- a/systemdata/formularkort.php
+++ b/systemdata/formularkort.php
@@ -59,6 +59,7 @@
 // 20260529 CL/PHR Rettet: manglende xa-records (mailtekst/bilag) for art=5 oprettes nu automatisk ved visning
 // 20260604 LOE Added 'Performed by' to form dropdown..to be translated later when needed.
 // 20260710 SZ Added Settings search box (settingsSearch.php/.js/.css)
+// 20260911 CDX/LH SD-186 Use the Danish Udført af label for the invoice field.
 @session_start();
 $s_id=session_id();
 
@@ -809,7 +810,7 @@ function drop_down($x,$form_nr,$art_nr,$formularsprog,$id,$beskrivelse,$xa,$xb,$
 		print "<option value = 'ordre_tlf'>".findtekst('605|Ordre', $sprog_id)." ".strtolower(findtekst('49|Tlf', $sprog_id))."</option>";                                         #Ordre tlf
 	}
 	if ($form_nr<6 || $form_nr==10 || $form_nr>=12) {
-		print "<option value = 'ordre_hvem'>Performed by</option>"; 
+		print "<option value = 'ordre_hvem'>Udført af</option>";
 		print "<option value = 'ordre_ean'>".findtekst('605|Ordre', $sprog_id)." EAN</option>";                                                                                    #Ordre EAN
 		print "<option value = 'ordre_felt_1'>".findtekst('605|Ordre', $sprog_id)." ".strtolower(findtekst('543|Felt', $sprog_id))." 1</option>";                                  #Ordre felt 1
 		print "<option value = 'ordre_felt_2'>".findtekst('605|Ordre', $sprog_id)." ".strtolower(findtekst('543|Felt', $sprog_id))." 2</option>";                                  #Ordre felt 2

--- a/tests/characterization/debitor/OrderEmployeeFieldsTest.test.php
+++ b/tests/characterization/debitor/OrderEmployeeFieldsTest.test.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../debitor/orderIncludes/renderEmployeeFields.php';
+
+final class OrderEmployeeFieldsTest extends TestCase
+{
+    private function fields(array $employees, ?string $reference, ?string $performedBy, bool $disabled = false): DOMXPath
+    {
+        $html = renderOrderEmployeeFields($employees, $reference, $performedBy, 'Vor ref.', $disabled);
+        $document = new DOMDocument();
+        $document->loadHTML('<html><head><meta charset="UTF-8"></head><body><form><table>' . $html . '</table></form></body></html>');
+        return new DOMXPath($document);
+    }
+
+    private function options(DOMXPath $fields, string $name): array
+    {
+        $values = [];
+        foreach ($fields->query("//select[@name='$name']/option") as $option) {
+            $values[] = $option->getAttribute('value');
+        }
+        return $values;
+    }
+
+    public function testBothFieldsShareEmployeesWithIndependentSelectionsInOneRow(): void
+    {
+        $fields = $this->fields(['Anna', 'Søren'], 'Anna', 'Søren');
+        self::assertSame(['', 'Anna', 'Søren'], $this->options($fields, 'ref'));
+        self::assertSame($this->options($fields, 'ref'), $this->options($fields, 'hvem'));
+        self::assertSame('Anna', $fields->evaluate('string(//select[@name="ref"]/option[@selected]/@value)'));
+        self::assertSame('Søren', $fields->evaluate('string(//select[@name="hvem"]/option[@selected]/@value)'));
+        self::assertSame(1, $fields->query('//tr[td/select[@name="ref"] and td/select[@name="hvem"]]')->length);
+        self::assertSame('Udført af', $fields->evaluate('string(//label[@for="order-hvem"])'));
+        self::assertSame('ref', $fields->query('//select')->item(0)->getAttribute('name'));
+        self::assertSame('hvem', $fields->query('//select')->item(1)->getAttribute('name'));
+    }
+
+    public function testBlankPerformedByStaysBlankAndCanBeRenderedWithoutEmployees(): void
+    {
+        $fields = $this->fields(['Anna'], 'Anna', null);
+        self::assertSame('', $fields->evaluate('string(//select[@name="hvem"]/option[@selected]/@value)'));
+        self::assertSame('Anna', $fields->evaluate('string(//select[@name="ref"]/option[@selected]/@value)'));
+        $empty = $this->fields([], null, null);
+        self::assertSame([''], $this->options($empty, 'ref'));
+        self::assertSame([''], $this->options($empty, 'hvem'));
+        self::assertSame(2, $empty->query('//option[@selected and @value=""]')->length);
+    }
+
+    public function testHistoricalSelectionIsPreservedWithoutAddingItToTheOtherField(): void
+    {
+        $fields = $this->fields(['Anna'], 'Anna', 'Former employee');
+        self::assertSame(['', 'Anna'], $this->options($fields, 'ref'));
+        self::assertSame(['', 'Anna', 'Former employee'], $this->options($fields, 'hvem'));
+        self::assertSame('Former employee', $fields->evaluate('string(//select[@name="hvem"]/option[@selected]/@value)'));
+        self::assertSame('Former employee', $fields->evaluate('string(//input[@name="oldhvem"]/@value)'));
+    }
+
+    public function testNamesWithQuotesAndMarkupRoundTripAsText(): void
+    {
+        $employee = 'Søren O\'Neil "A&B" <technician>';
+        $fields = $this->fields([$employee], $employee, $employee);
+        foreach (['ref', 'hvem'] as $name) {
+            self::assertSame(['', $employee], $this->options($fields, $name));
+            self::assertSame($employee, $fields->evaluate("string(//select[@name='$name']/option[@selected])"));
+        }
+        self::assertSame(0, $fields->query('//technician')->length);
+    }
+
+    public function testEmployeeListsAreRefreshedAndDoNotLeakBetweenRegnskaber(): void
+    {
+        foreach ([['Anna'], ['Søren'], ['Anna', 'Søren', 'New employee']] as $employees) {
+            $fields = $this->fields($employees, null, null);
+            foreach (['ref', 'hvem'] as $name) {
+                self::assertSame(array_merge([''], $employees), $this->options($fields, $name));
+            }
+        }
+    }
+
+    public function testEditingRestrictionAppliesToBothDropdowns(): void
+    {
+        self::assertSame(2, $this->fields(['Anna'], 'Anna', '', true)->query('//select[@disabled]')->length);
+        self::assertSame(0, $this->fields(['Anna'], 'Anna', '', false)->query('//select[@disabled]')->length);
+    }
+}

--- a/tests/characterization/debitor/OrderEmployeeSearchTest.test.php
+++ b/tests/characterization/debitor/OrderEmployeeSearchTest.test.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercise the actual order-grid query builders against PostgreSQL VALUES fixtures.
+ * No tenant rows are read or changed. Credentials come from local connect.php.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class OrderEmployeeSearchTest extends TestCase
+{
+    private string $originalCwd;
+
+    protected function setUp(): void
+    {
+        global $sqhost, $squser, $sqpass, $sqdb, $db_type, $db_encode, $connection;
+
+        $root = dirname(__DIR__, 3);
+        $this->originalCwd = getcwd();
+        if (!extension_loaded('pgsql') || !is_file($root . '/includes/connect.php')) {
+            self::markTestSkipped('Local PostgreSQL configuration is required.');
+        }
+        chdir($root . '/debitor');
+        $_SERVER['REQUEST_URI'] = '/saldi/debitor/ordreliste.php';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        require_once $root . '/includes/connect.php';
+        if (in_array($db_type, ['mysql', 'mysqli'], true)) {
+            self::markTestSkipped('The order grid uses PostgreSQL SQL syntax.');
+        }
+        $connection = db_connect($sqhost, $squser, $sqpass, $sqdb);
+        if (!$connection) {
+            self::markTestSkipped('Local PostgreSQL connection is unavailable.');
+        }
+        require_once $root . '/includes/std_func.php';
+        require_once $root . '/includes/orderFuncIncludes/grid_order.php';
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+    }
+
+    /**
+     * @return array{ids: int[], count: int} Ordered matches and grid pagination count.
+     */
+    private function search(array $terms, ?callable $generateSearch = null): array
+    {
+        global $connection;
+
+        $name = db_escape_string("Søren O'Neil");
+        $backslashName = db_escape_string('Søren\\West');
+        $grid = ['query' => "SELECT o.* FROM (VALUES
+            (1, '$name', 'Anna', 12.50, DATE '2026-09-11'),
+            (2, 'Team $name', 'Anna', 25.00, DATE '2026-09-12'),
+            (3, 'Anna', '$name', 5.00, DATE '2026-09-11'),
+            (4, '$backslashName', 'Anna', 0.00, DATE '2026-09-13')
+            ) AS o(id,hvem,ref,amount,ordredate)
+            WHERE {{WHERE}} ORDER BY {{SORT}}"];
+        $columns = [];
+        foreach (['id' => 'number', 'hvem' => 'text', 'ref' => 'text', 'amount' => 'number', 'ordredate' => 'date'] as $field => $type) {
+            $columns[] = [
+                'field' => $field, 'sqlOverride' => 'o.' . $field, 'type' => $type,
+                'searchable' => true, 'decimalPrecision' => 2,
+                'generateSearch' => $generateSearch ?? 'DEFAULT_GENERATE_SEARCH',
+            ];
+        }
+        $sql = build_query('sd186', $grid, $columns, [], $terms, 'id desc', 20, 0);
+        $countSql = build_count_query($grid, $columns, [], $terms, 'id desc');
+        $rows = pg_query($connection, $sql);
+        $count = pg_query($connection, $countSql);
+        self::assertNotFalse($rows);
+        self::assertNotFalse($count);
+        return [
+            'ids' => array_map('intval', pg_fetch_all_columns($rows)),
+            'count' => (int) pg_fetch_result($count, 0, 'total_items'),
+        ];
+    }
+
+    public function testApostropheMatchesPerformedByAndPrioritizesExactName(): void
+    {
+        self::assertSame(['ids' => [1, 2], 'count' => 2], $this->search(['hvem' => "Søren O'Neil"]));
+    }
+
+    public function testReferenceSearchRemainsIndependent(): void
+    {
+        self::assertSame(['ids' => [3], 'count' => 1], $this->search(['ref' => "Søren O'Neil"]));
+    }
+
+    public function testCustomSearchReceivesUnescapedTerm(): void
+    {
+        $exactSearch = static function ($column, $term): string {
+            return $column['sqlOverride'] . " = '" . db_escape_string($term) . "'";
+        };
+        self::assertSame(['ids' => [4], 'count' => 1], $this->search(['hvem' => 'Søren\\West'], $exactSearch));
+    }
+
+    public function testNonmatchingNameReturnsNoRows(): void
+    {
+        self::assertSame(['ids' => [], 'count' => 0], $this->search(['hvem' => "Nobody O'Neil"]));
+    }
+
+    public function testExistingNumericAndDateSearchesStillWork(): void
+    {
+        self::assertSame(['ids' => [2, 1], 'count' => 2], $this->search(['amount' => '>10']));
+        self::assertSame(['ids' => [3, 1], 'count' => 2], $this->search(['ordredate' => '11-09-2026']));
+    }
+}


### PR DESCRIPTION
## What are the changes about?

Fix SD-186: selecting an employee in “Udført af” previously produced a blank invoice field because the print/email query omitted `hvem`. The field now appears beside “Vor ref.” with the same employee choices and an independent, optional selection. Invoice PDFs and email attachments receive the selected value through the existing `ordre_hvem` template field.

Define the Danish “Udført af” column in the order/invoice column pool so saved layouts can expose and search it. Fix database escaping when saving employee names and ordering search matches; names such as `Søren O'Neil` now save and filter correctly. Existing historical employee selections remain available.

No schema migration is needed: this uses the existing independent `ordrer.hvem` column. Each accounting entity's active invoice layout must include `ordre_hvem`; users can enable the searchable column in their list settings.

## Validation

- On this branch, based on master `e60c6005`: **19 tests, 58 assertions passed**, including the two new employee test classes and existing debtor characterization tests. PHP syntax checks passed for all eight changed/new files; `git diff --cached --check` passed.
- Before transferring the change onto current master, exercised the running application in **three disposable local accounting databases**: login, create order, select independent employees, save/reopen, clear/reopen without changing Vor ref., and matching/nonmatching searches in both order and invoice lists.
- Created invoices through the UI in all three databases, including approval/delivery in one. Downloaded and visually inspected actual PDFs, captured invoice emails in local Mailpit, and checked the attached PDFs for the selected employee. An extra invoice with Udført af blank also passed PDF and email checks.
- Confirmed final stored selections, posted invoice status, totals, and corresponding receivable entries. The temporary databases were removed afterward.

Reproduce automated checks in a configured PHP/PostgreSQL checkout:

```sh
php includes/vendor/phpunit.phar --do-not-cache-result --test-suffix .test.php tests/characterization/debitor
```

The three customer production regnskaber have **not** been tested or deployed. The complete browser workflow was not rerun after transferring onto current master; the automated suite and syntax checks were rerun on the PR branch. Customer-specific PDFs and screenshots remain local because the repository is public.

## Regression checks for reviewers / rollout

| Affected area | Scenario and expected result |
|---|---|
| `ordre.php` / `renderOrderEmployeeFields()`; `ordrer.ref`, `ordrer.hvem`, employee master | Select different employees, save and reopen; clear only Udført af and reopen. Both controls use the same active employee list and retain independent values. Try an apostrophe and a historical employee. |
| `ordreliste.php`; shared `build_query()` / `build_count_query()` | Enable Udført af, search an apostrophe-containing employee in both lists, then a nonmatch. Verify results/counts and exercise existing Vor ref., numeric and date searches. |
| `formfunk.php` / `formularprint()` | Add `ordre_hvem` to an invoice layout; print and email invoices with selected and blank employees. Compare the preview and attachment. |
| `formularkort.php` / `drop_down()` | Confirm the field is offered as “Udført af”; place it without overlapping existing invoice text. Repeat on each active production layout. |
| Order copy / credit-note paths sharing employee persistence | Copy an order and create a credit note with an apostrophe-containing employee; verify independent values survive. These paths were not exercised in the browser run. |

## Have you checked the following?

- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that I am not linking to external style- or JavaScript-files that could compromise stability
- [ ] I have read and understood the developer guidelines linked in the repository PR template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added independent “Vor ref.” and “Udført af” employee selectors for orders.
  - Preserved historical employee values and blank selections when editing orders.
  - Made the “Udført af” column configurable through saved order-list layouts.
  - Included the performed-by value when printing or emailing order documents.
  - Updated employee labels to Danish.

- **Bug Fixes**
  - Employee names containing apostrophes or special characters are now handled correctly.
  - Improved order searching for names, references, and other supported fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->