### PR TITLE
SST-740: dedupe and constrain pool_files.filename…

### DIFF
--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -556,4 +556,56 @@ if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 	db_modify($pbs_index, __FILE__ . " linje " . __LINE__);
 }
 
+// 20260910 CL/SZ SST-776 follow-up (root cause identified during the SST-740 trace on
+// 20260908, but PR #584 only shipped the FileReservation/session-tenant half - this closes
+// the other half): pool_files never had a uniqueness constraint on filename in the
+// schema paths that actually provision it (admin/opret.php, includes/opdat_4.1.php,
+// includes/opdat_4.2.php all create it without one - only docPool.php's own from-scratch
+// CREATE TABLE IF NOT EXISTS included one, which never runs against a tenant that already
+// has the table). Combined with docPool.php's pulje-folder sync only ever inserting a row
+// when the filename string isn't already known - never checking whether the tracked row
+// still corresponds to a file actually on disk - a row orphaned by any pulje-file removal
+// other than the guarded attach flow in includes/docsIncludes/insertDoc.php (a manual
+// delete, a failed move, etc.) could sit forever and later get silently re-attached to an
+// unrelated upload that happened to reuse the same generated filename (recurring vendor +
+// date names, e.g. NETS/META, collide easily). The customer then sees one document's real
+// PDF paired with a different document's vendor/amount/date/invoice number. Same
+// dedupe-then-constrain pattern as pbs_ordrer_liste_ordre_uidx above: existing duplicate
+// filenames are collapsed to the highest id (most recently inserted row) before the index
+// is added, so this cannot fail on data that predates the fix. The docPool.php sync itself
+// now also deletes any row whose file is no longer in the pulje folder, which is what
+// actually prevents new orphans going forward - this index is the backstop against a race
+// between two requests doing that same reconciliation concurrently.
+if ($db_type == 'mysql' || $db_type == 'mysqli') {
+	$qtxt = "SELECT index_name FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'pool_files' AND non_unique = 0 AND seq_in_index = 1 AND column_name = 'filename'";
+	$pool_files_dedupe = "DELETE a FROM pool_files a JOIN pool_files b ON a.filename = b.filename AND a.id < b.id";
+	$pool_files_index = "CREATE UNIQUE INDEX pool_files_filename_uidx ON pool_files (filename)";
+} else {
+	// Checked against pg_index/pg_attribute directly (not a fixed index name, and not
+	// information_schema.table_constraints) because a tenant whose pool_files table
+	// didn't exist yet when docPool.php's own CREATE TABLE IF NOT EXISTS bootstrap first
+	// ran (its schema already includes an unnamed UNIQUE(filename) table constraint,
+	// which Postgres auto-names pool_files_filename_key) already has this covered under
+	// a different name - confirmed live against a real customer dump (saldi_821_verify,
+	// used for MB-39) that has exactly that constraint with zero duplicate filenames.
+	// Checking any single-column unique index on filename, regardless of name or
+	// whether it backs a formal constraint, avoids creating a second redundant index
+	// on tenants provisioned that way.
+	$qtxt = "
+		SELECT indexrelid::regclass AS idxname
+		FROM pg_index i
+		JOIN pg_class t ON t.oid = i.indrelid
+		WHERE t.relname = 'pool_files'
+			AND i.indisunique
+			AND i.indnatts = 1
+			AND i.indkey[0] = (SELECT attnum FROM pg_attribute WHERE attrelid = t.oid AND attname = 'filename')
+	";
+	$pool_files_dedupe = "DELETE FROM pool_files a USING pool_files b WHERE a.filename = b.filename AND a.id < b.id";
+	$pool_files_index = "CREATE UNIQUE INDEX IF NOT EXISTS pool_files_filename_uidx ON pool_files (filename)";
+}
+if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
+	db_modify($pool_files_dedupe, __FILE__ . " linje " . __LINE__);
+	db_modify($pool_files_index, __FILE__ . " linje " . __LINE__);
+}
+
 ?>

--- a/includes/betweenUpdates.php
+++ b/includes/betweenUpdates.php
@@ -577,7 +577,10 @@ if (!db_fetch_array(db_select($qtxt, __FILE__ . " linje " . __LINE__))) {
 // actually prevents new orphans going forward - this index is the backstop against a race
 // between two requests doing that same reconciliation concurrently.
 if ($db_type == 'mysql' || $db_type == 'mysqli') {
-	$qtxt = "SELECT index_name FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'pool_files' AND non_unique = 0 AND seq_in_index = 1 AND column_name = 'filename'";
+	// Group by index_name and require exactly one column in the index - seq_in_index = 1
+	// alone would also match a composite index like UNIQUE(filename, account), which
+	// still permits duplicate filenames and must not be treated as covering this.
+	$qtxt = "SELECT index_name FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'pool_files' AND non_unique = 0 GROUP BY index_name HAVING COUNT(*) = 1 AND MAX(column_name) = 'filename'";
 	$pool_files_dedupe = "DELETE a FROM pool_files a JOIN pool_files b ON a.filename = b.filename AND a.id < b.id";
 	$pool_files_index = "CREATE UNIQUE INDEX pool_files_filename_uidx ON pool_files (filename)";
 } else {

--- a/includes/docsIncludes/docPool.php
+++ b/includes/docsIncludes/docPool.php
@@ -43,6 +43,20 @@
 //                 which the very next INSERT/UPDATE in each of those code paths already
 //                 references - a brand-new tenant's first pool file would fail with
 //                 "column norm_amount does not exist". Added the column to both.
+// 20260910 CL/SZ SST-776 follow-up (root cause identified during the SST-740 trace on
+//                 20260908, but PR #584 only shipped the FileReservation/session-tenant half -
+//                 this closes the other half): syncPuljeFilesToDatabase() only ever inserted a
+//                 row for a filename it didn't already know, never checking whether a known
+//                 filename still had a file behind it. A row orphaned by any pulje-file removal
+//                 other than insertDoc.php's guarded attach (manual delete, a failed move, etc.)
+//                 sat forever and got silently reused by a later unrelated upload that
+//                 generated the same filename, showing that document's real PDF paired with
+//                 a different document's vendor/amount/date/invoice number. Now deletes any
+//                 pool_files row whose file is no longer in the pulje folder before checking
+//                 what's missing (a failed scandir() bails out first, so it can't misread a
+//                 read failure as "folder is empty" and wipe every row), and the insert is
+//                 ON CONFLICT DO NOTHING now that includes/betweenUpdates.php adds a unique
+//                 index on filename.
 include_once(__DIR__ . "/poolAmountNormalizer.php");
 /**
  * Log message to a file in temp/$db/docPool.log
@@ -148,6 +162,14 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 	// Get all PDF and XML files from the pulje directory
 	$pdfFiles = [];
 	$files = scandir($puljePath);
+	// scandir() returns false on a read failure (permission issue, a disconnected
+	// owncloud mount, etc.) rather than an empty array - treating that the same as
+	// "genuinely empty" would make the orphan cleanup below delete every pool_files row
+	// for this tenant on a transient read failure. Bail out instead; nothing to sync.
+	if ($files === false) {
+		docPoolLog("syncPuljeFilesToDatabase: scandir($puljePath) failed, skipping sync");
+		return;
+	}
 	foreach ($files as $file) {
 		if ($file === '.' || $file === '..') continue;
 		$ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
@@ -155,11 +177,27 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 			$pdfFiles[] = $file;
 		}
 	}
-	
+
+	// Drop any pool_files row whose file is no longer in the pulje folder, before
+	// looking at what's missing. insertDoc.php only deletes a row when a pool file is
+	// attached via its own guarded move (SST-740); any other removal (manual delete, a
+	// failed move, etc.) left the row behind forever, so a later unrelated upload that
+	// happened to generate the same filename (e.g. recurring vendor + date, like NETS/META)
+	// silently inherited that stale row's vendor/amount/date/invoice number - the customer
+	// then saw the right PDF paired with a different document's metadata. This must run
+	// even when the pulje folder is now empty, so it's before the empty-check below.
+	if ($pdfFiles) {
+		$onDiskEscaped = array_map(function($f) { return "'" . db_escape_string($f) . "'"; }, $pdfFiles);
+		$onDiskClause = "filename NOT IN (" . implode(',', $onDiskEscaped) . ")";
+	} else {
+		$onDiskClause = "1=1";
+	}
+	db_modify("DELETE FROM pool_files WHERE $onDiskClause", __FILE__ . " line " . __LINE__);
+
 	if (empty($pdfFiles)) {
 		return;
 	}
-	
+
 	// Get existing filenames from database in one query
 	$escapedFiles = array_map(function($f) { return "'" . db_escape_string($f) . "'"; }, $pdfFiles);
 	$inClause = implode(',', $escapedFiles);
@@ -212,7 +250,7 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 				'" . db_escape_string($fileDate) . "',
 				'" . db_escape_string($invoiceNumber) . "',
 				'" . db_escape_string($description) . "'
-			)";
+			) ON CONFLICT (filename) DO NOTHING";
 			db_modify($qtxt, __FILE__ . " line " . __LINE__);
 		}
 	}

--- a/includes/docsIncludes/docPool.php
+++ b/includes/docsIncludes/docPool.php
@@ -99,6 +99,7 @@ if (!function_exists('docPoolLog')) {
  * This runs once on page load and adds any missing PDF files to the database.
  */
 function syncPuljeFilesToDatabase($docFolder, $db) {
+	global $db_type;
 	$puljePath = "$docFolder/$db/pulje";
 	
 	$skip = get_settings_value("skip_sync", "docs", 0);
@@ -186,13 +187,24 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 	// silently inherited that stale row's vendor/amount/date/invoice number - the customer
 	// then saw the right PDF paired with a different document's metadata. This must run
 	// even when the pulje folder is now empty, so it's before the empty-check below.
+	//
+	// Excludes rows updated in the last 60 seconds: moveDoc.php (and other writers) always
+	// write the file to disk before inserting its pool_files row, but this function's own
+	// scandir() snapshot above is taken before that INSERT, not atomically with it - a
+	// concurrent request's file+row could land in that gap, and without this grace window
+	// the row would look orphaned (not in our snapshot) and get deleted despite its file
+	// now genuinely being on disk. The next sync pass sees it correctly once the snapshot
+	// catches up, so this only ever delays cleanup of a real orphan by at most one pass.
 	if ($pdfFiles) {
 		$onDiskEscaped = array_map(function($f) { return "'" . db_escape_string($f) . "'"; }, $pdfFiles);
 		$onDiskClause = "filename NOT IN (" . implode(',', $onDiskEscaped) . ")";
 	} else {
 		$onDiskClause = "1=1";
 	}
-	db_modify("DELETE FROM pool_files WHERE $onDiskClause", __FILE__ . " line " . __LINE__);
+	$recentGuard = ($db_type == 'mysql' || $db_type == 'mysqli')
+		? "(updated IS NULL OR updated < (NOW() - INTERVAL 60 SECOND))"
+		: "(updated IS NULL OR updated < (NOW() - INTERVAL '60 seconds'))";
+	db_modify("DELETE FROM pool_files WHERE ($onDiskClause) AND $recentGuard", __FILE__ . " line " . __LINE__);
 
 	if (empty($pdfFiles)) {
 		return;
@@ -238,10 +250,13 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 			// get date from file
 			$fileDate = date("Y-m-d H:i:s", filemtime("$puljePath/$file"));
 
-			// Insert into database
+			// Insert into database. ON CONFLICT is PostgreSQL-only syntax; MySQL's
+			// equivalent no-op-on-duplicate-key is INSERT IGNORE instead.
 			$syncNormAmount = normalizePoolAmount($amount);
 			$syncNormAmountSql = ($syncNormAmount === null) ? 'NULL' : db_escape_string((string) $syncNormAmount);
-			$qtxt = "INSERT INTO pool_files (filename, subject, account, amount, norm_amount, file_date, invoice_number, description) VALUES (
+			$insertVerb = ($db_type == 'mysql' || $db_type == 'mysqli') ? 'INSERT IGNORE' : 'INSERT';
+			$onConflictClause = ($db_type == 'mysql' || $db_type == 'mysqli') ? '' : ' ON CONFLICT (filename) DO NOTHING';
+			$qtxt = "$insertVerb INTO pool_files (filename, subject, account, amount, norm_amount, file_date, invoice_number, description) VALUES (
 				'" . db_escape_string($file) . "',
 				'" . db_escape_string($subject) . "',
 				'" . db_escape_string($account) . "',
@@ -250,7 +265,7 @@ function syncPuljeFilesToDatabase($docFolder, $db) {
 				'" . db_escape_string($fileDate) . "',
 				'" . db_escape_string($invoiceNumber) . "',
 				'" . db_escape_string($description) . "'
-			) ON CONFLICT (filename) DO NOTHING";
+			)$onConflictClause";
 			db_modify($qtxt, __FILE__ . " line " . __LINE__);
 		}
 	}


### PR DESCRIPTION
## Summary
Found during the SST-740 investigation trace, but filed as an implementation fix under
SST-776 (document/metadata association) rather than under SST-740 itself, since SST-740 is
explicitly scoped as trace-only ("no customer postings changed during investigation";
follow-up fixes belong in the four linked tickets).

`pool_files` (the table backing the document pool / bilagspulje) had no unique constraint on
`filename`, and the only place that ever deletes a row (`insertDoc.php`, when a document
gets attached to a journal line) only fires on that one specific path. Any other way a pulje
file disappeared — manual delete, a failed move, etc. — left its `pool_files` row behind
forever.

`docPool.php`'s folder-sync then only ever checked "do I already have a row for this
filename," never "does that row still correspond to a real file." So if a later, completely
unrelated document happened to generate the same filename (easy for recurring vendors like
NETS/META, since filenames are built from vendor+date), it silently inherited the old row's
vendor/amount/date/invoice number — the customer sees the right PDF next to a different
document's data.

This directly matches the customer symptoms reported in SST-740 (Custom Audio): "Hverken
filnavn, beløb, Fakturanr. Eller dato passer med dokumentet der er valgt" — filename,
amount, invoice number, and date all disagreeing with the actually-selected document.
## What are the changes about?
1. Added a `UNIQUE(filename)` index on `pool_files`, with a one-time dedupe first (keeps the
   most recent row) so the migration can't fail on any pre-existing collisions.
2. Changed the pool-folder sync (`syncPuljeFilesToDatabase()`) to delete any `pool_files`
   row whose file is no longer on disk **before** checking what's missing, and made its
   insert conflict-safe now that the constraint exists.

## Files Changed
- includes/betweenUpdates.php — the migration (idempotent, dedupe-then-constrain)
- includes/docsIncludes/docPool.php — the sync fix, in `syncPuljeFilesToDatabase()`

## Relationship to SST-740 and other Bilagspulje tickets
- This is one of the findings the SST-740 trace was meant to surface and classify. Per that
  ticket's own scope, the fix belongs in a follow-up ticket, not in SST-740 itself — filed
  here under SST-776 (document/metadata association) as the best fit among the four linked
  follow-ups.
- Related but distinct from the fix already made in SST-776's earlier PR (filename-collision
  handling at **upload time**, in `includes/documents.php`). That fix prevents a *new*
  upload from overwriting an existing file on disk. This fix addresses a *different* moment:
  a stale, orphaned `pool_files` **database row** getting silently reattached to a
  *different* physical file that happens to reuse the same name later, via the folder-sync
  path in `docPool.php`, not the upload path. Both are real and both needed fixing;
  neither makes the other redundant.
- Does not address extraction accuracy (SST-775) or the private-expense feature (SST-778) —
  out of scope here per the ticket boundaries.

## How to Test
1. Manually create a `pool_files` row for a filename whose actual file has since been
   deleted from disk (simulating an orphaned row from a manual delete or failed move).
2. Upload a new, unrelated document that happens to generate the same filename (e.g. same
   vendor + same date pattern).
3. Run the folder sync — verify the stale orphaned row is deleted before the new file is
   processed, and the new document gets its own correct metadata, not the old row's.
4. Run the migration against a database with pre-existing duplicate filenames in
   `pool_files` — verify the dedupe keeps the most recent row per filename and the unique
   constraint is then applied successfully with no errors.
5. Run the migration a second time (idempotency check) — verify it does not fail or
   duplicate the constraint.
6. Attempt to reproduce one of the specific customer examples from SST-740 (e.g. the NETS or
   HIPER filename-recurrence pattern) against a sanitized copy of the customer's data, if
   available, and confirm the fix resolves the specific reported mismatch.
7. Confirm normal, non-colliding pool document flows (upload → preview → select → attach)
   are unaffected by either change.

## Acceptance Criteria
| # | Scenario | Expected Result |
|---|---|---|
| 1 | Stale pool_files row (file deleted from disk) + new document reusing the same filename | Stale row is removed before new file is processed; new document gets correct metadata |
| 2 | Migration against a DB with existing filename duplicates | Dedupe keeps most recent row, unique constraint applies without error |
| 3 | Migration run twice | Idempotent — no failure, no duplicate constraint |
| 4 | Normal, non-colliding pool document flow | Unaffected |

## Have you checked the following? 
- [ ] I have updated relevant documentation at https://github.com/DANOSOFT/saldi/wiki
- [x] I have checked that i am not linking to any external resources such as external style- or JavaScript-files, that could compromise stability
- [x] I have read and understood the developer guidelines  
      https://docs.google.com/document/d/1GOmomtvKf21OV2VWNOIPweDi4gJHpMCK5qXzrPrypUc/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale file records from being incorrectly reused when a new upload has the same filename.
  - Improved file synchronization to avoid deleting newly created records during concurrent updates.
  - Ensured records for files removed from a folder are cleaned up appropriately.
  - Prevented failed folder scans from being treated as empty folders, avoiding unintended record removal.
  - Added safeguards to maintain unique file metadata and safely handle existing duplicate entries.
  - Improved compatibility when synchronizing file records across supported database systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->